### PR TITLE
Add vectors, matrices, and QR decomposition

### DIFF
--- a/src/Mathematics.NET/Core/ComplexNumber.cs
+++ b/src/Mathematics.NET/Core/ComplexNumber.cs
@@ -386,6 +386,8 @@ public readonly struct ComplexNumber
     public static ComplexNumber FromPolarForm(Real magnitude, Real phase)
         => new(magnitude * Math.Cos(phase.Value), magnitude * Math.Sin(phase.Value));
 
+    public static ComplexNumber FromReal(Real x) => new(x);
+
     private static double Hypot(double x, double y)
     {
         // Factor out the larger value to avoid possible overflow

--- a/src/Mathematics.NET/Core/ComplexNumber.cs
+++ b/src/Mathematics.NET/Core/ComplexNumber.cs
@@ -383,6 +383,8 @@ public readonly struct ComplexNumber
 
     public static ComplexNumber Conjugate(ComplexNumber z) => new(z._real, -z._imaginary);
 
+    public static ComplexNumber FromDouble(double x) => new(x);
+
     public static ComplexNumber FromPolarForm(Real magnitude, Real phase)
         => new(magnitude * Math.Cos(phase.Value), magnitude * Math.Sin(phase.Value));
 

--- a/src/Mathematics.NET/Core/IComplex.cs
+++ b/src/Mathematics.NET/Core/IComplex.cs
@@ -148,6 +148,11 @@ public interface IComplex<T>
         return result;
     }
 
+    /// <summary>Create an instance of type <typeparamref name="T"/> from one of type <see cref="double"/></summary>
+    /// <param name="x">A value of type <see cref="double"/></param>
+    /// <returns>An instance of type <typeparamref name="T"/> created from <paramref name="x"/></returns>
+    static abstract T FromDouble(double x);
+
     /// <summary>Create an instance of type <typeparamref name="T"/> from one of type <see cref="Real"/></summary>
     /// <remarks>If the value to convert from is also of type <see cref="Real"/>, return itself</remarks>
     /// <param name="x">A value of type <see cref="Real"/></param>
@@ -267,7 +272,7 @@ public interface IComplex<T>
 
     /// <summary>Convert a value of type <see cref="IFloatingPointIeee754{TSelf}"/> to one of type <typeparamref name="T"/></summary>
     /// <param name="x">The value to convert</param>
-    static virtual implicit operator T(double x) => T.CreateSaturating(x);
+    static virtual implicit operator T(double x) => T.FromDouble(x);
 
     /// <summary>Convert a value of type <see cref="Real"/> to one of type <typeparamref name="T"/></summary>
     /// <remarks>If the type to convert from is also <see cref="Real"/>, return itself</remarks>

--- a/src/Mathematics.NET/Core/IComplex.cs
+++ b/src/Mathematics.NET/Core/IComplex.cs
@@ -148,6 +148,12 @@ public interface IComplex<T>
         return result;
     }
 
+    /// <summary>Create an instance of type <typeparamref name="T"/> from one of type <see cref="Real"/></summary>
+    /// <remarks>If the value to convert from is also of type <see cref="Real"/>, return itself</remarks>
+    /// <param name="x">A value of type <see cref="Real"/></param>
+    /// <returns>An instance of type <typeparamref name="T"/> created from <paramref name="x"/></returns>
+    static abstract T FromReal(Real x);
+
     /// <summary>Check if a value is finite</summary>
     /// <param name="z">The value to check</param>
     /// <returns><see langword="true"/> if the value is finite; otherwise, <see langword="false"/></returns>
@@ -262,4 +268,9 @@ public interface IComplex<T>
     /// <summary>Convert a value of type <see cref="IFloatingPointIeee754{TSelf}"/> to one of type <typeparamref name="T"/></summary>
     /// <param name="x">The value to convert</param>
     static virtual implicit operator T(double x) => T.CreateSaturating(x);
+
+    /// <summary>Convert a value of type <see cref="Real"/> to one of type <typeparamref name="T"/></summary>
+    /// <remarks>If the type to convert from is also <see cref="Real"/>, return itself</remarks>
+    /// <param name="x">The value to convert</param>
+    static virtual implicit operator T(Real x) => T.FromReal(x);
 }

--- a/src/Mathematics.NET/Core/IReal.cs
+++ b/src/Mathematics.NET/Core/IReal.cs
@@ -69,4 +69,15 @@ public interface IReal<T>
     /// <param name="y">The second value</param>
     /// <returns>The lesser of the two values</returns>
     static abstract T Min(T x, T y);
+
+    /// <summary>Find the sign of a real number</summary>
+    /// <param name="x">The value to check</param>
+    /// <returns>
+    /// A number indicating the sign of the value:<br/><br/>
+    /// <b>1</b> if the value is greater than zero<br/>
+    /// <b>0</b> if the value is greater than zero<br/>
+    /// <b>-1</b> if the value is less than zero
+    /// </returns>
+    /// <exception cref="ArithmeticException">An overflow or underflow has occurred</exception>
+    static abstract int Sign(T x);
 }

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -438,6 +438,8 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
     public static Rational<T> Conjugate(Rational<T> x) => x;
 
