### PR TITLE
Rename ComplexNumber to Complex

### DIFF
--- a/docs/articles/fundamentals/numeric-types.md
+++ b/docs/articles/fundamentals/numeric-types.md
@@ -2,7 +2,7 @@
 
 There are three numeric types that can be used to represent complex, real, and rational numbers in Mathematics.NET.
 
-All Mathematics.NET numbers implement the [IComplex\<T\>](https://mathematics.hamlettanyavong.com/api/Mathematics.NET.Core.IComplex-1.html) interface. Particularly useful is the fact that, unlike .NET runtime's [INumberBase\<T\>](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs), `IComplex<T>` defines the `Conjugate` method; this is helpful in avoiding code duplication for calculations involving complex and real numbers.
+All Mathematics.NET numbers implement the `IComplex<T>` interface. Particularly useful is the fact that, unlike .NET runtime's [INumberBase\<T\>](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs), `IComplex<T>` defines the `Conjugate` method; this is helpful in avoiding code duplication for calculations involving complex and real numbers.
 
 ## Floating-Point Types
 
@@ -10,13 +10,15 @@ Floating-point Mathematics.NET numbers are backed by the [double](https://github
 
 ### Complex Numbers
 
+The type that represents complex numbers in this package shares the same name with the one defined in `System.Numerics.Complex`. Therefore, if we wish to use this library with `System.Numerics`, we need to create an alias to resolve the ambigious reference. Adding the line `using Complex = Mathematics.NET.Core.Complex;` should suffice.
+
 To create a complex number, we can write
 ```csharp
-ComplexNumber z = new(3, 4);
+Complex z = new(3, 4);
 ```
 This represents the number $ z = 3+i4 $. We can also specify only one number to create a complex number with no imaginary part
 ```csharp
-ComplexNumber z = 3;
+Complex z = 3;
 ```
 which represents $ z = 3 $.
 

--- a/src/Mathematics.NET/Core/Complex.cs
+++ b/src/Mathematics.NET/Core/Complex.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ComplexNumber.cs" company="Mathematics.NET">
+﻿// <copyright file="Complex.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -36,12 +36,12 @@ namespace Mathematics.NET.Core;
 /// <summary>Represents a complex number</summary>
 [Serializable]
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct ComplexNumber
-    : IComplex<ComplexNumber>,
-      IDifferentiableFunctions<ComplexNumber>
+public readonly struct Complex
+    : IComplex<Complex>,
+      IDifferentiableFunctions<Complex>
 {
-    private static readonly ComplexNumber s_im = new(Real.Zero, Real.One);
-    private static readonly ComplexNumber s_imOverTwo = new(Real.Zero, Real.One / 2.0);
+    private static readonly Complex s_im = new(Real.Zero, Real.One);
+    private static readonly Complex s_imOverTwo = new(Real.Zero, Real.One / 2.0);
 
     // For division and reciprocal
 
@@ -52,22 +52,22 @@ public readonly struct ComplexNumber
     // 2.0 / (Precision.DblEpsilonVariant * Precision.DblEpsilonVariant)
     private const double s_scale = 4.05648192073033408e31;
 
-    public static readonly ComplexNumber Zero = Real.Zero;
-    public static readonly ComplexNumber One = Real.One;
+    public static readonly Complex Zero = Real.Zero;
+    public static readonly Complex One = Real.One;
 
-    public static readonly ComplexNumber NaN = new(Real.NaN, Real.NaN);
-    public static readonly ComplexNumber Infinity = new(Real.PositiveInfinity, Real.PositiveInfinity);
+    public static readonly Complex NaN = new(Real.NaN, Real.NaN);
+    public static readonly Complex Infinity = new(Real.PositiveInfinity, Real.PositiveInfinity);
 
     private readonly Real _real;
     private readonly Real _imaginary;
 
-    public ComplexNumber(Real real)
+    public Complex(Real real)
     {
         _real = real;
         _imaginary = 0.0;
     }
 
-    public ComplexNumber(Real real, Real imaginary)
+    public Complex(Real real, Real imaginary)
     {
         _real = real;
         _imaginary = imaginary;
@@ -87,25 +87,25 @@ public readonly struct ComplexNumber
     // Constants
     //
 
-    static ComplexNumber IComplex<ComplexNumber>.Zero => Zero;
-    static ComplexNumber IComplex<ComplexNumber>.One => One;
-    static ComplexNumber IComplex<ComplexNumber>.NaN => NaN;
+    static Complex IComplex<Complex>.Zero => Zero;
+    static Complex IComplex<Complex>.One => One;
+    static Complex IComplex<Complex>.NaN => NaN;
 
     //
     // Operators
     //
 
-    public static ComplexNumber operator -(ComplexNumber z) => new(-z._real, -z._imaginary);
+    public static Complex operator -(Complex z) => new(-z._real, -z._imaginary);
 
-    public static ComplexNumber operator +(ComplexNumber z, ComplexNumber w) => new(z._real + w._real, z._imaginary + w._imaginary);
+    public static Complex operator +(Complex z, Complex w) => new(z._real + w._real, z._imaginary + w._imaginary);
 
-    public static ComplexNumber operator -(ComplexNumber z, ComplexNumber w) => new(z._real - w._real, z._imaginary - w._imaginary);
+    public static Complex operator -(Complex z, Complex w) => new(z._real - w._real, z._imaginary - w._imaginary);
 
-    public static ComplexNumber operator *(ComplexNumber z, ComplexNumber w)
+    public static Complex operator *(Complex z, Complex w)
         => new(z._real * w._real - z._imaginary * w._imaginary, z._real * w._imaginary + w._real * z._imaginary);
 
     // From Michael Baudin and Robert L. Smith
-    public static ComplexNumber operator /(ComplexNumber z, ComplexNumber w)
+    public static Complex operator /(Complex z, Complex w)
     {
         var a = z._real.Value;
         var b = z._imaginary.Value;
@@ -209,13 +209,13 @@ public readonly struct ComplexNumber
     // Equality
     //
 
-    public static bool operator ==(ComplexNumber left, ComplexNumber right) => left.Re == right.Re && left.Im == right.Im;
+    public static bool operator ==(Complex left, Complex right) => left.Re == right.Re && left.Im == right.Im;
 
-    public static bool operator !=(ComplexNumber left, ComplexNumber right) => left.Re != right.Re || left.Im != right.Im;
+    public static bool operator !=(Complex left, Complex right) => left.Re != right.Re || left.Im != right.Im;
 
-    public override bool Equals([NotNullWhen(true)] object? obj) => obj is ComplexNumber other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is Complex other && Equals(other);
 
-    public bool Equals(ComplexNumber value) => _real.Equals(value.Re) && _imaginary.Equals(value.Im);
+    public bool Equals(Complex value) => _real.Equals(value.Re) && _imaginary.Equals(value.Im);
 
     public override int GetHashCode() => HashCode.Combine(_real, _imaginary);
 
@@ -317,35 +317,35 @@ public readonly struct ComplexNumber
     // Parsing
     //
 
-    public static ComplexNumber Parse(string s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    public static Complex Parse(string s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-    public static ComplexNumber Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
+    public static Complex Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-    public static ComplexNumber Parse(string s, NumberStyles style, IFormatProvider? provider)
+    public static Complex Parse(string s, NumberStyles style, IFormatProvider? provider)
     {
         ArgumentNullException.ThrowIfNull(s);
         return Parse((ReadOnlySpan<char>)s, style, provider);
     }
 
-    public static ComplexNumber Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null)
+    public static Complex Parse(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands, IFormatProvider? provider = null)
     {
-        if (!TryParse(s, style, provider, out ComplexNumber result))
+        if (!TryParse(s, style, provider, out Complex result))
         {
             return Infinity;
         }
         return result;
     }
 
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ComplexNumber result)
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Complex result)
         => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ComplexNumber result)
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Complex result)
         => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
-    public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out ComplexNumber result)
+    public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out Complex result)
         => TryParse((ReadOnlySpan<char>)s, style, provider, out result);
 