+    public static Rational<T> FromReal(Real x) => (Rational<T>)x;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static T GCD(T p, T q)
     {

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -438,6 +438,8 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
     public static Rational<T> Conjugate(Rational<T> x) => x;
 
+    public static Rational<T> FromDouble(double x) => (Rational<T>)x;
+
     public static Rational<T> FromReal(Real x) => (Rational<T>)x;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -605,9 +607,9 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
     //
 
     // TODO: Find a better implementation
-    public static explicit operator Rational<T>(Real x)
+    public static explicit operator Rational<T>(double x)
     {
-        var value = x.Value;
+        var value = x;
         if (double.IsNaN(value) || double.IsInfinity(value))
         {
             return NaN;
@@ -626,6 +628,8 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
         return new(num / gcd, den / gcd);
     }
+
+    public static explicit operator Rational<T>(Real x) => (Rational<T>)x.Value;
 
     public static explicit operator checked Real(Rational<T> x) => checked(double.CreateChecked(x._numerator) / double.CreateChecked(x._denominator));
 

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -530,6 +530,15 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
         return new(x._numerator / gcd, x._denominator / gcd);
     }
 
+    public static int Sign(Rational<T> x)
+    {
+        if (x == Rational<T>.Zero)
+        {
+            return 0;
+        }
+        return x._numerator > T.Zero ? 1 : -1;
+    }
+
     public static bool TryConvertFromChecked<U>(U value, out Rational<T> result)
         where U : INumberBase<U>
     {

--- a/src/Mathematics.NET/Core/Real.cs
+++ b/src/Mathematics.NET/Core/Real.cs
@@ -293,6 +293,8 @@ public readonly struct Real
         return 1.0 / x;
     }
 
+    public static int Sign(Real x) => Math.Sign(x._value);
+
     public static bool TryConvertFromChecked<U>(U value, out Real result)
         where U : INumberBase<U>
     {

--- a/src/Mathematics.NET/Core/Real.cs
+++ b/src/Mathematics.NET/Core/Real.cs
@@ -262,6 +262,8 @@ public readonly struct Real
 
     public static Real Conjugate(Real x) => x;
 
+    public static Real FromDouble(double x) => new(x);
+
     public static Real FromReal(Real x) => x;
 
     public static Real Hypot(Real x, Real y) => double.Hypot(x._value, y._value);

--- a/src/Mathematics.NET/Core/Real.cs
+++ b/src/Mathematics.NET/Core/Real.cs
@@ -262,6 +262,8 @@ public readonly struct Real
 
     public static Real Conjugate(Real x) => x;
 
+    public static Real FromReal(Real x) => x;
+
     public static Real Hypot(Real x, Real y) => double.Hypot(x._value, y._value);
 
     public static bool IsFinite(Real x) => double.IsFinite(x._value);

--- a/src/Mathematics.NET/Extensions.cs
+++ b/src/Mathematics.NET/Extensions.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="Extensions.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Text;
+
+namespace Mathematics.NET;
+
+public static class Extensions
+{
+    /// <summary>Remove specified characters from the end of a string being built by a string builder</summary>
+    /// <param name="builder">A string builder instance</param>
+    /// <param name="unwantedChars">An array of characters to trim</param>
+    /// <returns>The same string builder with characters removed</returns>
+    public static StringBuilder TrimEnd(this StringBuilder builder, params char[]? unwantedChars)
+    {
+        if (unwantedChars == null || builder.Length == 0 || unwantedChars.Length == 0)
+        {
+            return builder;
+        }
+
+        int i = builder.Length - 1;
+        while (i >= 0)
+        {
+            if (!unwantedChars.Contains(builder[i]))
+            {
+                break;
+            }
+            i--;
+        }
+        if (i < builder.Length - 1)
+        {
+            builder.Length = ++i;
+        }
+
+        return builder;
+    }
+}

--- a/src/Mathematics.NET/Extensions.cs
+++ b/src/Mathematics.NET/Extensions.cs
@@ -29,6 +29,7 @@ using System.Text;
 
 namespace Mathematics.NET;
 
+/// <summary>A class containing Mathematics.NET extension methods</summary>
 public static class Extensions
 {
     /// <summary>Remove specified characters from the end of a string being built by a string builder</summary>

--- a/src/Mathematics.NET/ExternalExtensions.cs
+++ b/src/Mathematics.NET/ExternalExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Extensions.cs" company="Mathematics.NET">
+﻿// <copyright file="ExternalExtensions.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -29,8 +29,8 @@ using System.Text;
 
 namespace Mathematics.NET;
 
-/// <summary>A class containing Mathematics.NET extension methods</summary>
-public static class Extensions
+/// <summary>A class containing extension methods for external .NET objects</summary>
+public static class ExternalExtensions
 {
     /// <summary>Remove specified characters from the end of a string being built by a string builder</summary>
     /// <param name="builder">A string builder instance</param>

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IArrayRepresentable.cs
@@ -25,8 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.Core;
-
 namespace Mathematics.NET.LinearAlgebra.Abstractions;
 
 /// <summary>Defines support for mathematical objects that can be represented by arrays</summary>

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IOneDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IOneDimensionalArrayRepresentable.cs
@@ -25,7 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.Core;
 using Mathematics.NET.Core.Operations;
 using Mathematics.NET.Core.Relations;
 

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IOneDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IOneDimensionalArrayRepresentable.cs
@@ -57,8 +57,7 @@ public interface IOneDimensionalArrayRepresentable<T, U>
     /// <returns>The norm</returns>
     Real Norm();
 
-    /// <summary>Normalize a given vector</summary>
-    /// <param name="vector">The vector to normalize</param>
+    /// <summary>Normalize the vector</summary>
     /// <returns>The normalized vector</returns>
     T Normalize();
 }

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
@@ -48,6 +48,11 @@ public interface ISquareMatrix<T, U>
     /// <returns>The inverse if the matrix is invertible; otherwise, <see cref="NaM"/></returns>
     T Inverse();
 
+    /// <summary>Check if a value is not a matrix</summary>
+    /// <param name="matrix">The value to check</param>
+    /// <returns><see langword="true"/> if the value is not a matrix; otherwise, <see langword="false"/></returns>
+    static abstract bool IsNaM(T matrix);
+
     /// <summary>Compute the trace of the matrix</summary>
     /// <returns>The trace</returns>
     U Trace();

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
@@ -25,8 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.Core;
-
 namespace Mathematics.NET.LinearAlgebra.Abstractions;
 
 /// <summary>Defines support for square matrices</summary>

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/ISquareMatrix.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="ISquareMatrix.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.Core;
+
+namespace Mathematics.NET.LinearAlgebra.Abstractions;
+
+/// <summary>Defines support for square matrices</summary>
+/// <typeparam name="T">A type that implements <see cref="ITwoDimensionalArrayRepresentable{T, U}"/></typeparam>
+/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
+public interface ISquareMatrix<T, U>
+    where T : ITwoDimensionalArrayRepresentable<T, U>
+    where U : IComplex<U>
+{
+    /// <summary>Represents a value that is not a matrix</summary>
+    /// <remarks>This result will be returned when trying to invert a singular matrix</remarks>
+    static abstract T NaM { get; }
+
+    /// <summary>Compute the determinant of the matrix</summary>
+    /// <returns>The determinant</returns>
+    U Determinant();
+
+    /// <summary>Compute the inverse of the matrix</summary>
+    /// <returns>The inverse if the matrix is invertible; otherwise, <see cref="NaM"/></returns>
+    T Inverse();
+
+    /// <summary>Compute the trace of the matrix</summary>
+    /// <returns>The trace</returns>
+    U Trace();
+}

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/ITwoDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/ITwoDimensionalArrayRepresentable.cs
@@ -25,7 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.Core;
 using Mathematics.NET.Core.Operations;
 using Mathematics.NET.Core.Relations;
 

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/ITwoDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/ITwoDimensionalArrayRepresentable.cs
@@ -1,0 +1,58 @@
+﻿// <copyright file="ITwoDimensionalArrayRepresentable.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.Core;
+using Mathematics.NET.Core.Operations;
+using Mathematics.NET.Core.Relations;
+
+namespace Mathematics.NET.LinearAlgebra.Abstractions;
+
+/// <summary>Defines support for mathematical objects that can be represented by two-dimensional arrays</summary>
+/// <typeparam name="T">The type that implements the interface</typeparam>
+/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
+public interface ITwoDimensionalArrayRepresentable<T, U>
+    : IArrayRepresentable<U>,
+      IAdditionOperation<T, T>,
+      ISubtractionOperation<T, T>,
+      IMultiplicationOperation<T, T>,
+      IEqualityRelation<T, bool>,
+      IFormattable
+    where T : ITwoDimensionalArrayRepresentable<T, U>
+    where U : IComplex<U>
+{
+    /// <summary>The number of rows in the array</summary>
+    static abstract int E1Components { get; }
+
+    /// <summary>The number of columns in the array</summary>
+    static abstract int E2Components { get; }
+
+    /// <summary>Get the element at the specified row and column</summary>
+    /// <param name="row">The row</param>
+    /// <param name="column">The column</param>
+    /// <returns>The element at the specified row and column</returns>
+    U this[int row, int column] { get; set; }
+}

--- a/src/Mathematics.NET/LinearAlgebra/Extensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Extensions.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="Extensions.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using CommunityToolkit.HighPerformance;
+using Mathematics.NET.Core;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+public static class Extensions
+{
+    /// <summary>Create a new <see cref="Span2D{T}"/> over a 4x4 matrix of <typeparamref name="T"/> numbers</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="matrix">The input matrix</param>
+    /// <returns>A <see cref="Span2D{T}"/> with elements from the input matrix</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe Span2D<T> AsSpan2D<T>(this Matrix4x4<T> matrix)
+        where T : IComplex<T>
+    {
+        return new Span2D<T>(Unsafe.AsPointer(ref matrix.E11), Matrix4x4<T>.E1Components, Matrix4x4<T>.E2Components, 0);
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -38,6 +38,22 @@ public static class LinAlg
     /// <param name="matrix">A matrix</param>
     /// <param name="method">A QR decomposition method</param>
     /// <returns>The eigenvalues of the given matrix</returns>
+    /// <example>
+    /// Suppose we want to find the eigenvalues of a 2x2 matrix. We can write the following to get them:
+    /// <code language="cs">
+    /// Span2D&lt;ComplexNumber&gt; matrix = new ComplexNumber[2, 2]
+    /// {
+    ///     { new(1, 2), new(2, 3) },
+    ///     { new(1, -2), new(3, 5) }
+    /// }
+    /// var eigvals = LinAlg.EigVals(matrix, LinAlg.QRGramSchmidt);
+    /// </code>
+    /// This method returns a span of the eigenvalues which we can use for other computations. We can also specify the number of
+    /// iterations as well if the values do not converge quickly enough. To display the result in the console, write
+    /// <code language="cs">
+    /// Console.WriteLine(eigvals.ToDisplayString());
+    /// </code>
+    /// </example>
     public static Span<T> EigVals<T>(Span2D<T> matrix, QRDecompositionMethod<T> method, int iterations = 10)
         where T : IComplex<T>
     {

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -26,9 +26,7 @@
 // </copyright>
 
 using System.Runtime.CompilerServices;
-using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Enumerables;
-using Mathematics.NET.Core;
 
 namespace Mathematics.NET.LinearAlgebra;
 

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -1,0 +1,178 @@
+﻿// <copyright file="LinAlg.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using CommunityToolkit.HighPerformance;
+using CommunityToolkit.HighPerformance.Enumerables;
+using Mathematics.NET.Core;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+/// <summary>A class containing linear algebra operations</summary>
+public static class LinAlg
+{
+    /// <summary>Compute the eigenvalues of a matrix using a QR decomposition method</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="matrix">A matrix</param>
+    /// <param name="method">A QR decomposition method</param>
+    /// <returns>The eigenvalues of the given matrix</returns>
+    public static Span<T> EigVals<T>(Span2D<T> matrix, QRDecompositionMethod<T> method, int iterations = 10)
+        where T : IComplex<T>
+    {
+        // TODO: Implement shifted QR algorithm for faster convergence and dynamically determine how many iterations should be run
+        // TODO: Check to make sure new arrays are not being created every iteration
+        Span2D<T> rq = matrix;
+        for (int i = 0; i < iterations; i++)
+        {
+            method(rq, out Span2D<T> Q, out Span2D<T> R);
+            rq = MatMul(R, Q);
+        }
+
+        Span<T> result = new T[matrix.Height];
+        for (int i = 0; i < matrix.Height; i++)
+        {
+            result[i] = rq[i, i];
+        }
+        return result;
+    }
+
+    /// <summary>Multiply two matrices</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="left">The left matrix</param>
+    /// <param name="right">The right matrix</param>
+    /// <returns>The result of the operation if the dimensions of the matrices are valid; otherwise, throw an exception</returns>
+    /// <exception cref="ArgumentException">Cannot multiply matrices of incompatible dimensions</exception>
+    public static Span2D<T> MatMul<T>(Span2D<T> left, Span2D<T> right)
+        where T : IComplex<T>
+    {
+        if (left.Width != right.Height)
+        {
+            throw new ArgumentException("Cannot multiply matrices of incompatible dimensions");
+        }
+
+        Span2D<T> result = new T[left.Height, right.Width];
+        for (int i = 0; i < left.Height; i++)
+        {
+            for (int j = 0; j < right.Width; j++)
+            {
+                for (int k = 0; k < left.Width; k++)
+                {
+                    result[i, j] += left[i, k] * right[k, j];
+                }
+            }
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Real Norm<T>(RefEnumerable<T> vector)
+        where T : IComplex<T>
+    {
+        Span<Real> components = new Real[vector.Length];
+        for (int i = 0; i < vector.Length; i++)
+        {
+            components[i] = (vector[i] * T.Conjugate(vector[i])).Re;
+        }
+
+        Real max = components[0];
+        for (int i = 1; i < vector.Length; i++)
+        {
+            if (components[i] > max)
+            {
+                max = components[i];
+            }
+        }
+
+        var partialSum = Real.Zero;
+        var scale = Real.One / (max * max);
+        foreach (ref var component in components)
+        {
+            partialSum += scale * component;
+        }
+
+        return max * Real.Sqrt(partialSum);
+    }
+
+    /// <summary>Encapsulates a QR decomposition method with one input and two out parameters</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="matrix">An input matrix</param>
+    /// <param name="Q">The resulting orthogonal matrix</param>
+    /// <param name="R">The resulting upper triangular matrix</param>
+    public delegate void QRDecompositionMethod<T>(Span2D<T> matrix, out Span2D<T> Q, out Span2D<T> R)
+        where T : IComplex<T>;
+
+    /// <summary>Perform QR decomposition on a matrix using the modified Gram-Schmidt process</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="matrix">An input matrix</param>
+    /// <param name="Q">The resulting orthogonal matrix</param>
+    /// <param name="R">The resulting upper triangular matrix</param>
+    /// <exception cref="DivideByZeroException">One of the columns is not linearly independent from the others</exception>
+    public static void QRGramSchmidt<T>(Span2D<T> matrix, out Span2D<T> Q, out Span2D<T> R)
+        where T : IComplex<T>
+    {
+        var height = matrix.Height;
+        var width = matrix.Width;
+
+        Q = new T[height, width];
+        R = new T[height, width];
+
+        for (int i = 0; i < width; i++)
+        {
+            var column = Q.GetColumn(i);
+            matrix.GetColumn(i).CopyTo(column);
+            for (int j = 0; j < i; j++)
+            {
+                var proj = T.Zero;
+                for (int k = 0; k < height; k++)
+                {
+                    proj += T.Conjugate(Q[k, j]) * Q[k, i];
+                }
+                R[j, i] = proj;
+
+                for (int k = 0; k < height; k++)
+                {
+                    Q[k, i] = Q[k, i] - proj * Q[k, j];
+                }
+            }
+
+            var norm = Norm(column);
+            if (norm != Real.Zero)
+            {
+                R[i, i] = norm;
+                foreach (ref var element in column)
+                {
+                    element /= norm;
+                }
+            }
+            else
+            {
+                // TODO: Consider not throwing an exception
+                throw new DivideByZeroException(string.Format("Column {0} is not linearly independent from the others", i));
+            }
+        }
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -27,8 +27,6 @@
 
 using System.Runtime.CompilerServices;
 using System.Text;
-using CommunityToolkit.HighPerformance;
-using Mathematics.NET.Core;
 
 namespace Mathematics.NET.LinearAlgebra;
 

--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Extensions.cs" company="Mathematics.NET">
+﻿// <copyright file="LinAlgExtensions.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -32,7 +32,8 @@ using Mathematics.NET.Core;
 
 namespace Mathematics.NET.LinearAlgebra;
 
-public static class Extensions
+/// <summary>A class containing linear algebra extension methods</summary>
+public static class LinAlgExtensions
 {
     /// <summary>Create a new <see cref="Span2D{T}"/> over a 4x4 matrix of <typeparamref name="T"/> numbers</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>

--- a/src/Mathematics.NET/LinearAlgebra/Matrix2x2.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix2x2.cs
@@ -1,0 +1,218 @@
+﻿// <copyright file="Matrix2x2.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+/// <summary>Represents a 2x2 matrix</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+public struct Matrix2x2<T>
+    : ITwoDimensionalArrayRepresentable<Matrix2x2<T>, T>,
+      ISquareMatrix<Matrix2x2<T>, T>
+    where T : IComplex<T>
+{
+    public const int Components = 4;
+    public const int E1Components = 2;
+    public const int E2Components = 2;
+
+    public static readonly Matrix2x2<T> NaM = CreateDiagonal(T.NaN, T.NaN);
+
+    public T E11;
+    public T E12;
+
+    public T E21;
+    public T E22;
+
+    public Matrix2x2(T e11, T e12, T e21, T e22)
+    {
+        E11 = e11;
+        E12 = e12;
+
+        E21 = e21;
+        E22 = e22;
+    }
+
+    //
+    // Constants
+    //
+
+    static int IArrayRepresentable<T>.Components => Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix2x2<T>, T>.E1Components => E1Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix2x2<T>, T>.E2Components => E2Components;
+    static Matrix2x2<T> ISquareMatrix<Matrix2x2<T>, T>.NaM => NaM;
+
+    //
+    // Indexer
+    //
+
+    public T this[int row, int column]
+    {
+        get
+        {
+            if ((uint)row >= 2)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            ref Vector2<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector2<T>>(ref E11), row);
+            return vrow[column];
+        }
+        set
+        {
+            if ((uint)row >= 2)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            ref Vector2<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector2<T>>(ref E11), row);
+            var temp = Vector2<T>.WithElement(vrow, column, value);
+            vrow = temp;
+        }
+    }
+
+
+    //
+    // Operators
+    //
+
+    public static Matrix2x2<T> operator +(Matrix2x2<T> a, Matrix2x2<T> b)
+    {
+        return new(
+            a.E11 + b.E11, a.E12 + b.E12,
+            a.E21 + b.E21, a.E22 + b.E22);
+    }
+
+    public static Matrix2x2<T> operator -(Matrix2x2<T> a, Matrix2x2<T> b)
+    {
+        return new(
+            a.E11 - b.E11, a.E12 - b.E12,
+            a.E21 - b.E21, a.E22 - b.E22);
+    }
+
+    public static Matrix2x2<T> operator *(Matrix2x2<T> a, Matrix2x2<T> b)
+    {
+        return new(
+            a.E11 * b.E11 + a.E12 * b.E21, a.E11 * b.E12 + a.E12 * b.E22,
+            a.E21 * b.E11 + a.E22 * b.E21, a.E21 * b.E12 + a.E22 * b.E22);
+    }
+
+    //
+    // Equality
+    //
+
+    public static bool operator ==(Matrix2x2<T> a, Matrix2x2<T> b)
+    {
+        return a.E11 == b.E11 && a.E22 == b.E22 // Check diagonal first
+            && a.E12 == b.E12
+            && a.E21 == b.E21;
+    }
+
+    public static bool operator !=(Matrix2x2<T> a, Matrix2x2<T> b)
+    {
+        return a.E11 != b.E11 || a.E22 != b.E22 // Check diagonal first
+            || a.E12 != b.E12
+            || a.E21 != b.E21;
+    }
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Matrix2x2<T> other && Equals(other);
+
+    public bool Equals(Matrix2x2<T> value)
+    {
+        return E11.Equals(value.E11) && E22.Equals(value.E22) // Check diagonal first
+            && E12.Equals(value.E12)
+            && E21.Equals(value.E21);
+    }
+
+    public override readonly int GetHashCode() => HashCode.Combine(E11, E12, E21, E22);
+
+    //
+    // Formatting
+    //
+
+    public string ToString(string? format, IFormatProvider? provider)
+    {
+        Span2D<string> strings = new string[2, 2];
+        var maxElementLength = 0;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                var s = this[i, j].ToString(format, provider);
+                strings[i, j] = s;
+                var length = s.Length + 2;
+                if (maxElementLength < length)
+                {
+                    maxElementLength = length;
+                }
+            }
+        }
+
+        StringBuilder builder = new();
+        var newlineChars = Environment.NewLine.ToCharArray();
+        builder.Append('[');
+        for (int i = 0; i < 2; i++)
+        {
+            builder.Append(i != 0 ? " [" : "[");
+            for (int j = 0; j < 2; j++)
+            {
+                string value = j != 1 ? $"{strings[i, j]}, " : strings[i, j];
+                builder.Append(value.PadRight(maxElementLength));
+            }
+            LinAlgExtensions.CloseGroup(builder, newlineChars);
+        }
+        LinAlgExtensions.CloseGroup(builder, newlineChars, true);
+        return string.Format(provider, builder.ToString());
+    }
+
+    public static Matrix2x2<T> CreateDiagonal(T e11, T e22)
+        => new(e11, T.Zero, T.Zero, e22);
+
+    public readonly T Determinant() => E11 * E22 - E12 * E21;
+
+    public Matrix2x2<T> Inverse()
+    {
+        var det = Determinant();
+        if (det == T.Zero)
+        {
+            return NaM;
+        }
+        T invDet = T.One / det;
+
+        return new(E22 * invDet, -E12 * invDet, -E21 * invDet, E11 * invDet);
+    }
+
+    public static bool IsNaM(Matrix2x2<T> matrix)
+        => T.IsNaN(matrix.E11) && T.IsNaN(matrix.E22);
+
+    public T Trace() => E11 + E22;
+
+    public Matrix2x2<T> Transpose() => new(E11, E21, E12, E22);
+}

--- a/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
@@ -314,12 +314,9 @@ public struct Matrix3x3<T>
 
     public Matrix3x3<T> Transpose()
     {
-        Unsafe.SkipInit(out Matrix3x3<T> result);
-
-        result.E11 = E11; result.E12 = E21; result.E13 = E31;
-        result.E21 = E12; result.E22 = E22; result.E23 = E32;
-        result.E31 = E13; result.E32 = E23; result.E33 = E33;
-
-        return result;
+        return new(
+            E11, E21, E31,
+            E12, E22, E32,
+            E13, E23, E33);
     }
 }

--- a/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
@@ -1,0 +1,325 @@
+﻿// <copyright file="Matrix3x3.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+/// <summary>Represents a 3x3 matrix</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+public struct Matrix3x3<T>
+    : ITwoDimensionalArrayRepresentable<Matrix3x3<T>, T>,
+      ISquareMatrix<Matrix3x3<T>, T>
+    where T : IComplex<T>
+{
+    public const int Components = 9;
+    public const int E1Components = 3;
+    public const int E2Components = 3;
+
+    public static readonly Matrix3x3<T> NaM = CreateDiagonal(T.NaN, T.NaN, T.NaN);
+
+    public T E11;
+    public T E12;
+    public T E13;
+
+    public T E21;
+    public T E22;
+    public T E23;
+
+    public T E31;
+    public T E32;
+    public T E33;
+
+    public Matrix3x3(
+        T e11, T e12, T e13,
+        T e21, T e22, T e23,
+        T e31, T e32, T e33)
+    {
+        E11 = e11;
+        E12 = e12;
+        E13 = e13;
+
+        E21 = e21;
+        E22 = e22;
+        E23 = e23;
+
+        E31 = e31;
+        E32 = e32;
+        E33 = e33;
+    }
+
+    //
+    // Constants
+    //
+
+    static int IArrayRepresentable<T>.Components => Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix3x3<T>, T>.E1Components => E1Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix3x3<T>, T>.E2Components => E2Components;
+    static Matrix3x3<T> ISquareMatrix<Matrix3x3<T>, T>.NaM => NaM;
+
+    //
+    // Indexer
+    //
+
+    public T this[int row, int column]
+    {
+        get
+        {
+            if ((uint)row >= 3)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            ref Vector3<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector3<T>>(ref E11), row);
+            return vrow[column];
+        }
+        set
+        {
+            if ((uint)row >= 3)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            ref Vector3<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector3<T>>(ref E11), row);
+            var temp = Vector3<T>.WithElement(vrow, column, value);
+            vrow = temp;
+        }
+    }
+
+    //
+    // Operators
+    //
+
+    public static Matrix3x3<T> operator +(Matrix3x3<T> a, Matrix3x3<T> b)
+    {
+        return new(
+            a.E11 + b.E11, a.E12 + b.E12, a.E13 + b.E13,
+            a.E21 + b.E21, a.E22 + b.E22, a.E23 + b.E23,
+            a.E31 + b.E31, a.E32 + b.E32, a.E33 + b.E33);
+    }
+
+    public static Matrix3x3<T> operator -(Matrix3x3<T> a, Matrix3x3<T> b)
+    {
+        return new(
+            a.E11 - b.E11, a.E12 - b.E12, a.E13 - b.E13,
+            a.E21 - b.E21, a.E22 - b.E22, a.E23 - b.E23,
+            a.E31 - b.E31, a.E32 - b.E32, a.E33 - b.E33);
+    }
+
+    public static Matrix3x3<T> operator *(Matrix3x3<T> a, Matrix3x3<T> b)
+    {
+        Unsafe.SkipInit(out Matrix3x3<T> result);
+
+        result.E11 = a.E11 * b.E11 + a.E12 * b.E21 + a.E13 * b.E31;
+        result.E12 = a.E11 * b.E12 + a.E12 * b.E22 + a.E13 * b.E32;
+        result.E13 = a.E11 * b.E13 + a.E12 * b.E23 + a.E13 * b.E33;
+
+        result.E21 = a.E21 * b.E11 + a.E22 * b.E21 + a.E23 * b.E31;
+        result.E22 = a.E21 * b.E12 + a.E22 * b.E22 + a.E23 * b.E32;
+        result.E23 = a.E21 * b.E13 + a.E22 * b.E23 + a.E23 * b.E33;
+
+        result.E31 = a.E31 * b.E11 + a.E32 * b.E21 + a.E33 * b.E31;
+        result.E32 = a.E31 * b.E12 + a.E32 * b.E22 + a.E33 * b.E32;
+        result.E33 = a.E31 * b.E13 + a.E32 * b.E23 + a.E33 * b.E33;
+
+        return result;
+    }
+
+    //
+    // Equality
+    //
+
+    public static bool operator ==(Matrix3x3<T> a, Matrix3x3<T> b)
+    {
+        return a.E11 == b.E11 && a.E22 == b.E22 && a.E33 == b.E33 // Check diagonal first
+            && a.E12 == b.E12 && a.E13 == b.E13
+            && a.E21 == b.E21 && a.E23 == b.E23
+            && a.E31 == b.E31 && a.E32 == b.E32;
+    }
+
+    public static bool operator !=(Matrix3x3<T> a, Matrix3x3<T> b)
+    {
+        return a.E11 != b.E11 || a.E22 != b.E22 || a.E33 != b.E33 // Check diagonal first
+            || a.E12 != b.E12 || a.E13 != b.E13
+            || a.E21 != b.E21 || a.E23 != b.E23
+            || a.E31 != b.E31 || a.E32 != b.E32;
+    }
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Matrix3x3<T> other && Equals(other);
+
+    public bool Equals(Matrix3x3<T> value)
+    {
+        return E11.Equals(value.E11) && E22.Equals(value.E22) && E33.Equals(value.E33) // Check diagonal first
+            && E12.Equals(value.E12) && E13.Equals(value.E13)
+            && E21.Equals(value.E21) && E23.Equals(value.E23)
+            && E31.Equals(value.E31) && E32.Equals(value.E32);
+    }
+
+    public override readonly int GetHashCode()
+    {
+        HashCode hash = default;
+
+        hash.Add(E11);
+        hash.Add(E12);
+        hash.Add(E13);
+
+        hash.Add(E21);
+        hash.Add(E22);
+        hash.Add(E23);
+
+        hash.Add(E31);
+        hash.Add(E32);
+        hash.Add(E33);
+
+        return hash.ToHashCode();
+    }
+
+    //
+    // Formatting
+    //
+
+    public string ToString(string? format, IFormatProvider? provider)
+    {
+        Span2D<string> strings = new string[3, 3];
+        var maxElementLength = 0;
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                var s = this[i, j].ToString(format, provider);
+                strings[i, j] = s;
+                var length = s.Length + 2;
+                if (maxElementLength < length)
+                {
+                    maxElementLength = length;
+                }
+            }
+        }
+
+        StringBuilder builder = new();
+        var newlineChars = Environment.NewLine.ToCharArray();
+        builder.Append('[');
+        for (int i = 0; i < 3; i++)
+        {
+            builder.Append(i != 0 ? " [" : "[");
+            for (int j = 0; j < 3; j++)
+            {
+                string value = j != 2 ? $"{strings[i, j]}, " : strings[i, j];
+                builder.Append(value.PadRight(maxElementLength));
+            }
+            LinAlgExtensions.CloseGroup(builder, newlineChars);
+        }
+        LinAlgExtensions.CloseGroup(builder, newlineChars, true);
+        return string.Format(provider, builder.ToString());
+    }
+
+    //
+    // Methods
+    //
+
+    public static Matrix3x3<T> CreateDiagonal(T e11, T e22, T e33)
+    {
+        return new(
+            e11, T.Zero, T.Zero,
+            T.Zero, e22, T.Zero,
+            T.Zero, T.Zero, e33);
+    }
+
+    public readonly T Determinant()
+    {
+        T a = E11, b = E12, c = E13;
+        T d = E21, e = E22, f = E23;
+        T g = E31, h = E32, i = E33;
+
+        T ei_fh = e * i - f * h;
+        T di_fg = d * i - f * g;
+        T dh_eg = d * h - e * g;
+
+        return a * ei_fh - b * di_fg + c * dh_eg;
+    }
+
+    public Matrix3x3<T> Inverse()
+    {
+        T a = E11, b = E12, c = E13;
+        T d = E21, e = E22, f = E23;
+        T g = E31, h = E32, i = E33;
+
+        T ei_fh = e * i - f * h;
+        T di_fg = d * i - f * g;
+        T dh_eg = d * h - e * g;
+
+        T det = a * ei_fh - b * di_fg + c * dh_eg;
+        if (det == T.Zero)
+        {
+            return NaM;
+        }
+        var invDet = T.One / det;
+
+        Matrix3x3<T> result;
+
+        result.E11 = ei_fh * invDet;
+        result.E21 = -di_fg * invDet;
+        result.E31 = dh_eg * invDet;
+
+        T bi_ch = b * i - c * h;
+        T ai_cg = a * i - c * g;
+        T ah_bg = a * h - b * g;
+
+        result.E12 = -bi_ch * invDet;
+        result.E22 = ai_cg * invDet;
+        result.E32 = -ah_bg * invDet;
+
+        T bf_ce = b * f - c * e;
+        T af_cd = a * f - c * d;
+        T ae_bd = a * e - b * d;
+
+        result.E13 = bf_ce * invDet;
+        result.E23 = -af_cd * invDet;
+        result.E33 = ae_bd * invDet;
+
+        return result;
+    }
+
+    public static bool IsNaM(Matrix3x3<T> matrix)
+        => T.IsNaN(matrix.E11) && T.IsNaN(matrix.E22) && T.IsNaN(matrix.E33);
+
+    public T Trace() => E11 + E22 + E33;
+
+    public Matrix3x3<T> Transpose()
+    {
+        Unsafe.SkipInit(out Matrix3x3<T> result);
+
+        result.E11 = E11; result.E12 = E21; result.E13 = E31;
+        result.E21 = E12; result.E22 = E22; result.E23 = E32;
+        result.E31 = E13; result.E32 = E23; result.E33 = E33;
+
+        return result;
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -1,0 +1,328 @@
+﻿// <copyright file="Matrix4x4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using CommunityToolkit.HighPerformance;
+using Mathematics.NET.Core;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct Matrix4x4<T>
+    : ITwoDimensionalArrayRepresentable<Matrix4x4<T>, T>,
+      ISquareMatrix<Matrix4x4<T>, T>
+    where T : IComplex<T>
+{
+    public static readonly Matrix4x4<T> NaM = CreateDiagonal(T.NaN, T.NaN, T.NaN, T.NaN);
+
+    public T E11;
+    public T E12;
+    public T E13;
+    public T E14;
+
+    public T E21;
+    public T E22;
+    public T E23;
+    public T E24;
+
+    public T E31;
+    public T E32;
+    public T E33;
+    public T E34;
+
+    public T E41;
+    public T E42;
+    public T E43;
+    public T E44;
+
+    public Matrix4x4(
+        T e11, T e12, T e13, T e14,
+        T e21, T e22, T e23, T e24,
+        T e31, T e32, T e33, T e34,
+        T e41, T e42, T e43, T e44)
+    {
+        E11 = e11;
+        E12 = e12;
+        E13 = e13;
+        E14 = e14;
+
+        E21 = e21;
+        E22 = e22;
+        E23 = e23;
+        E24 = e24;
+
+        E31 = e31;
+        E32 = e32;
+        E33 = e33;
+        E34 = e34;
+
+        E41 = e41;
+        E42 = e42;
+        E43 = e43;
+        E44 = e44;
+    }
+
+    public static int Components => 16;
+
+    public static int E1Components => 4;
+
+    public static int E2Components => 4;
+
+    //
+    // Indexer
+    //
+
+    public T this[int row, int column]
+    {
+        get
+        {
+            if ((uint)row >= 4)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            ref Vector4<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector4<T>>(ref E11), row);
+            return vrow[column];
+        }
+        set
+        {
+            if ((uint)row >= 4)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            ref Vector4<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector4<T>>(ref E11), row);
+            var temp = Vector4<T>.WithElement(vrow, column, value);
+            vrow = temp;
+        }
+    }
+
+    //
+    // Constants
+    //
+
+    static Matrix4x4<T> ISquareMatrix<Matrix4x4<T>, T>.NaM => NaM;
+
+    //
+    // Operators
+    //
+
+    public static Matrix4x4<T> operator +(Matrix4x4<T> a, Matrix4x4<T> b)
+    {
+        return new(
+            a.E11 + b.E11, a.E12 + b.E12, a.E13 + b.E13, a.E14 + b.E14,
+            a.E21 + b.E21, a.E22 + b.E22, a.E23 + b.E23, a.E24 + b.E24,
+            a.E31 + b.E31, a.E32 + b.E32, a.E33 + b.E33, a.E34 + b.E34,
+            a.E41 + b.E41, a.E42 + b.E42, a.E43 + b.E43, a.E44 + b.E44);
+    }
+
+    public static Matrix4x4<T> operator -(Matrix4x4<T> a, Matrix4x4<T> b)
+    {
+        return new(
+            a.E11 - b.E11, a.E12 - b.E12, a.E13 - b.E13, a.E14 - b.E14,
+            a.E21 - b.E21, a.E22 - b.E22, a.E23 - b.E23, a.E24 - b.E24,
+            a.E31 - b.E31, a.E32 - b.E32, a.E33 - b.E33, a.E34 - b.E34,
+            a.E41 - b.E41, a.E42 - b.E42, a.E43 - b.E43, a.E44 - b.E44);
+    }
+
+    public static Matrix4x4<T> operator *(Matrix4x4<T> a, Matrix4x4<T> b)
+    {
+        Unsafe.SkipInit(out Matrix4x4<T> result);
+
+        result.E11 = a.E11 * b.E11 + a.E12 * b.E21 + a.E13 * b.E31 + a.E14 * b.E41;
+        result.E12 = a.E11 * b.E12 + a.E12 * b.E22 + a.E13 * b.E32 + a.E14 * b.E42;
+        result.E13 = a.E11 * b.E13 + a.E12 * b.E23 + a.E13 * b.E33 + a.E14 * b.E43;
+        result.E14 = a.E11 * b.E14 + a.E12 * b.E24 + a.E13 * b.E34 + a.E14 * b.E44;
+
+        result.E21 = a.E21 * b.E11 + a.E22 * b.E21 + a.E23 * b.E31 + a.E24 * b.E41;
+        result.E22 = a.E21 * b.E12 + a.E22 * b.E22 + a.E23 * b.E32 + a.E24 * b.E42;
+        result.E23 = a.E21 * b.E13 + a.E22 * b.E23 + a.E23 * b.E33 + a.E24 * b.E43;
+        result.E24 = a.E21 * b.E14 + a.E22 * b.E24 + a.E23 * b.E34 + a.E24 * b.E44;
+
+        result.E31 = a.E31 * b.E11 + a.E32 * b.E21 + a.E33 * b.E31 + a.E34 * b.E41;
+        result.E32 = a.E31 * b.E12 + a.E32 * b.E22 + a.E33 * b.E32 + a.E34 * b.E42;
+        result.E33 = a.E31 * b.E13 + a.E32 * b.E23 + a.E33 * b.E33 + a.E34 * b.E43;
+        result.E34 = a.E31 * b.E14 + a.E32 * b.E24 + a.E33 * b.E34 + a.E34 * b.E44;
+
+        result.E41 = a.E41 * b.E11 + a.E42 * b.E21 + a.E43 * b.E31 + a.E44 * b.E41;
+        result.E42 = a.E41 * b.E12 + a.E42 * b.E22 + a.E43 * b.E32 + a.E44 * b.E42;
+        result.E43 = a.E41 * b.E13 + a.E42 * b.E23 + a.E43 * b.E33 + a.E44 * b.E43;
+        result.E44 = a.E41 * b.E14 + a.E42 * b.E24 + a.E43 * b.E34 + a.E44 * b.E44;
+
+        return result;
+    }
+
+    //
+    // Equality
+    //
+
+    public static bool operator ==(Matrix4x4<T> a, Matrix4x4<T> b)
+    {
+        return a.E11 == b.E11 && a.E22 == b.E22 && a.E33 == b.E33 && a.E44 == b.E44 // Check diagonal first
+            && a.E12 == b.E12 && a.E13 == b.E13 && a.E14 == b.E14
+            && a.E21 == b.E21 && a.E23 == b.E23 && a.E24 == b.E24
+            && a.E31 == b.E31 && a.E32 == b.E32 && a.E34 == b.E34
+            && a.E41 == b.E41 && a.E42 == b.E42 && a.E43 == b.E43;
+    }
+
+    public static bool operator !=(Matrix4x4<T> a, Matrix4x4<T> b)
+    {
+        return a.E11 != b.E11 || a.E22 != b.E22 || a.E33 != b.E33 || a.E44 == b.E44 // Check diagonal first
+            || a.E12 != b.E12 || a.E13 != b.E13 || a.E14 != b.E14
+            || a.E21 != b.E21 || a.E23 != b.E23 || a.E24 != b.E24
+            || a.E31 != b.E31 || a.E32 != b.E32 || a.E34 != b.E34
+            || a.E41 != b.E41 || a.E42 != b.E42 || a.E43 != b.E43;
+    }
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Matrix4x4<T> other && Equals(other);
+
+    public bool Equals(Matrix4x4<T> value)
+    {
+        return E11.Equals(value.E11) && E22.Equals(value.E22) && E33.Equals(value.E33) && E44.Equals(value.E44) // Check diagonal first
+            && E12.Equals(value.E12) && E13.Equals(value.E13) && E14.Equals(value.E14)
+            && E21.Equals(value.E21) && E23.Equals(value.E23) && E24.Equals(value.E24)
+            && E31.Equals(value.E31) && E32.Equals(value.E32) && E34.Equals(value.E34)
+            && E41.Equals(value.E41) && E42.Equals(value.E42) && E43.Equals(value.E43);
+    }
+
+    public override readonly int GetHashCode()
+    {
+        HashCode hash = default;
+
+        hash.Add(E11);
+        hash.Add(E12);
+        hash.Add(E13);
+        hash.Add(E14);
+
+        hash.Add(E21);
+        hash.Add(E22);
+        hash.Add(E23);
+        hash.Add(E24);
+
+        hash.Add(E31);
+        hash.Add(E32);
+        hash.Add(E33);
+        hash.Add(E34);
+
+        hash.Add(E41);
+        hash.Add(E42);
+        hash.Add(E43);
+        hash.Add(E44);
+
+        return hash.ToHashCode();
+    }
+
+    //
+    // Formatting
+    //
+
+    public string ToString(string? format, IFormatProvider? provider)
+    {
+        Span2D<string> strings = new string[4, 4];
+        var maxElementLength = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                var s = this[i, j].ToString(format, provider);
+                strings[i, j] = s;
+                var length = s.Length + 2;
+                if (maxElementLength < length)
+                {
+                    maxElementLength = length;
+                }
+            }
+        }
+
+        var trimLength = Environment.NewLine.Length;
+        StringBuilder builder = new();
+        builder.Append('[');
+        for (int i = 0; i < 4; i++)
+        {
+            builder.Append(i != 0 ? " [" : "[");
+            for (int j = 0; j < 4; j++)
+            {
+                string value = j != 3 ? $"{strings[i, j]}, " : strings[i, j];
+                builder.Append(value.PadRight(maxElementLength));
+            }
+            builder.Remove(builder.Length - trimLength, trimLength);
+            builder.Append($"],{Environment.NewLine}");
+        }
+        builder.Remove(builder.Length - trimLength - 1, trimLength + 1); // Trim last comma
+        builder.Append(']');
+        return string.Format(provider, builder.ToString());
+    }
+
+    //
+    // Methods
+    //
+
+    public static Matrix4x4<T> CreateDiagonal(T e11, T e22, T e33, T e44)
+    {
+        return new(
+            e11, T.Zero, T.Zero, T.Zero,
+            T.Zero, e22, T.Zero, T.Zero,
+            T.Zero, T.Zero, e33, T.Zero,
+            T.Zero, T.Zero, T.Zero, e44);
+    }
+
+    public T Determinant()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Matrix4x4<T> Inverse()
+    {
+        var det = Determinant();
+        if (det == T.Zero)
+        {
+            return NaM;
+        }
+        throw new NotImplementedException();
+    }
+
+    public static bool IsNaM(Matrix4x4<T> matrix)
+        => matrix.E11 == T.NaN && matrix.E22 == T.NaN && matrix.E33 == T.NaN && matrix.E44 == T.NaN;
+
+    public T Trace() => E11 + E22 + E33 + E44;
+
+    public Matrix4x4<T> Transpose()
+    {
+        Unsafe.SkipInit(out Matrix4x4<T> result);
+
+        result.E11 = E11; result.E12 = E21; result.E13 = E31; result.E14 = E41;
+        result.E21 = E12; result.E22 = E22; result.E23 = E32; result.E24 = E42;
+        result.E31 = E13; result.E32 = E23; result.E33 = E33; result.E34 = E43;
+        result.E41 = E14; result.E42 = E24; result.E43 = E34; result.E44 = E44;
+
+        return result;
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -386,13 +386,10 @@ public struct Matrix4x4<T>
 
     public Matrix4x4<T> Transpose()
     {
-        Unsafe.SkipInit(out Matrix4x4<T> result);
-
-        result.E11 = E11; result.E12 = E21; result.E13 = E31; result.E14 = E41;
-        result.E21 = E12; result.E22 = E22; result.E23 = E32; result.E24 = E42;
-        result.E31 = E13; result.E32 = E23; result.E33 = E33; result.E34 = E43;
-        result.E41 = E14; result.E42 = E24; result.E43 = E34; result.E44 = E44;
-
-        return result;
+        return new(
+            E11, E21, E31, E41,
+            E12, E22, E32, E42,
+            E13, E23, E33, E43,
+            E14, E24, E34, E44);
     }
 }

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -41,6 +41,10 @@ public struct Matrix4x4<T>
       ISquareMatrix<Matrix4x4<T>, T>
     where T : IComplex<T>
 {
+    public const int Components = 16;
+    public const int E1Components = 4;
+    public const int E2Components = 4;
+
     public static readonly Matrix4x4<T> NaM = CreateDiagonal(T.NaN, T.NaN, T.NaN, T.NaN);
 
     public T E11;
@@ -90,11 +94,14 @@ public struct Matrix4x4<T>
         E44 = e44;
     }
 
-    public static int Components => 16;
+    //
+    // Constants
+    //
 
-    public static int E1Components => 4;
-
-    public static int E2Components => 4;
+    static int IArrayRepresentable<T>.Components => Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix4x4<T>, T>.E1Components => E1Components;
+    static int ITwoDimensionalArrayRepresentable<Matrix4x4<T>, T>.E2Components => E2Components;
+    static Matrix4x4<T> ISquareMatrix<Matrix4x4<T>, T>.NaM => NaM;
 
     //
     // Indexer
@@ -124,12 +131,6 @@ public struct Matrix4x4<T>
             vrow = temp;
         }
     }