-    public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ComplexNumber result)
+    public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Complex result)
     {
         s = s.Trim();
         int openParenthesis = s.IndexOf('(');
@@ -379,16 +379,16 @@ public readonly struct ComplexNumber
     // Methods
     //
 
-    public static ComplexNumber Abs(ComplexNumber z) => Hypot(z._real.Value, z._imaginary.Value);
+    public static Complex Abs(Complex z) => Hypot(z._real.Value, z._imaginary.Value);
 
-    public static ComplexNumber Conjugate(ComplexNumber z) => new(z._real, -z._imaginary);
+    public static Complex Conjugate(Complex z) => new(z._real, -z._imaginary);
 
-    public static ComplexNumber FromDouble(double x) => new(x);
+    public static Complex FromDouble(double x) => new(x);
 
-    public static ComplexNumber FromPolarForm(Real magnitude, Real phase)
+    public static Complex FromPolarForm(Real magnitude, Real phase)
         => new(magnitude * Math.Cos(phase.Value), magnitude * Math.Sin(phase.Value));
 
-    public static ComplexNumber FromReal(Real x) => new(x);
+    public static Complex FromReal(Real x) => new(x);
 
     private static double Hypot(double x, double y)
     {
@@ -423,15 +423,15 @@ public readonly struct ComplexNumber
         }
     }
 