-
-    //
-    // Constants
-    //
-
-    static Matrix4x4<T> ISquareMatrix<Matrix4x4<T>, T>.NaM => NaM;
 
     //
     // Operators

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -264,8 +264,8 @@ public struct Matrix4x4<T>
             }
         }
 
-        var trimLength = Environment.NewLine.Length;
         StringBuilder builder = new();
+        var newlineChars = Environment.NewLine.ToCharArray();
         builder.Append('[');
         for (int i = 0; i < 4; i++)
         {
@@ -275,11 +275,9 @@ public struct Matrix4x4<T>
                 string value = j != 3 ? $"{strings[i, j]}, " : strings[i, j];
                 builder.Append(value.PadRight(maxElementLength));
             }
-            builder.Remove(builder.Length - trimLength, trimLength);
-            builder.Append($"],{Environment.NewLine}");
+            Extensions.CloseGroup(builder, newlineChars);
         }
-        builder.Remove(builder.Length - trimLength - 1, trimLength + 1); // Trim last comma
-        builder.Append(']');
+        Extensions.CloseGroup(builder, newlineChars, true);
         return string.Format(provider, builder.ToString());
     }
 

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -314,14 +314,71 @@ public struct Matrix4x4<T>
                d * (e * jo_kn - f * io_km + g * in_jm);
     }
 
+    // TODO: Optimize
     public Matrix4x4<T> Inverse()
     {
-        var det = Determinant();
+        T a = E11, b = E12, c = E13, d = E14;
+        T e = E21, f = E22, g = E23, h = E24;
+        T i = E31, j = E32, k = E33, l = E34;
+        T m = E41, n = E42, o = E43, p = E44;
+
+        T kp_lo = k * p - l * o;
+        T jp_ln = j * p - l * n;
+        T jo_kn = j * o - k * n;
+        T ip_lm = i * p - l * m;
+        T io_km = i * o - k * m;
+        T in_jm = i * n - j * m;
+
+        T a11 = f * kp_lo - g * jp_ln + h * jo_kn;
+        T a12 = -(e * kp_lo - g * ip_lm + h * io_km);
+        T a13 = e * jp_ln - f * ip_lm + h * in_jm;
+        T a14 = -(e * jo_kn - f * io_km + g * in_jm);
+
+        T det = a * a11 + b * a12 + c * a13 + d * a14;
+
         if (det == T.Zero)
         {
             return NaM;
         }
-        throw new NotImplementedException();
+
+        T invDet = T.One / det;
+        Matrix4x4<T> result;
+
+        result.E11 = a11 * invDet;
+        result.E21 = a12 * invDet;
+        result.E31 = a13 * invDet;
+        result.E41 = a14 * invDet;
+
+        result.E12 = -(b * kp_lo - c * jp_ln + d * jo_kn) * invDet;
+        result.E22 = (a * kp_lo - c * ip_lm + d * io_km) * invDet;
+        result.E32 = -(a * jp_ln - b * ip_lm + d * in_jm) * invDet;
+        result.E42 = (a * jo_kn - b * io_km + c * in_jm) * invDet;
+
+        T gp_ho = g * p - h * o;
+        T fp_hn = f * p - h * n;
+        T fo_gn = f * o - g * n;
+        T ep_hm = e * p - h * m;
+        T eo_gm = e * o - g * m;
+        T en_fm = e * n - f * m;
+
+        result.E13 = (b * gp_ho - c * fp_hn + d * fo_gn) * invDet;
+        result.E23 = -(a * gp_ho - c * ep_hm + d * eo_gm) * invDet;
+        result.E33 = (a * fp_hn - b * ep_hm + d * en_fm) * invDet;
+        result.E43 = -(a * fo_gn - b * eo_gm + c * en_fm) * invDet;
+
+        T gl_hk = g * l - h * k;
+        T fl_hj = f * l - h * j;
+        T fk_gj = f * k - g * j;
+        T el_hi = e * l - h * i;
+        T ek_gi = e * k - g * i;
+        T ej_fi = e * j - f * i;
+
+        result.E14 = -(b * gl_hk - c * fl_hj + d * fk_gj) * invDet;
+        result.E24 = (a * gl_hk - c * el_hi + d * ek_gi) * invDet;
+        result.E34 = -(a * fl_hj - b * el_hi + d * ej_fi) * invDet;
+        result.E44 = (a * fk_gj - b * ek_gi + c * ej_fi) * invDet;
+
+        return result;
     }
 
     public static bool IsNaM(Matrix4x4<T> matrix)

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -334,13 +334,12 @@ public struct Matrix4x4<T>
         T a14 = -(e * jo_kn - f * io_km + g * in_jm);
 
         T det = a * a11 + b * a12 + c * a13 + d * a14;