-    public static bool IsFinite(ComplexNumber z) => Real.IsFinite(z._real) && Real.IsFinite(z._imaginary);
+    public static bool IsFinite(Complex z) => Real.IsFinite(z._real) && Real.IsFinite(z._imaginary);
 
-    public static bool IsInfinity(ComplexNumber z) => Real.IsInfinity(z._real) || Real.IsInfinity(z._imaginary);
+    public static bool IsInfinity(Complex z) => Real.IsInfinity(z._real) || Real.IsInfinity(z._imaginary);
 
-    public static bool IsNaN(ComplexNumber z) => !IsInfinity(z) && !IsFinite(z);
+    public static bool IsNaN(Complex z) => !IsInfinity(z) && !IsFinite(z);
 
-    public static bool IsZero(ComplexNumber z) => Real.IsZero(z._real) && Real.IsZero(z._imaginary);
+    public static bool IsZero(Complex z) => Real.IsZero(z._real) && Real.IsZero(z._imaginary);
 
-    public static ComplexNumber Reciprocate(ComplexNumber z)
+    public static Complex Reciprocate(Complex z)
     {
         if (z._real == 0.0 && z._imaginary == 0.0)
         {
@@ -475,28 +475,28 @@ public readonly struct ComplexNumber
 
     // We will only consider the real part of complex numbers for these conversions.
 
-    public static bool TryConvertFromChecked<U>(U value, out ComplexNumber result)
+    public static bool TryConvertFromChecked<U>(U value, out Complex result)
         where U : INumberBase<U>
     {
         result = double.CreateChecked(value);
         return true;
     }
 
-    public static bool TryConvertFromSaturating<U>(U value, out ComplexNumber result)
+    public static bool TryConvertFromSaturating<U>(U value, out Complex result)
         where U : INumberBase<U>
     {
         result = double.CreateSaturating(value);
         return true;
     }
 
-    public static bool TryConvertFromTruncating<U>(U value, out ComplexNumber result)
+    public static bool TryConvertFromTruncating<U>(U value, out Complex result)
         where U : INumberBase<U>
     {
         result = double.CreateTruncating(value);
         return true;
     }
 
-    public static bool TryConvertToChecked<U>(ComplexNumber value, [MaybeNullWhen(false)] out U result)
+    public static bool TryConvertToChecked<U>(Complex value, [MaybeNullWhen(false)] out U result)
         where U : INumberBase<U>
     {
         if (value._imaginary == Real.Zero)
@@ -508,14 +508,14 @@ public readonly struct ComplexNumber
         return true;
     }
 
-    public static bool TryConvertToSaturating<U>(ComplexNumber value, [MaybeNullWhen(false)] out U result)
+    public static bool TryConvertToSaturating<U>(Complex value, [MaybeNullWhen(false)] out U result)
         where U : INumberBase<U>
     {
         result = U.CreateSaturating(value._real.Value);
         return true;
     }
 
-    public static bool TryConvertToTruncating<U>(ComplexNumber value, [MaybeNullWhen(false)] out U result)
+    public static bool TryConvertToTruncating<U>(Complex value, [MaybeNullWhen(false)] out U result)
         where U : INumberBase<U>
     {
         result = U.CreateTruncating(value._real.Value);
@@ -528,57 +528,57 @@ public readonly struct ComplexNumber
 
     // Exponential functions
 
-    public static ComplexNumber Exp(ComplexNumber z)
+    public static Complex Exp(Complex z)
     {
         Real expReal = Real.Exp(z._real);
         return new(expReal * Real.Cos(z._imaginary), expReal * Real.Sin(z._imaginary));
     }
 
-    public static ComplexNumber Exp2(ComplexNumber z) => Exp(Real.Ln2 * z);
+    public static Complex Exp2(Complex z) => Exp(Real.Ln2 * z);
 
-    public static ComplexNumber Exp10(ComplexNumber z) => Exp(Real.Ln10 * z);
+    public static Complex Exp10(Complex z) => Exp(Real.Ln10 * z);
 
     // Hyperbolic functions
 
-    public static ComplexNumber Acosh(ComplexNumber z) => Ln(z + Sqrt(z * z - One));
+    public static Complex Acosh(Complex z) => Ln(z + Sqrt(z * z - One));
 
-    public static ComplexNumber Asinh(ComplexNumber z) => Ln(z + Sqrt(z * z + One));
+    public static Complex Asinh(Complex z) => Ln(z + Sqrt(z * z + One));
 
-    public static ComplexNumber Atanh(ComplexNumber z) => 0.5 * Ln((One + z) / (One - z));
+    public static Complex Atanh(Complex z) => 0.5 * Ln((One + z) / (One - z));
 
-    public static ComplexNumber Cosh(ComplexNumber z)
+    public static Complex Cosh(Complex z)
         => new(Real.Cosh(z._real) * Real.Cos(z._imaginary), Real.Sinh(z._real) * Real.Sin(z._imaginary));
 
-    public static ComplexNumber Sinh(ComplexNumber z)
+    public static Complex Sinh(Complex z)
         => new(Real.Sinh(z._real) * Real.Cos(z._imaginary), Real.Cosh(z._real) * Real.Sin(z._imaginary));
 
-    public static ComplexNumber Tanh(ComplexNumber z) => Sinh(z) / Cosh(z);
+    public static Complex Tanh(Complex z) => Sinh(z) / Cosh(z);
 
     // Logarithmic functions
 
-    public static ComplexNumber Ln(ComplexNumber z) => new(Real.Ln(Hypot(z._real.Value, z._imaginary.Value)), Real.Atan2(z._imaginary, z._real));
+    public static Complex Ln(Complex z) => new(Real.Ln(Hypot(z._real.Value, z._imaginary.Value)), Real.Atan2(z._imaginary, z._real));
 
-    public static ComplexNumber Log(ComplexNumber z, ComplexNumber b) => Ln(z) / Ln(b);
+    public static Complex Log(Complex z, Complex b) => Ln(z) / Ln(b);
 
-    public static ComplexNumber Log2(ComplexNumber z) => Ln(z) / Ln(Real.Ln2);
+    public static Complex Log2(Complex z) => Ln(z) / Ln(Real.Ln2);
 
-    public static ComplexNumber Log10(ComplexNumber z) => Ln(z) / Ln(Real.Ln10);
+    public static Complex Log10(Complex z) => Ln(z) / Ln(Real.Ln10);
 
     // Power functions
 
-    public static ComplexNumber Pow(ComplexNumber z, ComplexNumber w) => Exp(w * Ln(z));
+    public static Complex Pow(Complex z, Complex w) => Exp(w * Ln(z));
 
     // Root functions
 
-    public static ComplexNumber Cbrt(ComplexNumber z) => Exp(Ln(z) / 3.0);
+    public static Complex Cbrt(Complex z) => Exp(Ln(z) / 3.0);
 
-    public static ComplexNumber Root(ComplexNumber z, ComplexNumber w) => Exp(Ln(z) / w);
+    public static Complex Root(Complex z, Complex w) => Exp(Ln(z) / w);
 
-    public static ComplexNumber Sqrt(ComplexNumber z) => Exp(0.5 * Ln(z));
+    public static Complex Sqrt(Complex z) => Exp(0.5 * Ln(z));
 
     // Trigonometric functions
 
-    public static ComplexNumber Acos(ComplexNumber z)
+    public static Complex Acos(Complex z)
     {
         AsinInternal(Math.Abs(z._real.Value), Math.Abs(z._imaginary.Value), out double b, out double bPrime, out double v);
 
@@ -604,7 +604,7 @@ public readonly struct ComplexNumber
         return new(u, v);
     }
 
-    public static ComplexNumber Asin(ComplexNumber z)
+    public static Complex Asin(Complex z)
     {
         AsinInternal(Math.Abs(z._real.Value), Math.Abs(z._imaginary.Value), out double b, out double bPrime, out double v);
 
@@ -722,9 +722,9 @@ public readonly struct ComplexNumber
         }
     }
 
-    public static ComplexNumber Atan(ComplexNumber z) => s_imOverTwo * Ln((s_im + z) / (s_im - z));
+    public static Complex Atan(Complex z) => s_imOverTwo * Ln((s_im + z) / (s_im - z));
 
-    public static ComplexNumber Cos(ComplexNumber z)
+    public static Complex Cos(Complex z)
     {
         Real p = Real.Exp(z._imaginary);
         Real q = Real.One / p;
@@ -733,7 +733,7 @@ public readonly struct ComplexNumber
         return new(Real.Cos(z._real) * cosh, -Real.Sin(z._real) * sinh);
     }
 
-    public static ComplexNumber Sin(ComplexNumber z)
+    public static Complex Sin(Complex z)
     {
         Real p = Real.Exp(z._imaginary);
         Real q = Real.One / p;
@@ -742,7 +742,7 @@ public readonly struct ComplexNumber
         return new(Real.Sin(z._real) * cosh, Real.Cos(z._real) * sinh);
     }
 
-    public static ComplexNumber Tan(ComplexNumber z)
+    public static Complex Tan(Complex z)
     {
         Real x2 = 2.0 * z._real;
         Real y2 = 2.0 * z._imaginary;
@@ -766,9 +766,9 @@ public readonly struct ComplexNumber
     // Implicit Operators
     //
 
-    public static implicit operator ComplexNumber(double x) => new(x);
+    public static implicit operator Complex(double x) => new(x);
 
-    /// <summary>Convert a value of type <see cref="Real"/> to one of type <see cref="ComplexNumber"/></summary>
+    /// <summary>Convert a value of type <see cref="Real"/> to one of type <see cref="Complex"/></summary>
     /// <param name="x">The value to convert</param>
-    public static implicit operator ComplexNumber(Real x) => new(x);
+    public static implicit operator Complex(Real x) => new(x);
 }

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -43,7 +43,7 @@ public static class LinAlg
     /// <example>
     /// Suppose we want to find the eigenvalues of a 2x2 matrix. We can write the following to get them:
     /// <code language="cs">
-    /// Span2D&lt;ComplexNumber&gt; matrix = new ComplexNumber[2, 2]
+    /// Span2D&lt;Complex&gt; matrix = new Complex[2, 2]
     /// {
     ///     { new(1, 2), new(2, 3) },
     ///     { new(1, -2), new(3, 5) }

--- a/src/Mathematics.NET/Mathematics.cs
+++ b/src/Mathematics.NET/Mathematics.cs
@@ -38,7 +38,7 @@ public static class Mathematics
     //
 
     /// <summary>Represents the imaginary unit, $ i $</summary>
-    public static ComplexNumber Im => new(Real.Zero, Real.One);
+    public static Complex Im => new(Real.Zero, Real.One);
 
     /// <inheritdoc cref="Constants.E"/>
     public static Real E => Real.E;

--- a/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/ComplexDivisionBenchmarks.cs
+++ b/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/ComplexDivisionBenchmarks.cs
@@ -30,11 +30,11 @@ namespace Mathematics.NET.Benchmarks.Core.ComplexNumberBenchmarks;
 [MemoryDiagnoser]
 public class ComplexDivisionBenchmarks
 {
-    public ComplexNumber Z { get; set; }
-    public ComplexNumber W { get; set; }
+    public Complex Z { get; set; }
+    public Complex W { get; set; }
 
-    public Complex X { get; set; }
-    public Complex Y { get; set; }
+    public SystemComplex X { get; set; }
+    public SystemComplex Y { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -47,13 +47,13 @@ public class ComplexDivisionBenchmarks
     }
 
     [Benchmark(Baseline = true)]
-    public Complex SystemDivision()
+    public SystemComplex SystemDivision()
     {
         return X / Y;
     }
 
     [Benchmark]
-    public ComplexNumber ComplexDivision_WithAggressiveInlining()
+    public Complex ComplexDivision_WithAggressiveInlining()
     {
         return Z / W;
     }

--- a/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/ComplexTrigonometryBenchmarks.cs
+++ b/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/ComplexTrigonometryBenchmarks.cs
@@ -32,10 +32,10 @@ namespace Mathematics.NET.Benchmarks.Core.ComplexNumberBenchmarks;
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class ComplexTrigonometryBenchmarks
 {
-    public ComplexNumber Z { get; set; }
-    public ComplexNumber ImOverTwo { get; set; }
+    public Complex Z { get; set; }
+    public Complex ImOverTwo { get; set; }
 
-    public Complex W { get; set; }
+    public SystemComplex W { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -47,26 +47,26 @@ public class ComplexTrigonometryBenchmarks
     }
 
     [Benchmark(Baseline = true)]
-    public Complex Atan_System()
+    public SystemComplex Atan_System()
     {
-        return Complex.Atan(W);
+        return SystemComplex.Atan(W);
     }
 
     [Benchmark]
-    public ComplexNumber Atan_MathNET()
+    public Complex Atan_MathNET()
     {
-        return ComplexNumber.Atan(Z);
+        return Complex.Atan(Z);
     }
 
     //[Benchmark]
-    public ComplexNumber Atan_WithoutConstImOverTwo()
+    public Complex Atan_WithoutConstImOverTwo()
     {
-        return Mathematics.Im / 2.0 * ComplexNumber.Ln((Mathematics.Im + Z) / (Mathematics.Im - Z));
+        return Mathematics.Im / 2.0 * Complex.Ln((Mathematics.Im + Z) / (Mathematics.Im - Z));
     }
 
     //[Benchmark]
-    public ComplexNumber Atan_WithConstImOverTwo()
+    public Complex Atan_WithConstImOverTwo()
     {
-        return ImOverTwo * ComplexNumber.Ln((Mathematics.Im + Z) / (Mathematics.Im - Z));
+        return ImOverTwo * Complex.Ln((Mathematics.Im + Z) / (Mathematics.Im - Z));
     }
 }

--- a/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/SystemComplexAbsVsComplexAbsBenchmarks.cs
+++ b/tests/Mathematics.NET.Benchmarks/Core/ComplexNumberBenchmarks/SystemComplexAbsVsComplexAbsBenchmarks.cs
@@ -32,8 +32,8 @@ namespace Mathematics.NET.Benchmarks.Core.ComplexNumberBenchmarks;
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class SystemComplexAbsVsComplexAbsBenchmarks
 {
-    public Complex Z { get; set; }
-    public ComplexNumber W { get; set; }
+    public SystemComplex Z { get; set; }
+    public Complex W { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -45,12 +45,12 @@ public class SystemComplexAbsVsComplexAbsBenchmarks
     [Benchmark(Baseline = true)]
     public Real SystemComplexAbs()
     {
-        return Complex.Abs(Z);
+        return SystemComplex.Abs(Z);
     }
 
     [Benchmark]
-    public ComplexNumber ComplexAbs()
+    public Complex ComplexAbs()
     {
-        return ComplexNumber.Abs(W);
+        return Complex.Abs(W);
     }
 }

--- a/tests/Mathematics.NET.Benchmarks/LinearAlgebra/MatrixMultiplyByScalarBenchmarks.cs
+++ b/tests/Mathematics.NET.Benchmarks/LinearAlgebra/MatrixMultiplyByScalarBenchmarks.cs
@@ -38,8 +38,8 @@ public class MatrixMultiplyByScalarBenchmarks
 {
     public int Rows { get; set; }
     public int Cols { get; set; }
-    public required ComplexNumber[,] MatrixOne { get; set; }
-    public required ComplexNumber[,] MatrixTwo { get; set; }
+    public required NET.Core.Complex[,] MatrixOne { get; set; }
+    public required NET.Core.Complex[,] MatrixTwo { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -47,7 +47,7 @@ public class MatrixMultiplyByScalarBenchmarks
         Rows = 100;
         Cols = 100;
 
-        MatrixOne = new ComplexNumber[Rows, Cols];
+        MatrixOne = new NET.Core.Complex[Rows, Cols];
 
         for (int i = 0; i < Rows; i++)
         {
@@ -75,7 +75,7 @@ public class MatrixMultiplyByScalarBenchmarks
     [Benchmark]
     public void MultiplyByScalarParallel()
     {
-        Memory2D<ComplexNumber> matrixAsMemory = MatrixTwo;
-        ParallelHelper.ForEach(matrixAsMemory, new MultiplyByScalarAction<ComplexNumber>(Real.Pi));
+        Memory2D<NET.Core.Complex> matrixAsMemory = MatrixTwo;
+        ParallelHelper.ForEach(matrixAsMemory, new MultiplyByScalarAction<NET.Core.Complex>(Real.Pi));
     }
 }

--- a/tests/Mathematics.NET.Benchmarks/Mathematics.NET.Benchmarks.csproj
+++ b/tests/Mathematics.NET.Benchmarks/Mathematics.NET.Benchmarks.csproj
@@ -20,7 +20,9 @@
     <Using Include="BenchmarkDotNet.Attributes" />
     <Using Include="BenchmarkDotNet.Order" />
     <Using Include="Mathematics.NET.Core" />
-    <Using Include="System.Numerics" />
+    <Using Include="System.Numerics.Complex">
+      <Alias>SystemComplex</Alias>
+    </Using>
   </ItemGroup>
 
 </Project>

--- a/tests/Mathematics.NET.Tests/Core/ComplexTests.cs
+++ b/tests/Mathematics.NET.Tests/Core/ComplexTests.cs
@@ -35,9 +35,9 @@ public sealed class ComplexTests
     [DataRow(1.23, 2.34, 1.114564084931578, -1.686112230652994)]
     public void Acos_Complex_ReturnsComplex(double inReal, double inImaginary, double expectedRe, double expectedIm)
     {
-        ComplexNumber input = new(inReal, inImaginary);
+        Complex input = new(inReal, inImaginary);
 
-        var actualResult = ComplexNumber.Acos(input);
+        var actualResult = Complex.Acos(input);
         var actualRe = actualResult.Re.Value;
         var actualIm = actualResult.Im.Value;
 
@@ -49,9 +49,9 @@ public sealed class ComplexTests
     [DataRow(1.23, 2.34, 4.562322418633185e-1, 1.686112230652994)]
     public void Asin_Complex_ReturnsComplex(double inReal, double inImaginary, double expectedRe, double expectedIm)
     {
-        ComplexNumber input = new(inReal, inImaginary);
+        Complex input = new(inReal, inImaginary);
 
-        var actualResult = ComplexNumber.Asin(input);
+        var actualResult = Complex.Asin(input);
         var actualRe = actualResult.Re.Value;
         var actualIm = actualResult.Im.Value;
 
@@ -63,9 +63,9 @@ public sealed class ComplexTests
     [DataRow(1.23, 2.34, 1.37591078602063, 3.356559207392595e-1)]
     public void Atan_Complex_ReturnsComplex(double inReal, double inImaginary, double expectedRe, double expectedIm)
     {
-        ComplexNumber input = new(inReal, inImaginary);
+        Complex input = new(inReal, inImaginary);
 
-        var actualResult = ComplexNumber.Atan(input);
+        var actualResult = Complex.Atan(input);
         var actualRe = actualResult.Re.Value;
         var actualIm = actualResult.Im.Value;
 
@@ -77,10 +77,10 @@ public sealed class ComplexTests
     [DataRow(1.2, 2.3, 1.2, -2.3)]
     public void Conjugate_Complex_ReturnsConjugate(double inReal, double inImaginary, double outReal, double outImaginary)
     {
-        ComplexNumber input = new(inReal, inImaginary);
-        ComplexNumber expected = new(outReal, outImaginary);
+        Complex input = new(inReal, inImaginary);
+        Complex expected = new(outReal, outImaginary);
 
-        var actual = ComplexNumber.Conjugate(input);
+        var actual = Complex.Conjugate(input);
 
         Assert.AreEqual(expected, actual);
     }
@@ -92,8 +92,8 @@ public sealed class ComplexTests
     [DataRow(5, 3.5, 7, 0, 0.7142857142857142, 0.5)]
     public void Division_Complexs_ReturnsComplex(double dividendRe, double dividendIm, double divisorRe, double divisorIm, double expectedRe, double expectedIm)
     {
-        ComplexNumber dividend = new(dividendRe, dividendIm);
-        ComplexNumber divisor = new(divisorRe, divisorIm);
+        Complex dividend = new(dividendRe, dividendIm);
+        Complex divisor = new(divisorRe, divisorIm);
 
         var actualResult = dividend / divisor;
         var actualRe = actualResult.Re.Value;
@@ -107,7 +107,7 @@ public sealed class ComplexTests
     [DataRow(3, 4, 5)]
     public void Magnitude_Complex_ReturnsMagnitude(double inReal, double inImaginary, double expected)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         var actual = z.Magnitude.Value;
 
@@ -121,7 +121,7 @@ public sealed class ComplexTests
     [DataRow(-1, -1, -Math.PI, -Math.PI / 2)]
     public void Phase_Complex_ReturnsAngleInCorrectQuadrant(double inReal, double inImaginary, double expectedMin, double expectedMax)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         var actual = z.Phase.Value;
 
@@ -133,10 +133,10 @@ public sealed class ComplexTests
     [DataRow(1.5, 2.5, 1.76470588235294117e-1, -2.94117647058823529e-1)]
     public void Reciprocate_Complex_ReturnsReciprocal(double inReal, double inImaginary, double expectedRe, double expectedIm)
     {
-        ComplexNumber z = new(inReal, inImaginary);
-        ComplexNumber expected = new(expectedRe, expectedIm);
+        Complex z = new(inReal, inImaginary);
+        Complex expected = new(expectedRe, expectedIm);
 
-        var actual = ComplexNumber.Reciprocate(z);
+        var actual = Complex.Reciprocate(z);
 
         Assert.AreEqual(expected, actual);
     }
@@ -148,7 +148,7 @@ public sealed class ComplexTests
     [DataRow(7.345, 124.841, "IM", "124.841")]
     public void ToString_Complex_ReturnsString(double inReal, double inImaginary, string? format, string expected)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         var actual = z.ToString(format, null);
 
@@ -160,7 +160,7 @@ public sealed class ComplexTests
     [DataRow(1.23, 2.34, 12)]
     public void TryFormat_ComplexWithAdequateDestinationLength_ReturnsTrue(double inReal, double inImaginary, int length)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         Span<char> span = new char[length];
         var actual = z.TryFormat(span, out int _, null, null);
@@ -173,7 +173,7 @@ public sealed class ComplexTests
     [DataRow(1.23, 2.34, 11)]
     public void TryFormat_ComplexWithInadequateDestinationLength_ReturnsFalse(double inReal, double inImaginary, int length)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         Span<char> span = new char[length];
         var actual = z.TryFormat(span, out int _, null, null);
@@ -188,9 +188,9 @@ public sealed class ComplexTests
     [DataRow("( 1.23 , 3.45 )", 1.23, 3.45)]
     public void TryParse_SpanOfChar_ReturnsComplex(string s, double expectedRe, double expectedIm)
     {
-        ComplexNumber expected = new(expectedRe, expectedIm);
+        Complex expected = new(expectedRe, expectedIm);
 
-        _ = ComplexNumber.TryParse(s.AsSpan(), null, out ComplexNumber actual);
+        _ = Complex.TryParse(s.AsSpan(), null, out Complex actual);
 
         Assert.AreEqual(expected, actual);
     }
@@ -202,7 +202,7 @@ public sealed class ComplexTests
     [DataRow("(0,0")]
     public void TryParse_SpanOfChar_ReturnsFalse(string s)
     {
-        var actual = ComplexNumber.TryParse(s.AsSpan(), null, out _);
+        var actual = Complex.TryParse(s.AsSpan(), null, out _);
 
         Assert.IsFalse(actual);
     }
@@ -221,7 +221,7 @@ public sealed class ComplexTests
     [DataRow(1.2345, 0, 8, 8)]
     public void TryFormat_ComplexWithInadequateDestinationLength_ReturnsCorrectNumberOfCharsWritten(double inReal, double inImaginary, int length, int expected)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         Span<char> span = new char[length];
         _ = z.TryFormat(span, out int actual, null, null);
@@ -236,7 +236,7 @@ public sealed class ComplexTests
     [DataRow(1.2, 7, 1, "IM", "7")]
     public void TryFormat_Complex_ReturnsSpanOfCharacters(double inReal, double inImaginary, int length, string? format, string expected)
     {
-        ComplexNumber z = new(inReal, inImaginary);
+        Complex z = new(inReal, inImaginary);
 
         Span<char> actual = new char[length];
         _ = z.TryFormat(actual, out int _, format, null);

--- a/tests/Mathematics.NET.Tests/LinearAlgebra/LinAlgTests.cs
+++ b/tests/Mathematics.NET.Tests/LinearAlgebra/LinAlgTests.cs
@@ -40,7 +40,7 @@ public sealed class LinAlgTests
     {
         yield return new[]
         {
-            new ComplexNumber[2, 2]
+            new Complex[2, 2]
             {
                 { new(1, 2), new(2, 3) },
                 { new(1, -2), new(3, 5) }
@@ -65,7 +65,7 @@ public sealed class LinAlgTests
 
     [TestMethod]
     [DynamicData(nameof(GetComplexInputs), DynamicDataSourceType.Method)]
-    public void QRGramSchmidt_MatrixOfComplex_ReturnsQRDecompositionOfMatrix(ComplexNumber[,] matrix)
+    public void QRGramSchmidt_MatrixOfComplex_ReturnsQRDecompositionOfMatrix(Complex[,] matrix)
         => QRGramSchmidt_Helper_MatrixOfGeneric_ReturnsQRDecompositionOfMatrix(matrix);
 
     [TestMethod]


### PR DESCRIPTION
- Users should create an alias for Mathematics.NET.Core.Complex if they want to use it along with the complex number type defined in System.Numerics
- Update documentation to reflect this change
- Update tests and benchmarks to reflect this change