-
         if (det == T.Zero)
         {
             return NaM;
         }
-
         T invDet = T.One / det;
+
         Matrix4x4<T> result;
 
         result.E11 = a11 * invDet;

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -35,6 +35,8 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.LinearAlgebra;
 
+/// <summary>Represents a 4x4 matrix</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
 [StructLayout(LayoutKind.Sequential)]
 public struct Matrix4x4<T>
     : ITwoDimensionalArrayRepresentable<Matrix4x4<T>, T>,

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -275,9 +275,9 @@ public struct Matrix4x4<T>
                 string value = j != 3 ? $"{strings[i, j]}, " : strings[i, j];
                 builder.Append(value.PadRight(maxElementLength));
             }
-            Extensions.CloseGroup(builder, newlineChars);
+            LinAlgExtensions.CloseGroup(builder, newlineChars);
         }
-        Extensions.CloseGroup(builder, newlineChars, true);
+        LinAlgExtensions.CloseGroup(builder, newlineChars, true);
         return string.Format(provider, builder.ToString());
     }
 

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -113,7 +113,7 @@ public struct Matrix4x4<T>
         {
             if ((uint)row >= 4)
             {
-                throw new ArgumentOutOfRangeException();
+                throw new IndexOutOfRangeException();
             }
 
             ref Vector4<T> vrow = ref Unsafe.Add(ref Unsafe.As<T, Vector4<T>>(ref E11), row);

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -29,8 +29,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using CommunityToolkit.HighPerformance;
-using Mathematics.NET.Core;
 using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.LinearAlgebra;

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -381,7 +381,7 @@ public struct Matrix4x4<T>
     }
 
     public static bool IsNaM(Matrix4x4<T> matrix)
-        => matrix.E11 == T.NaN && matrix.E22 == T.NaN && matrix.E33 == T.NaN && matrix.E44 == T.NaN;
+        => T.IsNaN(matrix.E11) && T.IsNaN(matrix.E22) && T.IsNaN(matrix.E33) && T.IsNaN(matrix.E44);
 
     public T Trace() => E11 + E22 + E33 + E44;
 

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -294,9 +294,24 @@ public struct Matrix4x4<T>
             T.Zero, T.Zero, T.Zero, e44);
     }
 
-    public T Determinant()
+    public readonly T Determinant()
     {
-        throw new NotImplementedException();
+        T a = E11, b = E12, c = E13, d = E14;
+        T e = E21, f = E22, g = E23, h = E24;
+        T i = E31, j = E32, k = E33, l = E34;
+        T m = E41, n = E42, o = E43, p = E44;
+
+        T kp_lo = k * p - l * o;
+        T jp_ln = j * p - l * n;
+        T jo_kn = j * o - k * n;
+        T ip_lm = i * p - l * m;
+        T io_km = i * o - k * m;
+        T in_jm = i * n - j * m;
+
+        return a * (f * kp_lo - g * jp_ln + h * jo_kn) -
+               b * (e * kp_lo - g * ip_lm + h * io_km) +
+               c * (e * jp_ln - f * ip_lm + h * in_jm) -
+               d * (e * jo_kn - f * io_km + g * in_jm);
     }
 
     public Matrix4x4<T> Inverse()

--- a/src/Mathematics.NET/LinearAlgebra/Vector2.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector2.cs
@@ -1,0 +1,172 @@
+﻿// <copyright file="Vector2.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+/// <summary>Represents a vector with two components</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector2<T> : IOneDimensionalArrayRepresentable<Vector2<T>, T>
+    where T : IComplex<T>
+{
+    /// <summary>The first element of the vector</summary>
+    public T X1;
+
+    /// <summary>The second element of the vector</summary>
+    public T X2;
+
+    public Vector2(T x1, T x2)
+    {
+        X1 = x1;
+        X2 = x2;
+    }
+
+    //
+    // IArrayRepresentable & relevant interfaces
+    //
+
+    public static int Components => 2;
+
+    public static int E1Components => 2;
+
+    //
+    // Indexer
+    //
+
+    public T this[int index]
+    {
+        get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static T GetElement(Vector2<T> vector, int index)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T GetElementUnsafe(ref Vector2<T> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        return Unsafe.Add(ref Unsafe.As<Vector2<T>, T>(ref vector), index);
+    }
+
+    // Set
+
+    internal static Vector2<T> WithElement(Vector2<T> vector, int index, T value)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        Vector2<T> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref Vector2<T> vector, int index, T value)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        Unsafe.Add(ref Unsafe.As<Vector2<T>, T>(ref vector), index) = value;
+    }
+
+    //
+    // Operators
+    //
+
+    public static Vector2<T> operator +(Vector2<T> left, Vector2<T> right)
+        => new(left.X1 + right.X1, left.X2 + right.X2);
+
+    public static Vector2<T> operator -(Vector2<T> left, Vector2<T> right)
+        => new(left.X1 - right.X1, left.X2 - right.X2);
+
+    public static Vector2<T> operator *(Vector2<T> left, Vector2<T> right)
+        => new(left.X1 * right.X1, left.X2 * right.X2);
+
+    //
+    // Equality
+    //
+
+    public static bool operator ==(Vector2<T> left, Vector2<T> right)
+        => left.X1 == right.X1 && left.X2 == right.X2;
+
+    public static bool operator !=(Vector2<T> left, Vector2<T> right)
+        => left.X1 != right.X1 || left.X2 != right.X2;
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Vector2<T> other && Equals(other);
+
+    public bool Equals(Vector2<T> value)
+        => X1.Equals(value.X1) && X2.Equals(value.X2);
+
+    public override readonly int GetHashCode() => HashCode.Combine(X1, X2);
+
+    //
+    // Formatting
+    //
+
+    public string ToString(string? format, IFormatProvider? provider)
+        => string.Format(provider, "({0}, {1})", X1.ToString(format, provider), X2.ToString(format, provider));
+
+    //
+    // Methods
+    //
+
+    public static T InnerProduct(Vector2<T> left, Vector2<T> right)
+        => T.Conjugate(left.X1) * right.X1 + T.Conjugate(left.X2) * right.X2;
+
+    public Real Norm()
+    {
+        var x0 = (X1 * T.Conjugate(X1)).Re;
+        var x1 = (X2 * T.Conjugate(X2)).Re;
+
+        Real max = Real.Max(x0, x1);
+        var maxSquared = max * max;
+
+        return max * Real.Sqrt(x0 / maxSquared + x1 / maxSquared);
+    }
+
+    public Vector2<T> Normalize()
+    {
+        var norm = Norm();
+        return new(X1 / norm, X2 / norm);
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/Vector3.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector3.cs
@@ -1,0 +1,215 @@
+﻿// <copyright file="Vector3.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.LinearAlgebra;
+
+/// <summary>Represents a vector with three components</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector3<T> : IOneDimensionalArrayRepresentable<Vector3<T>, T>
+    where T : IComplex<T>
+{
+    /// <summary>The first element of the vector</summary>
+    public T X1;
+
+    /// <summary>The second element of the vector</summary>
+    public T X2;
+
+    /// <summary>The third element of the vector</summary>
+    public T X3;
+
+    public Vector3(T x1, T x2, T x3)
+    {
+        X1 = x1;
+        X2 = x2;
+        X3 = x3;
+    }
+
+    //
+    // IArrayRepresentable & relevant interfaces
+    //
+
+    public static int Components => 3;
+
+    public static int E1Components => 3;
+
+    //
+    // Indexer
+    //
+
+    public T this[int index]
+    {
+        get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static T GetElement(Vector3<T> vector, int index)
+    {
+        if ((uint)index >= 3)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T GetElementUnsafe(ref Vector3<T> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 3);
+        return Unsafe.Add(ref Unsafe.As<Vector3<T>, T>(ref vector), index);
+    }
+
+    // Set
+
+    internal static Vector3<T> WithElement(Vector3<T> vector, int index, T value)
+    {
+        if ((uint)index >= 3)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        Vector3<T> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref Vector3<T> vector, int index, T value)
+    {
+        Debug.Assert(index is >= 0 and < 3);
+        Unsafe.Add(ref Unsafe.As<Vector3<T>, T>(ref vector), index) = value;
+    }
+
+    //
+    // Operators
+    //
+
+    public static Vector3<T> operator +(Vector3<T> left, Vector3<T> right)
+    {
+        return new(
+            left.X1 + right.X1,
+            left.X2 + right.X2,
+            left.X3 + right.X3);
+    }
+
+    public static Vector3<T> operator -(Vector3<T> left, Vector3<T> right)
+    {
+        return new(
+            left.X1 - right.X1,
+            left.X2 - right.X2,
+            left.X3 - right.X3);
+    }
+
+    public static Vector3<T> operator *(Vector3<T> left, Vector3<T> right)
+    {
+        return new(
+            left.X1 * right.X1,
+            left.X2 * right.X2,
+            left.X3 * right.X3);
+    }
+
+    //
+    // Equality
+    //
+
+    public static bool operator ==(Vector3<T> left, Vector3<T> right)
+        => left.X1 == right.X1
+        && left.X2 == right.X2
+        && left.X3 == right.X3;
+
+    public static bool operator !=(Vector3<T> left, Vector3<T> right)
+        => left.X1 != right.X1
+        || left.X2 != right.X2
+        || left.X3 != right.X3;
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Vector3<T> other && Equals(other);
+
+    public bool Equals(Vector3<T> value)
+        => X1.Equals(value.X1)
+        && X2.Equals(value.X2)
+        && X3.Equals(value.X3);
+
+    public override readonly int GetHashCode() => HashCode.Combine(X1, X2, X3);
+
+    //
+    // Formatting
+    //
+
+    public string ToString(string? format, IFormatProvider? provider)
+        => string.Format(provider, "({0}, {1}, {2})",
+            X1.ToString(format, provider),
+            X2.ToString(format, provider),
+            X3.ToString(format, provider));
+
+    //
+    // Methods
+    //
+
+    public static T InnerProduct(Vector3<T> left, Vector3<T> right)
+        => T.Conjugate(left.X1) * right.X1 + T.Conjugate(left.X2) * right.X2 + T.Conjugate(left.X3) * right.X3;
+
+    public Real Norm()
+    {
+        Span<Real> components = stackalloc Real[3];
+
+        components[0] = (X1 * T.Conjugate(X1)).Re;
+        components[1] = (X2 * T.Conjugate(X2)).Re;
+        components[2] = (X3 * T.Conjugate(X3)).Re;
+
+        Real max = components[0];
+        for (int i = 1; i < 3; i++)
+        {
+            if (components[i] > max)
+            {
+                max = components[i];
+            }
+        }
+
+        var partialSum = Real.Zero;
+        var maxSquared = max * max;
+        partialSum += components[0] / maxSquared;
+        partialSum += components[1] / maxSquared;
+        partialSum += components[2] / maxSquared;
+
+        return max * Real.Sqrt(partialSum);
+    }
+
+    public Vector3<T> Normalize()
+    {
+        var norm = Norm();
+        return new(X1 / norm, X2 / norm, X3 / norm);
+    }
+}

--- a/src/Mathematics.NET/LinearAlgebra/Vector4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector4.cs
@@ -173,7 +173,7 @@ public struct Vector4<T> : IOneDimensionalArrayRepresentable<Vector4<T>, T>
         && X3.Equals(value.X3)
         && X4.Equals(value.X4);
 
-    public override int GetHashCode() => HashCode.Combine(X1, X2, X3, X4);
+    public override readonly int GetHashCode() => HashCode.Combine(X1, X2, X3, X4);
 
     //
     // Formatting

--- a/src/Mathematics.NET/LinearAlgebra/Vector4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector4.cs
@@ -197,10 +197,10 @@ public struct Vector4<T> : IOneDimensionalArrayRepresentable<Vector4<T>, T>
     {
         Span<Real> components = stackalloc Real[4];
 
-        components[0] = (T.Conjugate(X1) * X1).Re;
-        components[1] = (T.Conjugate(X2) * X2).Re;
-        components[2] = (T.Conjugate(X3) * X3).Re;
-        components[3] = (T.Conjugate(X4) * X4).Re;
+        components[0] = (X1 * T.Conjugate(X1)).Re;
+        components[1] = (X2 * T.Conjugate(X2)).Re;
+        components[2] = (X3 * T.Conjugate(X3)).Re;
+        components[3] = (X4 * T.Conjugate(X4)).Re;
 
         Real max = components[0];
         for (int i = 1; i < 4; i++)
@@ -211,7 +211,7 @@ public struct Vector4<T> : IOneDimensionalArrayRepresentable<Vector4<T>, T>
             }
         }
 
-        Real partialSum = Real.Zero;
+        var partialSum = Real.Zero;
         var maxSquared = max * max;
         partialSum += components[0] / maxSquared;
         partialSum += components[1] / maxSquared;

--- a/src/Mathematics.NET/LinearAlgebra/Vector4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector4.cs
@@ -223,7 +223,7 @@ public struct Vector4<T> : IOneDimensionalArrayRepresentable<Vector4<T>, T>
 
     public Vector4<T> Normalize()
     {
-        var norm = Norm().Value;
+        var norm = Norm();
         return new(X1 / norm, X2 / norm, X3 / norm, X4 / norm);
     }
 }

--- a/src/Mathematics.NET/LinearAlgebra/Vector4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Vector4.cs
@@ -29,7 +29,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Mathematics.NET.Core;
 using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.LinearAlgebra;

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -43,4 +43,9 @@
     <ProjectReference Include="..\Mathematics.NET.SourceGenerators\Mathematics.NET.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="CommunityToolkit.HighPerformance" />
+    <Using Include="Mathematics.NET.Core" />
+  </ItemGroup>
+
 </Project>

--- a/src/Mathematics.NET/Mathematics.cs
+++ b/src/Mathematics.NET/Mathematics.cs
@@ -25,8 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.Core;
-
 namespace Mathematics.NET;
 
 /// <summary>Provides Mathematics.NET functionality</summary>


### PR DESCRIPTION
- Add Vector3 and Vector2
- Add Matrix4x4, Matrix3x3, and Matrix2x2
- Add extension methods for formatting Span and Span2D into strings
- Other minor changes

This update contains a method for performing QR decomposition that uses the Gram-Schmidt process. This update also contains a method for computing the eigenvalues of a matrix. Further optimizations are needed for these methods as well as the added vector and matrix types.