### PR TITLE
Add second-order, reverse-mode automatic differentiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 
 ## About
 
-Mathematics.NET provides custom types for complex, real, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors.[^1] Mathematics.NET also supports automatic differentiation.[^2]
+Mathematics.NET provides custom types for complex, real, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors.[^1] Mathematics.NET also supports first-order, forward and reverse-mode automatic differentiation.
 
 [^1]: Please visit the [documentation site](https://mathematics.hamlettanyavong.com) for detailed information.
-[^2]: So far, only first-order, reverse-mode automatic differentiation is supported; first-order, forward-mode, as well as second-order forward and reverse-modes are planned features.

--- a/docs/guide/autodiff/first-order-reverse-mode.md
+++ b/docs/guide/autodiff/first-order-reverse-mode.md
@@ -98,11 +98,11 @@ graph BT
 ```
 We can then calculate the gradient of our function by using the `ReverseAccumulation` method.
 ```csharp
-tape.ReverseAccumulation(out var gradients);
+tape.ReverseAccumulation(out var gradient);
 ```
 Since this is a single variable equation, we can access the first element of `gradients` to get our result.
 ```csharp
-Console.WriteLine(gradients[0]);
+Console.WriteLine(gradient[0]);
 ```
 The correct value for the derivative should be `3.525753368769319`. The complete code looks as follows:
 ```csharp
@@ -119,12 +119,12 @@ var result = tape.Divide(
 // Optional: examine the nodes on the gradient tape
 tape.PrintNodes();
 
-tape.ReverseAccumulation(out var gradients);
+tape.ReverseAccumulation(out var gradient);
 
 // The value of the function at the point x = 1.23: 0.6675110878078776
 Console.WriteLine("Value: {0}", result);
 // The derivative of the function with respect to x at the point x = 1.23: 3.525753368769319
-Console.WriteLine("Derivative: {0}", gradients[0]);
+Console.WriteLine("Derivative: {0}", gradient[0]);
 ```
 
 ## Multivariable Equations
@@ -202,7 +202,7 @@ graph BT
 ```
 As before, we can use `ReverseAccumulation` to get our gradients
 ```csharp
-tape.ReverseAccumulation(out var gradients);
+tape.ReverseAccumulation(out var gradient);
 ```
 and print them to the console with
 ```csharp
@@ -210,7 +210,7 @@ using Mathematics.NET.LinearAlgebra;
 
 // code
 
-Console.WriteLine(gradients.ToDisplayString());
+Console.WriteLine(gradient.ToDisplayString());
 ```
 This will print the following to the console:
 ```
@@ -303,12 +303,12 @@ var result = tape.Cos(
 tape.PrintNodes(CancellationToken.None);
 Console.WriteLine();
 
-tape.ReverseAccumulation(out var gradients);
+tape.ReverseAccumulation(out var gradient);
 
 // The value of the function at the point z = 1.23 + i2.34 and w = -0.66 + i0.23
 Console.WriteLine("Value: {0}", result);
-// The gradients of the function: ∂f/∂z and ∂f/∂w, respectively
-Console.WriteLine("Gradients: {0}", gradients.ToDisplayString());
+// The gradient of the function: ∂f/∂z and ∂f/∂w, respectively
+Console.WriteLine("Gradient: {0}", gradient.ToDisplayString());
 ```
 which is almost the exact same code we would have written in the real case. (Note that some methods such as `Atan2` are not available for complex gradient tapes.) This should output the following to the console:
 ```
@@ -333,7 +333,7 @@ Node 5:
     Parents: [4, 5]
 
 Value: (27.784322505370138, 24.753716703326287)
-Gradients: [(126.28638563049401, -98.74954259806483),  (-38.801295827094066, -109.6878698782088)  ]
+Gradient: [(126.28638563049401, -98.74954259806483),  (-38.801295827094066, -109.6878698782088)  ]
 ```
 
 ## Custom Operations
@@ -348,9 +348,9 @@ var result = tape.CustomOperation(
     x => Real.Sin(x),  // The function
     x => Real.Cos(x)); // The derivative of the function
 
-tape.ReverseAccumulation(out var gradients);
+tape.ReverseAccumulation(out var gradient);
 Console.WriteLine("Value: {0}", result);
-Console.WriteLine("Gradient: {0}", gradients.ToDisplayString());
+Console.WriteLine("Gradient: {0}", gradient.ToDisplayString());
 ```
 For custom binary operations, we can write
 ```csharp

--- a/docs/guide/autodiff/first-order-reverse-mode.md
+++ b/docs/guide/autodiff/first-order-reverse-mode.md
@@ -200,7 +200,7 @@ graph BT
     mul -- adj(w₆) = adj(w₇) ∂w₇/∂w₆ --> div
     div -- adj(f) = adj(w₇) = 1 (seed) --> function["f(x, y, z)"]
 ```
-As before, we can use the `ReverseAccumulation` to get our gradients
+As before, we can use `ReverseAccumulation` to get our gradients
 ```csharp
 tape.ReverseAccumulation(out var gradients);
 ```

--- a/docs/guide/autodiff/first-order-reverse-mode.md
+++ b/docs/guide/autodiff/first-order-reverse-mode.md
@@ -2,7 +2,7 @@
 
 Support for first-order, reverse-mode automatic differentiation (autodiff) is provided by the `GradientTape` class.
 
-## Gradient tapes
+## Gradient Tapes
 
 Gradient tapes keep track of operations for autodiff; unlike forward-mode autodiff, tracking is required since gradients have to be calculated in reverse order. To begin using reverse-mode autodiff, we must create a gradient tape and assign it variables to track. These variables will be passed into and returned from methods that will compute the local gradients for us and record them on the tape.
 ```csharp

--- a/docs/guide/autodiff/second-order-reverse-mode.md
+++ b/docs/guide/autodiff/second-order-reverse-mode.md
@@ -1,0 +1,58 @@
+# Second-Order, Reverse Mode Automatic Differentiation
+
+Support for first-order, reverse-mode automatic differentiation (autodiff) is provided by the `HessianTape` class.
+
+## Hessian Tapes
+
+The steps needed to perform second-order, reverse-mode autodiff is similar to the steps needed to perform the first-order case. This time, however, we have access to the following overloads and/or versions of `ReverseAccumulation`:
+```csharp
+HessianTape<Complex> tape = new();
+
+// Do some math...
+
+// Use when we are only interested in the gradient
+tape.ReverseAccumulation(out ReadOnlySpan<Complex> gradient);
+// Use when we are only interested in the Hessian
+tape.ReverseAccumulation(out ReadOnlySpan2D<Complex> hessian);
+// Use when we are interested in both the gradient and Hessian
+tape.ReverseAccumulation(out var gradient, out var hessian);
+```
+The last version may be useful for calculations such as finding the Laplacian of a scalar function in spherical coordinates which involves derivatives of first and second orders:
+$$
+\begin{align}
+    \nabla^2f(r,\theta,\phi)    &   =\frac{1}{r^2}\frac{\partial}{\partial r}\left(r^2\frac{\partial f}{\partial r}\right)+\frac{1}{r^2\sin{\theta}}\frac{\partial}{\partial\theta}\left(\sin{\theta}\frac{\partial f}{\partial\theta}\right)+\frac{1}{r^2\sin^2{\theta}}\frac{\partial^2f}{\partial\phi^2}   \\
+    &   =\frac{2}{r}\frac{\partial f}{\partial r}+\frac{\partial^2f}{\partial r^2}+\frac{1}{r^2\sin{\theta}}\left(\cos{\theta}\frac{\partial f}{\partial\theta}+\sin{\theta}\frac{\partial^2f}{\partial\theta^2}\right)+\frac{1}{r^2\sin^2{\theta}}\frac{\partial^2f}{\partial\phi^2}
+\end{align}
+$$
+Note that, in the future, we will not have to do this manually since there will be a method made specifically to compute Laplacians in spherical coordinates. For now, if we wanted to compute the Laplacian of the function
+$$
+    f(x,y,z) = \frac{\cos(x)}{(x+y)\sin(z)}
+$$
+we can write
+```csharp
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Core;
+
+HessianTape<Real> tape = new();
+var x = tape.CreateVariableVector(1.23, 0.66, 0.23);
+
+// f(x, y, z) = cos(x) / ((x + y) * sin(z))
+_ = tape.Divide(
+        tape.Cos(x.X1),
+        tape.Multiply(
+            tape.Add(x.X1, x.X2),
+            tape.Sin(x.X3)));
+
+tape.ReverseAccumulation(out var gradient, out var hessian);
+
+// Manual Laplacian computation
+var u = Real.One / (x.X1.Value * Real.Sin(x.X2.Value)); // 1 / (r * sin(θ))
+var laplacian = 2.0 * gradient[0] / x.X1.Value +
+                hessian[0, 0] +
+                u * Real.Cos(x.X2.Value) * gradient[1] / x.X1.Value +
+                hessian[1, 1] / (x.X1.Value * x.X1.Value) +
+                u * u * hessian[2, 2];
+
+Console.WriteLine(laplacian);
+```
+which should give us `48.80966092022821`.

--- a/docs/guide/toc.yml
+++ b/docs/guide/toc.yml
@@ -14,3 +14,5 @@
     href: autodiff/first-order-reverse-mode.md
   - name: First-Order, Forward-Mode Automatic Differentiation
     href: autodiff/first-order-forward-mode.md
+  - name: Second-Order, Reverse-Mode Automatic Differentiation
+    href: autodiff/second-order-reverse-mode.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,4 +54,4 @@
 
 ## About
 
-Mathematics.NET provides custom types for complex, real, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors.
+Mathematics.NET provides custom types for complex, real, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors. Mathematics.NET also supports forward and reverse-mode automatic differentiation.

--- a/src/Mathematics.NET.SourceGenerators/Mathematics.NET.SourceGenerators.csproj
+++ b/src/Mathematics.NET.SourceGenerators/Mathematics.NET.SourceGenerators.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
@@ -227,6 +227,22 @@ public static class AutoDiffExtensions
         return result;
     }
 
+    /// <summary>Compute the Laplacian of a scalar function using reverse-mode automatic differentiation: $ \nabla^2f $.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f">A scalar function</param>
+    /// <param name="x">The point at which to compute the Laplacian</param>
+    /// <returns>The Laplacian of the scalar function</returns>
+    public static T Laplacian<T>(this HessianTape<T> tape, Func<ITape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out ReadOnlySpan2D<T> hessian);
+
+        return hessian[0, 0] + hessian[1, 1] + hessian[2, 2];
+    }
+
     /// <summary>Compute the vector-Jacobian product of a vector and a vector function using reverse-mode automatic differentiation.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>

--- a/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
@@ -36,23 +36,23 @@ public static class AutoDiffExtensions
     // Variable creation
     //
 
-    /// <summary>Create a three-element vector from a seed vector of length three</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <summary>Create a three-element vector from a seed vector of length three.</summary>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x">A three-element vector of seed values</param>
     /// <returns>A variable vector of length three</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    public static VariableVector3<T> CreateVariableVector<T>(this GradientTape<T> tape, Vector3<T> x)
+    public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, Vector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x.X1), tape.CreateVariable(x.X2), tape.CreateVariable(x.X3));
 
-    /// <summary>Create a three-element vector from seed values</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <summary>Create a three-element vector from seed values.</summary>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x1Seed">The first seed value</param>
     /// <param name="x2Seed">The second seed value</param>
     /// <param name="x3Seed">The third seed value</param>
     /// <returns>A variable vector of length three</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    public static VariableVector3<T> CreateVariableVector<T>(this GradientTape<T> tape, T x1Seed, T x2Seed, T x3Seed)
+    public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, T x1Seed, T x2Seed, T x3Seed)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed), tape.CreateVariable(x3Seed));
 
@@ -71,10 +71,10 @@ public static class AutoDiffExtensions
     /// <returns>The curl of the vector field</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Vector3<T> Curl<T>(
-        this GradientTape<T> tape,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fz,
+        this ITape<T> tape,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
@@ -101,9 +101,9 @@ public static class AutoDiffExtensions
     /// <returns>The directional derivative</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static T DirectionalDerivative<T>(
-        this GradientTape<T> tape,
+        this ITape<T> tape,
         Vector3<T> v,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> f,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> f,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
@@ -123,10 +123,10 @@ public static class AutoDiffExtensions
     /// <returns>The divergence of the vector field</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static T Divergence<T>(
-        this GradientTape<T> tape,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fz,
+        this ITape<T> tape,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
@@ -154,8 +154,8 @@ public static class AutoDiffExtensions
     /// <returns>The gradient of the scalar function</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Vector3<T> Gradient<T>(
-        this GradientTape<T> tape,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> f,
+        this ITape<T> tape,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> f,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
@@ -175,10 +175,10 @@ public static class AutoDiffExtensions
     /// <returns>The Jacobian of the vector function</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Matrix3x3<T> Jacobian<T>(
-        this GradientTape<T> tape,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fz,
+        this ITape<T> tape,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
@@ -209,10 +209,10 @@ public static class AutoDiffExtensions
     /// <returns>The Jacobian-vector product of the vector function and vector</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Vector3<T> JVP<T>(
-        this GradientTape<T> tape,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fz,
+        this ITape<T> tape,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
         VariableVector3<T> x,
         Vector3<T> v)
         where T : IComplex<T>, IDifferentiableFunctions<T>
@@ -244,11 +244,11 @@ public static class AutoDiffExtensions
     /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static unsafe Vector3<T> VJP<T>(
-        this GradientTape<T> tape,
+        this ITape<T> tape,
         Vector3<T> v,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<GradientTape<T>, VariableVector3<T>, Variable<T>> fz,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
+        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
         VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {

--- a/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
@@ -37,21 +37,21 @@ public static class AutoDiffExtensions
     //
 
     /// <summary>Create a three-element vector from a seed vector of length three.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x">A three-element vector of seed values</param>
     /// <returns>A variable vector of length three</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, Vector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x.X1), tape.CreateVariable(x.X2), tape.CreateVariable(x.X3));
 
     /// <summary>Create a three-element vector from seed values.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x1Seed">The first seed value</param>
     /// <param name="x2Seed">The second seed value</param>
     /// <param name="x3Seed">The third seed value</param>
     /// <returns>A variable vector of length three</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, T x1Seed, T x2Seed, T x3Seed)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed), tape.CreateVariable(x3Seed));
@@ -63,13 +63,13 @@ public static class AutoDiffExtensions
     // TODO: Improve performance; perhaps see if caching is possible for some of these methods
 
     /// <summary>Compute the curl of a vector field using reverse-mode automatic differentiation: $ (\nabla\times\textbf{F})(\textbf{x}) $.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="fx">The x-component of the vector field</param>
     /// <param name="fy">The y-component of the vector field</param>
     /// <param name="fz">The z-component of the vector field</param>
     /// <param name="x">The point at which to compute the curl</param>
     /// <returns>The curl of the vector field</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Vector3<T> Curl<T>(
         this ITape<T> tape,
         Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
@@ -94,17 +94,13 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the derivative of a scalar function along a particular direction using reverse-mode automatic differentiation: $ \nabla_{\textbf{v}}f(\textbf{x}) $.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="v">A direction</param>
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the directional derivative</param>
     /// <returns>The directional derivative</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    public static T DirectionalDerivative<T>(
-        this ITape<T> tape,
-        Vector3<T> v,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> f,
-        VariableVector3<T> x)
+    public static T DirectionalDerivative<T>(this ITape<T> tape, Vector3<T> v, Func<ITape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
@@ -115,13 +111,13 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the divergence of a vector field using reverse-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="fx">The x-component of the vector field</param>
     /// <param name="fy">The y-component of the vector field</param>
     /// <param name="fz">The z-component of the vector field</param>
     /// <param name="x">The point at which to compute the divergence</param>
     /// <returns>The divergence of the vector field</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static T Divergence<T>(
         this ITape<T> tape,
         Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
@@ -148,15 +144,12 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the gradient of a scalar function using reverse-mode automatic differentiation: $ \nabla f(\textbf{x}) $.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the gradient</param>
     /// <returns>The gradient of the scalar function</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    public static Vector3<T> Gradient<T>(
-        this ITape<T> tape,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> f,
-        VariableVector3<T> x)
+    public static Vector3<T> Gradient<T>(this ITape<T> tape, Func<ITape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
@@ -167,13 +160,13 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the Jacobian of a vector function using reverse-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="fx">The first function</param>
     /// <param name="fy">The second function</param>
     /// <param name="fz">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian</param>
     /// <returns>The Jacobian of the vector function</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Matrix3x3<T> Jacobian<T>(
         this ITape<T> tape,
         Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
@@ -200,14 +193,14 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the Jacobian-vector product of a vector function and a vector using reverse-mode automatic differentiation.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="fx">The first function</param>
     /// <param name="fy">The second function</param>
     /// <param name="fz">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian-vector product</param>
     /// <param name="v">A vector</param>
     /// <returns>The Jacobian-vector product of the vector function and vector</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     public static Vector3<T> JVP<T>(
         this ITape<T> tape,
         Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
@@ -235,15 +228,15 @@ public static class AutoDiffExtensions
     }
 
     /// <summary>Compute the vector-Jacobian product of a vector and a vector function using reverse-mode automatic differentiation.</summary>
-    /// <param name="tape">A gradient tape</param>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="v">A vector</param>
     /// <param name="fx">The first function</param>
     /// <param name="fy">The second function</param>
     /// <param name="fz">The third function</param>
     /// <param name="x">The point at which to compute the vector-Jacobian product</param>
     /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
-    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    public static unsafe Vector3<T> VJP<T>(
+    public static Vector3<T> VJP<T>(
         this ITape<T> tape,
         Vector3<T> v,
         Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -142,15 +142,16 @@ public record class GradientTape<T>
         }
     }
 
-    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradients.</summary>
-    /// <param name="gradients">The gradients</param>
+    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
+    /// <param name="gradients">The gradient</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulation(out ReadOnlySpan<T> gradients)
         => ReverseAccumulation(out gradients, T.One);
 
-    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradients.</summary>
-    /// <param name="gradients">The gradients</param>
+    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
+    /// <param name="gradients">The gradient</param>
     /// <param name="seed">A seed value</param>
+    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulation(out ReadOnlySpan<T> gradients, T seed)
     {

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -143,17 +143,18 @@ public record class GradientTape<T>
     }
 
     /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
-    /// <param name="gradients">The gradient</param>
+    /// <param name="gradient">The gradient</param>
+    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public void ReverseAccumulation(out ReadOnlySpan<T> gradients)
-        => ReverseAccumulation(out gradients, T.One);
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient)
+        => ReverseAccumulation(out gradient, T.One);
 
     /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
-    /// <param name="gradients">The gradient</param>
+    /// <param name="gradient">The gradient</param>
     /// <param name="seed">A seed value</param>
     /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public void ReverseAccumulation(out ReadOnlySpan<T> gradients, T seed)
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient, T seed)
     {
         if (_variableCount == 0)
         {
@@ -170,13 +171,13 @@ public record class GradientTape<T>
         for (int i = length - 1; i >= _variableCount; i--)
         {
             var node = Unsafe.Add(ref start, i);
-            var gradient = gradientSpan[i];
+            var gradientElement = gradientSpan[i];
 
-            gradientSpan[node.PX] += gradient * node.DX;
-            gradientSpan[node.PY] += gradient * node.DY;
+            gradientSpan[node.PX] += gradientElement * node.DX;
+            gradientSpan[node.PY] += gradientElement * node.DY;
         }
 
-        gradients = gradientSpan[.._variableCount];
+        gradient = gradientSpan[.._variableCount];
     }
 
     //

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -65,7 +65,7 @@ namespace Mathematics.NET.AutoDiff;
 
 /// <summary>Represents a gradient tape</summary>
 /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-public record class GradientTape<T>
+public record class GradientTape<T> : ITape<T>
     where T : IComplex<T>, IDifferentiableFunctions<T>
 {
     // TODO: Measure performance with Stack<Node<T>> instead of List<Node<T>>
@@ -78,19 +78,14 @@ public record class GradientTape<T>
         _nodes = [];
     }
 
-    /// <summary>Get the number of nodes on the gradient tape.</summary>
     public int NodeCount => _nodes.Count;
 
-    /// <summary>Get the number of variables that are being tracked.</summary>
     public int VariableCount => _variableCount;
 
     //
     // Methods
     //
 
-    /// <summary>Create a variable for the gradient tape to track.</summary>
-    /// <param name="seed">A seed value</param>
-    /// <returns>A variable</returns>
     public Variable<T> CreateVariable(T seed)
     {
         _nodes.Add(new(_variableCount));
@@ -98,9 +93,6 @@ public record class GradientTape<T>
         return variable;
     }
 
-    /// <summary>Print the nodes of the gradient tape to the console.</summary>
-    /// <param name="cancellationToken">A cancellation token</param>
-    /// <param name="limit">The total number of nodes to print</param>
     public void PrintNodes(CancellationToken cancellationToken, int limit = 100)
     {
         const string tab = "    ";
@@ -142,17 +134,10 @@ public record class GradientTape<T>
         }
     }
 
-    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
-    /// <param name="gradient">The gradient</param>
-    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulation(out ReadOnlySpan<T> gradient)
         => ReverseAccumulation(out gradient, T.One);
 
-    /// <summary>Perform reverse accumulation on the gradient tape and output the resulting gradient.</summary>
-    /// <param name="gradient">The gradient</param>
-    /// <param name="seed">A seed value</param>
-    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulation(out ReadOnlySpan<T> gradient, T seed)
     {
@@ -184,40 +169,24 @@ public record class GradientTape<T>
     // Basic operations
     //
 
-    /// <summary>Add two variables</summary>
-    /// <param name="x">The first variable</param>
-    /// <param name="y">The second variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Add(Variable<T> x, Variable<T> y)
     {
         _nodes.Add(new(T.One, T.One, x._index, y._index));
         return new(_nodes.Count - 1, x.Value + y.Value);
     }
 
-    /// <summary>Add a constant value and a variable</summary>
-    /// <param name="c">A constant value</param>
-    /// <param name="x">A variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Add(T c, Variable<T> x)
     {
         _nodes.Add(new(T.One, x._index, _nodes.Count));
         return new(_nodes.Count - 1, c + x.Value);
     }
 
-    /// <summary>Add a variable and a constant value</summary>
-    /// <param name="x">A variable</param>
-    /// <param name="c">A constant value</param>
-    /// <returns>A variable</returns>
     public Variable<T> Add(Variable<T> x, T c)
     {
         _nodes.Add(new(T.One, x._index, _nodes.Count));
         return new(_nodes.Count - 1, x.Value + c);
     }
 
-    /// <summary>Divide two variables</summary>
-    /// <param name="x">A dividend</param>
-    /// <param name="y">A divisor</param>
-    /// <returns>A variable</returns>
     public Variable<T> Divide(Variable<T> x, Variable<T> y)
     {
         var u = T.One / y.Value;
@@ -225,10 +194,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, x.Value * u);
     }
 
-    /// <summary>Divide a constant value by a variable</summary>
-    /// <param name="c">A constant dividend</param>
-    /// <param name="x">A variable divisor</param>
-    /// <returns>A variable</returns>
     public Variable<T> Divide(T c, Variable<T> x)
     {
         var u = T.One / x.Value;
@@ -236,10 +201,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, x.Value * u);
     }
 
-    /// <summary>Divide a variable by a constant value</summary>
-    /// <param name="x">A variable dividend</param>
-    /// <param name="c">A constant divisor</param>
-    /// <returns>A variable</returns>
     public Variable<T> Divide(Variable<T> x, T c)
     {
         var u = T.One / c;
@@ -247,90 +208,54 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, x.Value * u);
     }
 
-    /// <summary>Compute the modulo of a variable given a divisor</summary>
-    /// <param name="x">A dividend</param>
-    /// <param name="y">A divisor</param>
-    /// <returns><paramref name="x"/> mod <paramref name="y"/></returns>
     public Variable<Real> Modulo(Variable<Real> x, Variable<Real> y)
     {
         _nodes.Add(new(T.One, x.Value * Real.Floor(x.Value / y.Value), x._index, y._index));
         return new(_nodes.Count - 1, x.Value % y.Value);
     }
 
-    /// <summary>Compute the modulo of a real value given a divisor</summary>
-    /// <param name="c">A real dividend</param>
-    /// <param name="x">A variable divisor</param>
-    /// <returns><paramref name="c"/> mod <paramref name="x"/></returns>
     public Variable<Real> Modulo(Real c, Variable<Real> x)
     {
         _nodes.Add(new(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, c % x.Value);
     }
 
-    /// <summary>Compute the modulo of a variable given a divisor</summary>
-    /// <param name="x">A variable dividend</param>
-    /// <param name="c">A real divisor</param>
-    /// <returns><paramref name="x"/> mod <paramref name="c"/></returns>
     public Variable<Real> Modulo(Variable<Real> x, Real c)
     {
         _nodes.Add(new(T.One, x._index, _nodes.Count));
         return new(_nodes.Count - 1, x.Value % c);
     }
 
-    /// <summary>Multiply two variables</summary>
-    /// <param name="x">The first variable</param>
-    /// <param name="y">The second variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Multiply(Variable<T> x, Variable<T> y)
     {
         _nodes.Add(new(y.Value, x.Value, x._index, y._index));
         return new(_nodes.Count - 1, x.Value * y.Value);
     }
 
-    /// <summary>Multiply a constant value by a variable</summary>
-    /// <param name="c">A constant value</param>
-    /// <param name="x">A variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Multiply(T c, Variable<T> x)
     {
         _nodes.Add(new(c, x._index, _nodes.Count));
         return new(_nodes.Count - 1, c * x.Value);
     }
 
-    /// <summary>Multiply a variable by a constant value</summary>
-    /// <param name="x">A variable</param>
-    /// <param name="c">A constant value</param>
-    /// <returns>A variable</returns>
     public Variable<T> Multiply(Variable<T> x, T c)
     {
         _nodes.Add(new(c, x._index, _nodes.Count));
         return new(_nodes.Count - 1, x.Value * c);
     }
 
-    /// <summary>Subract two variables</summary>
-    /// <param name="x">The first variable</param>
-    /// <param name="y">The second variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Subtract(Variable<T> x, Variable<T> y)
     {
         _nodes.Add(new(T.One, -T.One, x._index, y._index));
         return new(_nodes.Count - 1, x.Value - y.Value);
     }
 
-    /// <summary>Subtract a variable from a constant value</summary>
-    /// <param name="c">A constant value</param>
-    /// <param name="x">A variable</param>
-    /// <returns>A variable</returns>
     public Variable<T> Subtract(T c, Variable<T> x)
     {
         _nodes.Add(new(-T.One, x._index, _nodes.Count));
         return new(_nodes.Count - 1, c - x.Value);
     }
 
-    /// <summary>Subtract a constant value from a variable</summary>
-    /// <param name="x">A variable</param>
-    /// <param name="c">A constant value</param>
-    /// <returns>A variable</returns>
     public Variable<T> Subtract(Variable<T> x, T c)
     {
         _nodes.Add(new(T.One, x._index, _nodes.Count));
@@ -341,9 +266,6 @@ public record class GradientTape<T>
     // Other operations
     //
 
-    /// <summary>Negate a variable</summary>
-    /// <param name="x">A variable</param>
-    /// <returns>Minus one times the variable</returns>
     public Variable<T> Negate(Variable<T> x)
     {
         _nodes.Add(new(-T.One, x._index, _nodes.Count));
@@ -352,7 +274,6 @@ public record class GradientTape<T>
 
     // Exponential functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp(T)"/>
     public Variable<T> Exp(Variable<T> x)
     {
         var exp = T.Exp(x.Value);
@@ -360,7 +281,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, exp);
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp2(T)"/>
     public Variable<T> Exp2(Variable<T> x)
     {
         var exp2 = T.Exp2(x.Value);
@@ -368,7 +288,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, exp2);
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp10(T)"/>
     public Variable<T> Exp10(Variable<T> x)
     {
         var exp10 = T.Exp10(x.Value);
@@ -378,42 +297,36 @@ public record class GradientTape<T>
 
     // Hyperbolic functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acosh(T)"/>
     public Variable<T> Acosh(Variable<T> x)
     {
         _nodes.Add(new(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Acosh(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asinh(T)"/>
     public Variable<T> Asinh(Variable<T> x)
     {
         _nodes.Add(new(T.One / T.Sqrt(x.Value * x.Value + T.One), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Asinh(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atanh(T)"/>
     public Variable<T> Atanh(Variable<T> x)
     {
         _nodes.Add(new(T.One / (T.One - x.Value * x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Atanh(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cosh(T)"/>
     public Variable<T> Cosh(Variable<T> x)
     {
         _nodes.Add(new(T.Sinh(x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Cosh(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sinh(T)"/>
     public Variable<T> Sinh(Variable<T> x)
     {
         _nodes.Add(new(T.Cosh(x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Sinh(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tanh(T)"/>
     public Variable<T> Tanh(Variable<T> x)
     {
         var u = T.One / T.Cosh(x.Value);
@@ -423,14 +336,12 @@ public record class GradientTape<T>
 
     // Logarithmic functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Ln(T)"/>
     public Variable<T> Ln(Variable<T> x)
     {
         _nodes.Add(new(T.One / x.Value, x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Ln(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log(T, T)"/>
     public Variable<T> Log(Variable<T> x, Variable<T> b)
     {
         var lnB = T.Ln(b.Value);
@@ -438,14 +349,12 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log2(T)"/>
     public Variable<T> Log2(Variable<T> x)
     {
         _nodes.Add(new(T.One / (Real.Ln2 * x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Log2(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log10(T)"/>
     public Variable<T> Log10(Variable<T> x)
     {
         _nodes.Add(new(T.One / (Real.Ln10 * x.Value), x._index, _nodes.Count));
@@ -454,7 +363,6 @@ public record class GradientTape<T>
 
     // Power functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
     public Variable<T> Pow(Variable<T> x, Variable<T> y)
     {
         var pow = T.Pow(x.Value, y.Value);
@@ -464,7 +372,6 @@ public record class GradientTape<T>
 
     // Root functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cbrt(T)"/>
     public Variable<T> Cbrt(Variable<T> x)
     {
         var cbrt = T.Cbrt(x.Value);
@@ -472,7 +379,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, cbrt);
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Root(T, T)"/>
     public Variable<T> Root(Variable<T> x, Variable<T> n)
     {
         var root = T.Root(x.Value, n.Value);
@@ -480,7 +386,6 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, root);
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sqrt(T)"/>
     public Variable<T> Sqrt(Variable<T> x)
     {
         var sqrt = T.Sqrt(x.Value);
@@ -490,28 +395,24 @@ public record class GradientTape<T>
 
     // Trigonometric functions
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acos(T)"/>
     public Variable<T> Acos(Variable<T> x)
     {
         _nodes.Add(new(-T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Acos(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asin(T)"/>
     public Variable<T> Asin(Variable<T> x)
     {
         _nodes.Add(new(T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Asin(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atan(T)"/>
     public Variable<T> Atan(Variable<T> x)
     {
         _nodes.Add(new(T.One / (T.One + x.Value * x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Atan(x.Value));
     }
 
-    /// <inheritdoc cref="IReal{T}.Atan2(T, T)"/>
     public Variable<Real> Atan2(Variable<Real> y, Variable<Real> x)
     {
         var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
@@ -519,21 +420,18 @@ public record class GradientTape<T>
         return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cos(T)"/>
     public Variable<T> Cos(Variable<T> x)
     {
         _nodes.Add(new(-T.Sin(x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Cos(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sin(T)"/>
     public Variable<T> Sin(Variable<T> x)
     {
         _nodes.Add(new(T.Cos(x.Value), x._index, _nodes.Count));
         return new(_nodes.Count - 1, T.Sin(x.Value));
     }
 
-    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tan(T)"/>
     public Variable<T> Tan(Variable<T> x)
     {
         var sec = T.One / T.Cos(x.Value);

--- a/src/Mathematics.NET/AutoDiff/HessianNode.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianNode.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="HessianNode.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a node on a Hessian tape</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+internal readonly record struct HessianNode<T>
+    where T : IComplex<T>
+{
+    /// <summary>The first derivative of the left component of the binary operation</summary>
+    public readonly T DX;
+    /// <summary>The second derivative of the left component of the binary operation</summary>
+    public readonly T DXX;
+    /// <summary>The derivative of the left or right component of the binary operation with respect to the left and right variables</summary>
+    public readonly T DXY;
+    /// <summary>The first derivative of the right component of the binary operation</summary>
+    public readonly T DY;
+    /// <summary>The second derivative of the right component of the binary operation</summary>
+    public readonly T DYY;
+
+    /// <summary>The parent index of the left node</summary>
+    public readonly int PX;
+    /// <summary>The parent index of the right node</summary>
+    public readonly int PY;
+
+    public HessianNode(int index)
+    {
+        DX = T.Zero;
+        DXX = T.Zero;
+        DXY = T.Zero;
+        DY = T.Zero;
+        DYY = T.Zero;
+
+        PX = index;
+        PY = index;
+    }
+
+    public HessianNode(T dfx, T dfxx, int px, int py)
+    {
+        DX = dfx;
+        DXX = dfxx;
+        DXY = T.Zero;
+        DY = T.Zero;
+        DYY = T.Zero;
+
+        PX = px;
+        PY = py;
+    }
+
+    public HessianNode(T dfx, T dfxx, T dfxy, T dfy, T dfyy, int px, int py)
+    {
+        DX = dfx;
+        DXX = dfxx;
+        DXY = dfxy;
+        DY = dfy;
+        DYY = dfyy;
+
+        PX = px;
+        PY = py;
+    }
+}

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -1,0 +1,629 @@
+﻿// <copyright file="HessianTape.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a Hessian tape</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+public record class HessianTape<T>
+    where T : IComplex<T>, IDifferentiableFunctions<T>
+{
+    private List<HessianNode<T>> _nodes;
+    private int _variableCount;
+
+    public HessianTape()
+    {
+        _nodes = [];
+    }
+
+    /// <summary>Get the number of nodes on the gradient tape.</summary>
+    public int NodeCount => _nodes.Count;
+
+    /// <summary>Get the number of variables that are being tracked.</summary>
+    public int VariableCount => _variableCount;
+
+    //
+    // Methods
+    //
+
+    /// <summary>Create a variable for the gradient tape to track.</summary>
+    /// <param name="seed">A seed value</param>
+    /// <returns>A variable</returns>
+    public Variable<T> CreateVariable(T seed)
+    {
+        _nodes.Add(new(_variableCount));
+        Variable<T> variable = new(_variableCount++, seed);
+        return variable;
+    }
+
+    /// <summary>Print the nodes of the gradient tape to the console.</summary>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <param name="limit">The total number of nodes to print</param>
+    public void PrintNodes(CancellationToken cancellationToken, int limit = 100)
+    {
+        const string tab = "    ";
+
+        ReadOnlySpan<HessianNode<T>> nodeSpan = CollectionsMarshal.AsSpan(_nodes);
+        HessianNode<T> node;
+
+        int i = 0;
+        while (i < Math.Min(_variableCount, limit))
+        {
+            CheckForCancellation(cancellationToken);
+            node = nodeSpan[i];
+            Console.WriteLine($"Root Node {i}:");
+            Console.WriteLine($"{tab}Weights: [[{node.DX}, {node.DXX}, {node.DXY}],");
+            Console.WriteLine($"{tab}          [{node.DY}, {node.DYY}, {node.DXY}]]");
+            Console.WriteLine($"{tab}Parents: [{node.PX}, {node.PY}]");
+            i++;
+        }
+
+        CheckForCancellation(cancellationToken);
+        Console.WriteLine();
+
+        while (i < Math.Min(nodeSpan.Length, limit))
+        {
+            CheckForCancellation(cancellationToken);
+            node = nodeSpan[i];
+            Console.WriteLine($"Node {i}:");
+            Console.WriteLine($"{tab}Weights: [[{node.DX}, {node.DXX}, {node.DXY}],");
+            Console.WriteLine($"{tab}          [{node.DY}, {node.DYY}, {node.DXY}]]");
+            Console.WriteLine($"{tab}Parents: [{node.PX}, {node.PY}]");
+            i++;
+        }
+
+        static void CheckForCancellation(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Console.WriteLine("Print node operation cancelled");
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+
+    /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting Hessian.</summary>
+    /// <param name="gradient">The gradient</param>
+    /// <param name="hessian">The Hessian</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian)
+        => ReverseAccumulation(out gradient, out hessian, T.One);
+
+    // The following method uses the edge-pushing algorithm outlined by Gower and Mello: https://arxiv.org/pdf/2007.15040.pdf.
+    // TODO: use newer variations/versions of this algorithm since they are more performant
+
+    /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting Hessian.</summary>
+    /// <param name="gradient">The gradient</param>
+    /// <param name="hessian">The Hessian</param>
+    /// <param name="seed">A seed value</param>
+    /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian, T seed)
+    {
+        if (_variableCount == 0)
+        {
+            throw new Exception("Hessian tape contains no root nodes");
+        }
+
+        ReadOnlySpan<HessianNode<T>> nodes = CollectionsMarshal.AsSpan(_nodes);
+        ref var start = ref MemoryMarshal.GetReference(nodes);
+        var length = nodes.Length;
+
+        Span<T> gradientSpan = new T[length];
+        gradientSpan[length - 1] = seed;
+
+        Span2D<T> hessianSpan = new T[length, length];
+
+        for (int i = length - 1; i >= _variableCount; i--)
+        {
+            var node = Unsafe.Add(ref start, i);
+            var gradientElement = gradientSpan[i];
+
+            EdgePush(hessianSpan, ref node, i);
+            Accumulate(hessianSpan, ref node, gradientElement);
+
+            gradientSpan[node.PX] += gradientElement * node.DX;
+            gradientSpan[node.PY] += gradientElement * node.DY;
+        }
+
+        gradient = gradientSpan[.._variableCount];
+        hessian = hessianSpan.Slice(0, 0, _variableCount, _variableCount);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void EdgePush(Span2D<T> weight, ref HessianNode<T> node, int i)
+    {
+        for (int p = 0; p <= i; p++)
+        {
+            if (weight[i, p] == 0 || weight[p, i] == 0)
+            {
+                continue;
+            }
+            if (p != i)
+            {
+                if (node.PX != p)
+                {
+                    var x = node.DX * weight[i, p];
+                    weight[node.PX, p] += x;
+                    weight[p, node.PX] += x;
+                }
+                else
+                {
+                    weight[p, p] += 2 * node.DX * weight[i, p];
+                }
+
+                if (node.PY != p)
+                {
+                    var x = node.DY * weight[i, p];
+                    weight[node.PY, p] += x;
+                    weight[p, node.PY] += x;
+                }
+                else
+                {
+                    weight[p, p] += 2 * node.DY * weight[i, p];
+                }
+            }
+            else
+            {
+                var x = weight[i, i];
+                weight[node.PX, node.PX] += node.DX * node.DX * x;
+                weight[node.PX, node.PY] += node.DX * node.DY * x;
+                weight[node.PY, node.PX] += node.DY * node.DX * x;
+                weight[node.PY, node.PY] += node.DY * node.DY * x;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void Accumulate(Span2D<T> weight, ref HessianNode<T> node, T v)
+    {
+        weight[node.PX, node.PX] += v * node.DXX;
+        weight[node.PX, node.PY] += v * node.DXY;
+        weight[node.PY, node.PX] += v * node.DXY;
+        weight[node.PY, node.PY] += v * node.DYY;
+    }
+
+    //
+    // Basic operations
+    //
+
+    /// <inheritdoc cref="GradientTape{T}.Add(Variable{T}, Variable{T})"/>
+    public Variable<T> Add(Variable<T> x, Variable<T> y)
+    {
+        _nodes.Add(new(T.One, T.Zero, T.Zero, T.One, T.Zero, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value + y.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Add(T, Variable{T})"/>
+    public Variable<T> Add(T c, Variable<T> x)
+    {
+        _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c + x.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Add(Variable{T}, T)"/>
+    public Variable<T> Add(Variable<T> x, T c)
+    {
+        _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value + c);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Divide(Variable{T}, Variable{T})"/>
+    public Variable<T> Divide(Variable<T> x, Variable<T> y)
+    {
+        var n = T.One / y.Value;
+        var dfxy = -n * n;
+        _nodes.Add(new(n, T.Zero, dfxy, x.Value * dfxy, -2.0 * n * x.Value * dfxy, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value * n);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Divide(T, Variable{T})"/>
+    public Variable<T> Divide(T c, Variable<T> x)
+    {
+        var n = T.One / x.Value;
+        var dfxy = -n * n;
+        _nodes.Add(new(c * dfxy, -2.0 * n * c * dfxy, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c * n);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Divide(Variable{T}, T)"/>
+    public Variable<T> Divide(Variable<T> x, T c)
+    {
+        var n = T.One / c;
+        _nodes.Add(new(n, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value * n);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Modulo(Variable{Real}, Variable{Real})"/>
+    public Variable<Real> Modulo(Variable<Real> x, Variable<Real> y)
+    {
+        _nodes.Add(new(T.One, T.Zero, T.Zero, x.Value * Real.Floor(x.Value / y.Value), T.Zero, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value % y.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Modulo(Real, Variable{Real})"/>
+    public Variable<Real> Modulo(Real c, Variable<Real> x)
+    {
+        _nodes.Add(new(c.Value * Real.Floor(c.Value / x.Value), T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c % x.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Modulo(Variable{Real}, Real)"/>
+    public Variable<Real> Modulo(Variable<Real> x, Real c)
+    {
+        _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value % c);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Multiply(Variable{T}, Variable{T})"/>
+    public Variable<T> Multiply(Variable<T> x, Variable<T> y)
+    {
+        _nodes.Add(new(y.Value, T.Zero, T.One, x.Value, T.Zero, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value * y.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Multiply(T, Variable{T})"/>
+    public Variable<T> Multiply(T c, Variable<T> x)
+    {
+        _nodes.Add(new(c, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c * x.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Multiply(Variable{T}, T)"/>
+    public Variable<T> Multiply(Variable<T> x, T c)
+    {
+        _nodes.Add(new(c, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value * c);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Subtract(Variable{T}, Variable{T})"/>
+    public Variable<T> Subtract(Variable<T> x, Variable<T> y)
+    {
+        _nodes.Add(new(T.One, T.Zero, T.Zero, -T.One, T.Zero, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value - y.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Subtract(T, Variable{T})"/>
+    public Variable<T> Subtract(T c, Variable<T> x)
+    {
+        _nodes.Add(new(-T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c - x.Value);
+    }
+
+    /// <inheritdoc cref="GradientTape{T}.Subtract(Variable{T}, T)"/>
+    public Variable<T> Subtract(Variable<T> x, T c)
+    {
+        _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value - c);
+    }
+
+    //
+    // Other operations
+    //
+
+    /// <inheritdoc cref="GradientTape{T}.Negate(Variable{T})"/>
+    public Variable<T> Negate(Variable<T> x)
+    {
+        _nodes.Add(new(-T.One, T.Zero, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, -x.Value);
+    }
+
+    // Exponential functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp(T)"/>
+    public Variable<T> Exp(Variable<T> x)
+    {
+        var exp = T.Exp(x.Value);
+        _nodes.Add(new(exp, exp, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp2(T)"/>
+    public Variable<T> Exp2(Variable<T> x)
+    {
+        var exp2 = T.Exp(x.Value);
+        var df = Real.Ln2 * exp2;
+        _nodes.Add(new(df, Real.Ln2 * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp2);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp10(T)"/>
+    public Variable<T> Exp10(Variable<T> x)
+    {
+        var exp10 = T.Exp(x.Value);
+        var df = Real.Ln10 * exp10;
+        _nodes.Add(new(df, Real.Ln10 * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp10);
+    }
+
+    // Hyperbolic functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acosh(T)"/>
+    public Variable<T> Acosh(Variable<T> x)
+    {
+        var u = x.Value - T.One;
+        var v = x.Value + T.One;
+        _nodes.Add(new(T.One / (T.Sqrt(u) * T.Sqrt(v)), -x.Value * T.Pow(u, -1.5) * T.Pow(v, -1.5), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Acosh(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asinh(T)"/>
+    public Variable<T> Asinh(Variable<T> x)
+    {
+        var u = T.One + x.Value * x.Value;
+        _nodes.Add(new(T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Asinh(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atanh(T)"/>
+    public Variable<T> Atanh(Variable<T> x)
+    {
+        var df = T.One / (T.One - x.Value * x.Value);
+        _nodes.Add(new(df, 2.0 * df * x.Value * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Atanh(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cosh(T)"/>
+    public Variable<T> Cosh(Variable<T> x)
+    {
+        var cosh = T.Cosh(x.Value);
+        _nodes.Add(new(T.Sinh(x.Value), cosh, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, cosh);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sinh(T)"/>
+    public Variable<T> Sinh(Variable<T> x)
+    {
+        var sinh = T.Sinh(x.Value);
+        _nodes.Add(new(T.Cosh(x.Value), sinh, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, sinh);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tanh(T)"/>
+    public Variable<T> Tanh(Variable<T> x)
+    {
+        var tanh = T.Tanh(x.Value);
+        var u = T.One / T.Cosh(x.Value);
+        var df = u * u;
+        _nodes.Add(new(df, -2.0 * df * tanh, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, tanh);
+    }
+
+    // Logarithmic functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Ln(T)"/>
+    public Variable<T> Ln(Variable<T> x)
+    {
+        var df = T.One / x.Value;
+        _nodes.Add(new(df, -df * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Ln(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log(T, T)"/>
+    public Variable<T> Log(Variable<T> x, Variable<T> b)
+    {
+        var lnx = T.Ln(x.Value);
+        var lnb = T.Ln(b.Value);
+        var dfx = T.One / (lnb * x.Value);
+        var dfb = -lnx / (lnb * lnb * b.Value);
+        _nodes.Add(new(dfx, -dfx / x.Value, -dfx / (lnb * b.Value), dfb, -dfb * (2.0 / lnb + T.One) / b.Value, x._index, b._index));
+        return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log2(T)"/>
+    public Variable<T> Log2(Variable<T> x)
+    {
+        var u = T.One / x.Value;
+        var df = u / Real.Ln2;
+        _nodes.Add(new(df, -u * u / Real.Ln2, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Log2(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log10(T)"/>
+    public Variable<T> Log10(Variable<T> x)
+    {
+        var u = T.One / x.Value;
+        var df = u / Real.Ln10;
+        _nodes.Add(new(df, -u * u / Real.Ln10, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Log10(x.Value));
+    }
+
+    // Power functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
+    public Variable<T> Pow(Variable<T> x, Variable<T> n)
+    {
+        var pow = T.Pow(x.Value, n.Value);
+        var lnx = T.Ln(x.Value);
+        var pownmo = T.Pow(x.Value, n.Value - T.One);
+        var dfn = lnx * pow;
+        _nodes.Add(new(
+            n.Value * pownmo,
+            (n.Value - T.One) * n.Value * T.Pow(x.Value, n.Value - 2.0),
+            (T.One + lnx * n.Value) * pownmo,
+            dfn,
+            lnx * dfn,
+            x._index,
+            n._index));
+        return new(_nodes.Count - 1, pow);
+    }
+
+    // Root functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cbrt(T)"/>
+    public Variable<T> Cbrt(Variable<T> x)
+    {
+        var cbrt = T.Cbrt(x.Value);
+        var df = T.One / (3.0 * cbrt * cbrt);
+        _nodes.Add(new(df, -2.0 * df / (3.0 * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, cbrt);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Root(T, T)"/>
+    public Variable<T> Root(Variable<T> x, Variable<T> n)
+    {
+        var root = T.Root(x.Value, n.Value);
+        var lnx = T.Ln(x.Value);
+        var u = T.One / n.Value;
+        var v = T.One / x.Value;
+        var w = u * u;
+        var dfx = u * v * root;
+        var dfn = -lnx * root * w;
+        _nodes.Add(new(
+            dfx,
+            (n.Value - T.One) * v * root,
+            -(dfx * u + lnx * w),
+            dfn,
+            -(2.0 * u + lnx * w) * dfn,
+            x._index,
+            n._index));
+        return new(_nodes.Count - 1, root);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sqrt(T)"/>
+    public Variable<T> Sqrt(Variable<T> x)
+    {
+        var sqrt = T.Sqrt(x.Value);
+        var df = 0.5 / sqrt;
+        _nodes.Add(new(df, -0.5 / x.Value * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, sqrt);
+    }
+
+    // Trigonometric functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cos(T)"/>
+    public Variable<T> Cos(Variable<T> x)
+    {
+        var cos = T.Cos(x.Value);
+        _nodes.Add(new(-T.Sin(x.Value), -cos, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, cos);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acos(T)"/>
+    public Variable<T> Acos(Variable<T> x)
+    {
+        var u = T.One - x.Value * x.Value;
+        _nodes.Add(new(-T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Acos(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asin(T)"/>
+    public Variable<T> Asin(Variable<T> x)
+    {
+        var u = T.One - x.Value * x.Value;
+        _nodes.Add(new(T.One / T.Sqrt(u), x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Asin(x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atan(T)"/>
+    public Variable<T> Atan(Variable<T> x)
+    {
+        var df = T.One / (T.One + x.Value * x.Value);
+        _nodes.Add(new(df, -2.0 * df * x.Value * df, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Asin(x.Value));
+    }
+
+    /// <inheritdoc cref="IReal{T}.Atan2(T, T)"/>
+    public Variable<Real> Atan2(Variable<Real> y, Variable<Real> x)
+    {
+        var u = y.Value * y.Value;
+        var v = x.Value * x.Value;
+        var a = T.One / (u + v);
+        var b = a * a;
+        var dfyy = -2.0 * x.Value * b * y.Value;
+        _nodes.Add(new(
+            x.Value * a,
+            dfyy,
+            (u - v) * b,
+            -y.Value * a,
+            -dfyy,
+            y._index,
+            x._index));
+        return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sin(T)"/>
+    public Variable<T> Sin(Variable<T> x)
+    {
+        var sin = T.Sin(x.Value);
+        _nodes.Add(new(T.Cos(x.Value), -sin, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, sin);
+    }
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tan(T)"/>
+    public Variable<T> Tan(Variable<T> x)
+    {
+        var tan = T.Tan(x.Value);
+        var sec = T.One / T.Cos(x.Value);
+        var df = sec * sec;
+        _nodes.Add(new(df, 2.0 * df * tan, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, tan);
+    }
+
+    //
+    // Custom operations
+    //
+
+    /// <summary>Add a node to the Hessian tape using a custom unary operation.</summary>
+    /// <param name="x">A variable</param>
+    /// <param name="f">A function</param>
+    /// <param name="df">The derivative of the function</param>
+    /// <param name="dfxx">The second derivative of the function</param>
+    /// <returns>A variable</returns>
+    public Variable<T> CustomOperation(Variable<T> x, Func<T, T> f, Func<T, T> dfx, Func<T, T> dfxx)
+    {
+        _nodes.Add(new(dfx(x.Value), dfxx(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, f(x.Value));
+    }
+
+    /// <summary>Add a node to the Hessian tape using a custom binary operation.</summary>
+    /// <param name="x">The first variable</param>
+    /// <param name="y">The second variable</param>
+    /// <param name="f">A function</param>
+    /// <param name="dfx">The first derivative of the function with respect to the first variable</param>
+    /// <param name="dfxx">The second derivative of the function with respect to the first variable</param>
+    /// <param name="dfxy">The second derivative of the function with respect to both variables</param>
+    /// <param name="dfy">The first derivative of the function with respect to the second variable</param>
+    /// <param name="dfyy">The second derivative of the function with respect to the second variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> CustomOperation(
+        Variable<T> x,
+        Variable<T> y,
+        Func<T, T, T> f,
+        Func<T, T, T> dfx,
+        Func<T, T, T> dfxx,
+        Func<T, T, T> dfxy,
+        Func<T, T, T> dfy,
+        Func<T, T, T> dfyy)
+    {
+        _nodes.Add(new(dfx(x.Value, y.Value), dfxx(x.Value, y.Value), dfxy(x.Value, y.Value), dfy(x.Value, y.Value), dfyy(x.Value, y.Value), x._index, y._index));
+        return new(_nodes.Count - 1, f(x.Value, y.Value));
+    }
+}

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -348,7 +348,7 @@ public record class HessianTape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp2(T)"/>
     public Variable<T> Exp2(Variable<T> x)
     {
-        var exp2 = T.Exp(x.Value);
+        var exp2 = T.Exp2(x.Value);
         var df = Real.Ln2 * exp2;
         _nodes.Add(new(df, Real.Ln2 * df, x._index, _nodes.Count));
         return new(_nodes.Count - 1, exp2);
@@ -357,7 +357,7 @@ public record class HessianTape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp10(T)"/>
     public Variable<T> Exp10(Variable<T> x)
     {
-        var exp10 = T.Exp(x.Value);
+        var exp10 = T.Exp10(x.Value);
         var df = Real.Ln10 * exp10;
         _nodes.Add(new(df, Real.Ln10 * df, x._index, _nodes.Count));
         return new(_nodes.Count - 1, exp10);
@@ -493,15 +493,15 @@ public record class HessianTape<T>
         var lnx = T.Ln(x.Value);
         var u = T.One / n.Value;
         var v = T.One / x.Value;
-        var w = u * u;
+        var uu = u * u;
         var dfx = u * v * root;
-        var dfn = -lnx * root * w;
+        var dfn = -lnx * root * uu;
         _nodes.Add(new(
             dfx,
-            (n.Value - T.One) * v * root,
-            -(dfx * u + lnx * w),
+            (uu - u) * root * v * v,
+            -root * (lnx * u + T.One) * v * uu,
             dfn,
-            -(2.0 * u + lnx * w) * dfn,
+            -(2.0 * u + lnx * uu) * dfn,
             x._index,
             n._index));
         return new(_nodes.Count - 1, root);
@@ -555,7 +555,7 @@ public record class HessianTape<T>
     {
         var u = y.Value * y.Value;
         var v = x.Value * x.Value;
-        var a = T.One / (u + v);
+        var a = Real.One / (u + v);
         var b = a * a;
         var dfyy = -2.0 * x.Value * b * y.Value;
         _nodes.Add(new(

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -185,6 +185,7 @@ public record class HessianTape<T> : ITape<T>
 
     // The following method uses the edge-pushing algorithm outlined by Gower and Mello: https://arxiv.org/pdf/2007.15040.pdf.
     // TODO: use newer variations/versions of this algorithm since they are more performant
+    // TODO: consider creating an overload that computes only the diagonal components of Hessians
 
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting gradient and Hessian.</summary>
     /// <param name="gradient">The gradient</param>

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -1,0 +1,248 @@
+﻿// <copyright file="ITape.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Defines support for tapes used in reverse-mode automatic differentiation</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+public interface ITape<T>
+    where T : IComplex<T>, IDifferentiableFunctions<T>
+{
+    /// <summary>Get the number of nodes on the gradient tape.</summary>
+    public int NodeCount { get; }
+
+    /// <summary>Get the number of variables that are being tracked.</summary>
+    public int VariableCount { get; }
+
+    /// <summary>Create a variable for the gradient tape to track.</summary>
+    /// <param name="seed">A seed value</param>
+    /// <returns>A variable</returns>
+    public Variable<T> CreateVariable(T seed);
+
+    /// <summary>Print the nodes of the gradient tape to the console.</summary>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <param name="limit">The total number of nodes to print</param>
+    public void PrintNodes(CancellationToken cancellationToken, int limit = 100);
+
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
+    /// <param name="gradient">The gradient</param>
+    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient);
+
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
+    /// <param name="gradient">The gradient</param>
+    /// <param name="seed">A seed value</param>
+    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient, T seed);
+
+    //
+    // Basic operations
+    //
+
+    /// <summary>Add two variables</summary>
+    /// <param name="x">The first variable</param>
+    /// <param name="y">The second variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Add(Variable<T> x, Variable<T> y);
+
+    /// <summary>Add a constant value and a variable</summary>
+    /// <param name="c">A constant value</param>
+    /// <param name="x">A variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Add(T c, Variable<T> x);
+
+    /// <summary>Add a variable and a constant value</summary>
+    /// <param name="x">A variable</param>
+    /// <param name="c">A constant value</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Add(Variable<T> x, T c);
+
+    /// <summary>Divide two variables</summary>
+    /// <param name="x">A dividend</param>
+    /// <param name="y">A divisor</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Divide(Variable<T> x, Variable<T> y);
+
+    /// <summary>Divide a constant value by a variable</summary>
+    /// <param name="c">A constant dividend</param>
+    /// <param name="x">A variable divisor</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Divide(T c, Variable<T> x);
+
+    /// <summary>Divide a variable by a constant value</summary>
+    /// <param name="x">A variable dividend</param>
+    /// <param name="c">A constant divisor</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Divide(Variable<T> x, T c);
+
+    /// <summary>Compute the modulo of a variable given a divisor</summary>
+    /// <param name="x">A dividend</param>
+    /// <param name="y">A divisor</param>
+    /// <returns><paramref name="x"/> mod <paramref name="y"/></returns>
+    public Variable<Real> Modulo(Variable<Real> x, Variable<Real> y);
+
+    /// <summary>Compute the modulo of a real value given a divisor</summary>
+    /// <param name="c">A real dividend</param>
+    /// <param name="x">A variable divisor</param>
+    /// <returns><paramref name="c"/> mod <paramref name="x"/></returns>
+    public Variable<Real> Modulo(Real c, Variable<Real> x);
+
+    /// <summary>Compute the modulo of a variable given a divisor</summary>
+    /// <param name="x">A variable dividend</param>
+    /// <param name="c">A real divisor</param>
+    /// <returns><paramref name="x"/> mod <paramref name="c"/></returns>
+    public Variable<Real> Modulo(Variable<Real> x, Real c);
+
+    /// <summary>Multiply two variables</summary>
+    /// <param name="x">The first variable</param>
+    /// <param name="y">The second variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Multiply(Variable<T> x, Variable<T> y);
+
+    /// <summary>Multiply a constant value by a variable</summary>
+    /// <param name="c">A constant value</param>
+    /// <param name="x">A variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Multiply(T c, Variable<T> x);
+
+    /// <summary>Multiply a variable by a constant value</summary>
+    /// <param name="x">A variable</param>
+    /// <param name="c">A constant value</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Multiply(Variable<T> x, T c);
+
+    /// <summary>Subract two variables</summary>
+    /// <param name="x">The first variable</param>
+    /// <param name="y">The second variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Subtract(Variable<T> x, Variable<T> y);
+
+    /// <summary>Subtract a variable from a constant value</summary>
+    /// <param name="c">A constant value</param>
+    /// <param name="x">A variable</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Subtract(T c, Variable<T> x);
+
+    /// <summary>Subtract a constant value from a variable</summary>
+    /// <param name="x">A variable</param>
+    /// <param name="c">A constant value</param>
+    /// <returns>A variable</returns>
+    public Variable<T> Subtract(Variable<T> x, T c);
+
+    //
+    // Other operations
+    //
+
+    /// <summary>Negate a variable</summary>
+    /// <param name="x">A variable</param>
+    /// <returns>Minus one times the variable</returns>
+    public Variable<T> Negate(Variable<T> x);
+
+    // Exponential functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp(T)"/>
+    public Variable<T> Exp(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp2(T)"/>
+    public Variable<T> Exp2(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp10(T)"/>
+    public Variable<T> Exp10(Variable<T> x);
+
+    // Hyperbolic functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acosh(T)"/>
+    public Variable<T> Acosh(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asinh(T)"/>
+    public Variable<T> Asinh(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atanh(T)"/>
+    public Variable<T> Atanh(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cosh(T)"/>
+    public Variable<T> Cosh(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sinh(T)"/>
+    public Variable<T> Sinh(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tanh(T)"/>
+    public Variable<T> Tanh(Variable<T> x);
+
+    // Logarithmic functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Ln(T)"/>
+    public Variable<T> Ln(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log(T, T)"/>
+    public Variable<T> Log(Variable<T> x, Variable<T> b);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log2(T)"/>
+    public Variable<T> Log2(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Log10(T)"/>
+    public Variable<T> Log10(Variable<T> x);
+
+    // Power functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
+    public Variable<T> Pow(Variable<T> x, Variable<T> y);
+
+    // Root functions
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cbrt(T)"/>
+    public Variable<T> Cbrt(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Root(T, T)"/>
+    public Variable<T> Root(Variable<T> x, Variable<T> n);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sqrt(T)"/>
+    public Variable<T> Sqrt(Variable<T> x);
+
+    // Trigonometric function
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Acos(T)"/>
+    public Variable<T> Acos(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Asin(T)"/>
+    public Variable<T> Asin(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Atan(T)"/>
+    public Variable<T> Atan(Variable<T> x);
+
+    /// <inheritdoc cref="IReal{T}.Atan2(T, T)"/>
+    public Variable<Real> Atan2(Variable<Real> y, Variable<Real> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Cos(T)"/>
+    public Variable<T> Cos(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Sin(T)"/>
+    public Variable<T> Sin(Variable<T> x);
+
+    /// <inheritdoc cref="IDifferentiableFunctions{T}.Tan(T)"/>
+    public Variable<T> Tan(Variable<T> x);
+}

--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -93,6 +93,20 @@ public static class LinAlgExtensions
         return string.Format(provider, builder.ToString());
     }
 
+    /// <summary>Get the string representation of this <see cref="ReadOnlySpan2D{T}"/></summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+    /// <param name="readOnlySpan2D">A 2D read-only span to format</param>
+    /// <param name="format">The format to use</param>
+    /// <param name="provider">The provider to use to format the value</param>
+    /// <returns>A string representation of this object</returns>
+    public static string ToDisplayString<T>(this ReadOnlySpan2D<T> readOnlySpan2D, string? format = null, IFormatProvider? provider = null)
+        where T : IComplex<T>
+    {
+        Span2D<T> span = new T[readOnlySpan2D.Width, readOnlySpan2D.Height];
+        readOnlySpan2D.CopyTo(span);
+        return span.ToDisplayString(format, provider);
+    }
+
     /// <summary>Get the string representation of this <see cref="Span2D{T}"/> object</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
     /// <param name="span">The span to format</param>

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -7,10 +7,10 @@
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
     <Title>Mathematics.NET</Title>
-    <Version>0.1.0-alpha.7</Version>
+    <Version>0.1.0-alpha.8</Version>
     <PackageIcon>mathematics.net.png</PackageIcon>
     <Authors>Hamlet Tanyavong</Authors>
-    <Description>Mathematics.NET is a C# class library that provides tools for solving mathematical problems.</Description>
+    <Description>Mathematics.NET is a C# class library that provides tools for solving mathematical problems. Included are custom types for real, complex, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors. The library also contains methods for performing forward and reverse-mode automatic differentiation.</Description>
     <PackageTags>autodiff; complex; math; mathematics; physics; rational; tensors;</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <IncludeSymbols>True</IncludeSymbols>

--- a/tests/Mathematics.NET.Tests/AutoDiff/DualVector3OfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/DualVector3OfRealTests.cs
@@ -133,15 +133,15 @@ public sealed class DualVector3OfRealTests
     // Helpers
     //
 
-    public static Dual<Real> F(DualVector3<Real> x)
+    private static Dual<Real> F(DualVector3<Real> x)
         => Cos(x.X1) / ((x.X1 + x.X2) * Sin(x.X3));
 
-    public static Dual<Real> FX(DualVector3<Real> x)
+    private static Dual<Real> FX(DualVector3<Real> x)
         => Sin(x.X1) * (Cos(x.X2) + Sqrt(x.X3));
 
-    public static Dual<Real> FY(DualVector3<Real> x)
+    private static Dual<Real> FY(DualVector3<Real> x)
         => Sqrt(x.X1 + x.X2 + x.X3);
 
-    public static Dual<Real> FZ(DualVector3<Real> x)
+    private static Dual<Real> FZ(DualVector3<Real> x)
         => Sinh(Exp(x.X1) * x.X2 / x.X3);
 }

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
@@ -140,7 +140,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     //
 
     // f(x, y, z) = Cos(x) / ((x + y) * Sin(z))
-    private static Variable<Real> F(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> F(ITape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Divide(
             tape.Cos(x.X1),
@@ -150,7 +150,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sin(x) * (Cos(y) + Sqrt(z))
-    private static Variable<Real> FX(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FX(ITape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Multiply(
             tape.Sin(x.X1),
@@ -160,7 +160,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sqrt(x + y + z)
-    private static Variable<Real> FY(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FY(ITape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Sqrt(
             tape.Add(
@@ -171,7 +171,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sinh(Exp(x) * y / z)
-    private static Variable<Real> FZ(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FZ(ITape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Sinh(
             tape.Multiply(

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
@@ -140,7 +140,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     //
 
     // f(x, y, z) = Cos(x) / ((x + y) * Sin(z))
-    public static Variable<Real> F(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> F(GradientTape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Divide(
             tape.Cos(x.X1),
@@ -150,7 +150,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sin(x) * (Cos(y) + Sqrt(z))
-    public static Variable<Real> FX(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FX(GradientTape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Multiply(
             tape.Sin(x.X1),
@@ -160,7 +160,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sqrt(x + y + z)
-    public static Variable<Real> FY(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FY(GradientTape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Sqrt(
             tape.Add(
@@ -171,7 +171,7 @@ public sealed class GradientTapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sinh(Exp(x) * y / z)
-    public static Variable<Real> FZ(GradientTape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FZ(GradientTape<Real> tape, VariableVector3<Real> x)
     {
         return tape.Sinh(
             tape.Multiply(

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeExtensionsOfRealTests.cs
@@ -123,6 +123,19 @@ public sealed class GradientTapeExtensionsOfRealTests
 
     [TestMethod]
     [TestCategory("Vector Calculus")]
+    [DataRow(1.23, 0.66, 2.34, 1.471507039061705)]
+    public void Laplacian_ScalarFunction_ReturnsLaplacian(double x, double y, double z, double expected)
+    {
+        HessianTape<Real> tape = new();
+        var u = tape.CreateVariableVector(x, y, z);
+
+        var actual = tape.Laplacian(F, u);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [TestCategory("Vector Calculus")]
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -1.919813065970865, -3.508528536106042, 1.512286126049506)]
     public void VJP_VectorAndR3VectorFunction_ReturnsVJP(double vx, double vy, double vz, double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
@@ -65,13 +65,13 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 1, 1)]
-    public void Add_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Add_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Add, left, right);
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
@@ -80,11 +80,11 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Add(left, x);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
@@ -93,11 +93,11 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Add(x, right);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
@@ -129,7 +129,7 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 0.334835801674179, -0.1760034342133505)]
-    public void Atan2_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Atan2_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -200,13 +200,13 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
-    [DataRow(1.23, 2.34, -0.1760034342133505, 0.334835801674179)]
+    [DataRow(1.23, 2.34, 0.334835801674179, -0.1760034342133505)]
     public void CustomOperation_Binary_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         var y = _tape.CreateVariable(left);
         var x = _tape.CreateVariable(right);
         var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
-        _ = _tape.CustomOperation(x, y, Real.Atan2, (x, y) => x.Value * u, (x, y) => -y.Value * u);
+        _ = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x.Value * u, (y, x) => -y.Value * u);
         _tape.ReverseAccumulation(out var actual);
 
         Real[] expected = [expectedLeft, expectedRight];
@@ -220,16 +220,16 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(input);
         _ = _tape.CustomOperation(x, Real.Sin, Real.Cos);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
     [DataRow(1.23, 2.34, 0.4273504273504274, -0.2246329169406093)]
-    public void Divide_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Divide_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -244,9 +244,9 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Divide(left, x);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -257,9 +257,9 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Divide(x, right);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -302,7 +302,7 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 0.9563103467806, -0.1224030239537303)]
-    public void Log_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Log_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -331,13 +331,13 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 1, 0)]
-    public void Modulo_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Modulo_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Modulo, left, right);
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
@@ -346,11 +346,11 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Modulo(left, x);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
@@ -363,12 +363,12 @@ public sealed class GradientTapeOfRealTests
 
         var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
     [DataRow(1.23, 2.34, 2.34, 1.23)]
-    public void Multiply_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Multiply_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -383,9 +383,9 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Multiply(left, x);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
@@ -396,9 +396,9 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Multiply(x, right);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
@@ -407,18 +407,14 @@ public sealed class GradientTapeOfRealTests
     [DataRow(1.23, -1)]
     public void Negate_Variable_ReturnsNegation(double input, double expected)
     {
-        var x = _tape.CreateVariable(input);
-        _ = _tape.Negate(x);
-        _tape.ReverseAccumulation(out var gradients);
+        var actual = ComputeGradient(_tape.Negate, input);
 
-        var actual = gradients[0];
-
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
     [DataRow(1.23, 2.34, 3.088081166620949, 0.3360299854573856)]
-    public void Pow_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Pow_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -429,7 +425,7 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 0.3795771135606888, -0.04130373687338086)]
-    public void Root_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Root_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
@@ -467,39 +463,39 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 2.34, 1, -1)]
-    public void Subtract_TwoVariables_ReturnsGradients(double left, double right, double expectedLeft, double expectedRight)
+    public void Subtract_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Subtract, left, right);
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
     [DataRow(1.23, 2.34, -1)]
-    public void Subtract_ConstantAndVariable_ReturnsGradients(double left, double right, double expected)
+    public void Subtract_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Subtract(left, x);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]
     [DataRow(1.23, 2.34, 1)]
-    public void Subtract_VariableAndConstant_ReturnsGradients(double left, double right, double expected)
+    public void Subtract_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Subtract(x, right);
-        _tape.ReverseAccumulation(out var gradients);
+        _tape.ReverseAccumulation(out var gradient);
 
-        var actual = gradients[0];
+        var actual = gradient[0];
 
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
 
     [TestMethod]

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
@@ -69,7 +69,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Add, left, right);
+        var actual = ComputeGradient(_tape.Add, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
@@ -133,7 +133,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Atan2, left, right);
+        var actual = ComputeGradient(_tape.Atan2, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -233,7 +233,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Divide, left, right);
+        var actual = ComputeGradient(_tape.Divide, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -306,7 +306,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Log, left, right);
+        var actual = ComputeGradient(_tape.Log, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -335,7 +335,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Modulo, left, right);
+        var actual = ComputeGradient(_tape.Modulo, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -372,7 +372,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Multiply, left, right);
+        var actual = ComputeGradient(_tape.Multiply, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
@@ -422,7 +422,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Pow, left, right);
+        var actual = ComputeGradient(_tape.Pow, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -433,7 +433,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Root, left, right);
+        var actual = ComputeGradient(_tape.Root, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -471,7 +471,7 @@ public sealed class GradientTapeOfRealTests
     {
         Real[] expected = [expectedLeft, expectedRight];
 
-        var actual = ComputeGradients(_tape.Subtract, left, right);
+        var actual = ComputeGradient(_tape.Subtract, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
@@ -528,16 +528,16 @@ public sealed class GradientTapeOfRealTests
     {
         var x = _tape.CreateVariable(input);
         _ = function(x);
-        _tape.ReverseAccumulation(out var gradients);
-        return gradients[0];
+        _tape.ReverseAccumulation(out var gradient);
+        return gradient[0];
     }
 
-    private Real[] ComputeGradients(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
+    private Real[] ComputeGradient(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
     {
         var x = _tape.CreateVariable(left);
         var y = _tape.CreateVariable(right);
         _ = function(x, y);
-        _tape.ReverseAccumulation(out var gradients);
-        return gradients.ToArray();
+        _tape.ReverseAccumulation(out var gradient);
+        return gradient.ToArray();
     }
 }

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
@@ -405,7 +405,7 @@ public sealed class GradientTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, -1)]
-    public void Negate_Variable_ReturnsNegation(double input, double expected)
+    public void Negate_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Negate, input);
 

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -46,10 +46,28 @@ public sealed class HessianTapeOfRealTests
     //
 
     [TestMethod]
+    [DataRow(0.123, -1.007651429146436)]
+    public void Acos_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Acos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(0.123, -0.125845035324435)]
     public void Acos_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Acos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.396315794095838)]
+    public void Acosh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Acosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -64,12 +82,36 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1, 1)]
+    public void Add_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Add, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0, 0, 0)]
     public void Add_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Add, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 1)]
+    public void Add_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Add(left, x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -88,6 +130,19 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1)]
+    public void Add_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Add(x, right);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0)]
     public void Add_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
     {
@@ -101,10 +156,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(0.123, 1.007651429146436)]
+    public void Asin_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Asin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(0.123, 0.125845035324435)]
     public void Asin_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Asin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.6308300845448597)]
+    public void Asinh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Asinh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -119,10 +192,30 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.3979465955668749)]
+    public void Atan_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Atan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.3895692725912341)]
     public void Atan_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Atan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.334835801674179, -0.1760034342133505)]
+    public void Atan2_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Atan2, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -139,10 +232,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, -1.94969779684149)]
+    public void Atanh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Atanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 9.35125088756106)]
     public void Atanh_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Atanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.2903634877210767)]
+    public void Cbrt_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Cbrt, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -157,10 +268,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, -0.942488801931697)]
+    public void Cos_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Cos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.3342377271245026)]
     public void Cos_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Cos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.564468479304407)]
+    public void Cosh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Cosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -200,6 +329,31 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.334835801674179, -0.1760034342133505)]
+    public void CustomOperation_Binary_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        var y = _tape.CreateVariable(left);
+        var x = _tape.CreateVariable(right);
+        var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
+
+        _ = _tape.CustomOperation(
+            y,
+            x,
+            Real.Atan2,
+            (y, x) => x.Value * u,
+            (y, x) => Real.Zero, // Not of interest
+            (y, x) => Real.Zero, // Not of interest
+            (y, x) => -y.Value * u,
+            (y, x) => Real.Zero); // Not of interest
+
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> actual);
+
+        Real[] expected = [expectedLeft, expectedRight];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, -0.1178645019844717, -0.081137805227897, 0.1178645019844717)]
     public void CustomOperation_Binary_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
@@ -232,6 +386,23 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.3342377271245026)]
+    public void CustomOperation_Unary_ReturnsGradient(double input, double expected)
+    {
+        var x = _tape.CreateVariable(input);
+        _ = _tape.CustomOperation(
+            x,
+            Real.Sin,
+            Real.Cos,
+            x => Real.Zero); // Not of interest
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.942488801931697)]
     public void CustomOperation_Unary_ReturnsHessian(double input, double expected)
     {
@@ -240,6 +411,17 @@ public sealed class HessianTapeOfRealTests
         _tape.ReverseAccumulation(out var _, out var hessian);
 
         var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.4273504273504274, -0.2246329169406093)]
+    public void Divide_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Divide, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -256,6 +438,19 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, -0.2246329169406093)]
+    public void Divide_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Divide(left, x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.1919939461030848)]
     public void Divide_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
     {
@@ -264,6 +459,19 @@ public sealed class HessianTapeOfRealTests
         _tape.ReverseAccumulation(out var _, out var hessian);
 
         var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.4273504273504274)]
+    public void Divide_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Divide(x, right);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -283,9 +491,27 @@ public sealed class HessianTapeOfRealTests
 
     [TestMethod]
     [DataRow(1.23, 3.421229536289673)]
+    public void Exp_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Exp, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 3.421229536289673)]
     public void Exp_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Exp, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.625894476644487)]
+    public void Exp2_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Exp2, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -300,6 +526,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 39.10350518430174)]
+    public void Exp10_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Exp10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 90.0391481211886)]
     public void Exp10_Variable_ReturnsHessian(double input, double expected)
     {
@@ -309,10 +544,30 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.813008130081301)]
+    public void Ln_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Ln, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.6609822195782934)]
     public void Ln_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Ln, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.9563103467806, -0.1224030239537303)]
+    public void Log_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Log, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -329,10 +584,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.172922797470702)]
+    public void Log2_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Log2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.953595770301384)]
     public void Log2_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Log2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.35308494463679)]
+    public void Log10_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Log10, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -347,12 +620,36 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1, 0)]
+    public void Modulo_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Modulo, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0, 0, 0)]
     public void Modulo_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Modulo, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Modulo_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Modulo(left, x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -371,6 +668,19 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1)]
+    public void Modulo_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Modulo(x, right);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0)]
     public void Modulo_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
     {
@@ -384,6 +694,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.34, 1.23)]
+    public void Multiply_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Multiply, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0, 1, 0)]
     public void Multiply_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
@@ -392,6 +713,19 @@ public sealed class HessianTapeOfRealTests
         var actual = ComputeHessian(_tape.Multiply, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 1.23)]
+    public void Multiply_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Multiply(left, x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
     }
 
     [TestMethod]
@@ -408,6 +742,19 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.34)]
+    public void Multiply_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Multiply(x, right);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0)]
     public void Multiply_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
     {
@@ -421,8 +768,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, -1)]
+    public void Negate_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Negate, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0)]
-    public void Negate_Variable_ReturnsNegation(double input, double expected)
+    public void Negate_Variable_ReturnsHessian(double input, double expected)
     {
         var x = _tape.CreateVariable(input);
 
@@ -432,12 +788,34 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 3.088081166620949, 0.3360299854573856)]
+    public void Pow_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Pow, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 3.364251027050465, 1.958969363947686, 0.06956296832768787)]
     public void Pow_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Pow, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.3795771135606888, -0.04130373687338086)]
+    public void Root_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Root, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -454,10 +832,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.3342377271245026)]
+    public void Sin_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Sin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.942488801931697)]
     public void Sin_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Sin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.856761056985266)]
+    public void Sinh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Sinh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -472,6 +868,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.4508348173337161)]
+    public void Sqrt_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Sqrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.1832661859080147)]
     public void Sqrt_Variable_ReturnsHessian(double input, double expected)
     {
@@ -481,12 +886,36 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1, -1)]
+    public void Subtract_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
+    {
+        Real[] expected = [expectedLeft, expectedRight];
+
+        var actual = ComputeGradient(_tape.Subtract, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0, 0, 0)]
     public void Subtract_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
     {
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Subtract, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -1)]
+    public void Subtract_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Subtract(left, x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -505,6 +934,19 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1)]
+    public void Subtract_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Subtract(x, right);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+
+        var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0)]
     public void Subtract_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
     {
@@ -518,10 +960,28 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 8.95136077522624)]
+    public void Tan_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Tan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 50.4823759141874)]
     public void Tan_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Tan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.2900600799721436)]
+    public void Tanh_Variable_ReturnsGradient(double input, double expected)
+    {
+        var actual = ComputeGradient(_tape.Tanh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -538,6 +998,23 @@ public sealed class HessianTapeOfRealTests
     //
     // Helpers
     //
+
+    private Real ComputeGradient(Func<Variable<Real>, Variable<Real>> function, Real input)
+    {
+        var x = _tape.CreateVariable(input);
+        _ = function(x);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+        return gradient[0];
+    }
+
+    private Real[] ComputeGradient(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
+    {
+        var x = _tape.CreateVariable(left);
+        var y = _tape.CreateVariable(right);
+        _ = function(x, y);
+        _tape.ReverseAccumulation(out ReadOnlySpan<Real> gradient);
+        return gradient.ToArray();
+    }
 
     private Real ComputeHessian(Func<Variable<Real>, Variable<Real>> function, Real input)
     {

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -122,7 +122,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Add(left, x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -148,7 +148,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Add(x, right);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -378,7 +378,7 @@ public sealed class HessianTapeOfRealTests
 
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian.ToArray();
 
@@ -408,7 +408,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(input);
         _ = _tape.CustomOperation(x, Real.Sin, Real.Cos, x => -Real.Sin(x));
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -456,7 +456,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Divide(left, x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -482,7 +482,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Divide(x, right);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -660,7 +660,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Modulo(left, x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -686,7 +686,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Modulo(x, right);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -734,7 +734,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Multiply(left, x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -760,7 +760,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Multiply(x, right);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -926,7 +926,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(right);
         _ = _tape.Subtract(left, x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 
@@ -952,7 +952,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(left);
         _ = _tape.Subtract(x, right);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
 
         var actual = hessian[0, 0];
 

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -25,6 +25,7 @@
 // SOFTWARE.
 // </copyright>
 
+using CommunityToolkit.HighPerformance;
 using Mathematics.NET.AutoDiff;
 
 namespace Mathematics.NET.Tests.AutoDiff;
@@ -542,7 +543,7 @@ public sealed class HessianTapeOfRealTests
     {
         var x = _tape.CreateVariable(input);
         _ = function(x);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
         return hessian[0, 0];
     }
 
@@ -551,7 +552,7 @@ public sealed class HessianTapeOfRealTests
         var x = _tape.CreateVariable(left);
         var y = _tape.CreateVariable(right);
         _ = function(x, y);
-        _tape.ReverseAccumulation(out var _, out var hessian);
+        _tape.ReverseAccumulation(out ReadOnlySpan2D<Real> hessian);
         return hessian.ToArray();
     }
 }

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -1,0 +1,557 @@
+﻿// <copyright file="HessianTapeOfRealTests.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.AutoDiff;
+
+namespace Mathematics.NET.Tests.AutoDiff;
+
+[TestClass]
+[TestCategory("AutoDiff"), TestCategory("Hessian Tape")]
+public sealed class HessianTapeOfRealTests
+{
+    private HessianTape<Real> _tape;
+
+    public HessianTapeOfRealTests()
+    {
+        _tape = new();
+    }
+
+    //
+    // Tests
+    //
+
+    [TestMethod]
+    [DataRow(0.123, -0.125845035324435)]
+    public void Acos_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Acos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -3.348544407755665)]
+    public void Acosh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Acosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0, 0, 0)]
+    public void Add_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Add, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Add_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Add(left, x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Add_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Add(x, right);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(0.123, 0.125845035324435)]
+    public void Asin_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Asin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.3087751219667227)]
+    public void Asinh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Asinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.3895692725912341)]
+    public void Atan_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Atan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -0.1178645019844717, -0.081137805227897, 0.1178645019844717)]
+    public void Atan2_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Atan2, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-14);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 9.35125088756106)]
+    public void Atanh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Atanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.1573785841306649)]
+    public void Cbrt_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Cbrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.3342377271245026)]
+    public void Cos_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Cos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.856761056985266)]
+    public void Cosh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Cosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    [DataRow(4)]
+    public void CreateVariable_Multiple_TracksCorrectNumberOfVariables(int amount)
+    {
+        for (int i = 0; i < amount; i++)
+        {
+            _ = _tape.CreateVariable(0);
+        }
+
+        var actual = _tape.VariableCount;
+
+        Assert.AreEqual(amount, actual);
+    }
+
+    [TestMethod]
+    [DataRow(1.23)]
+    public void CreateVariable_WithSeedValue_ReturnsVariable(double value)
+    {
+        var actual = _tape.CreateVariable(value).Value;
+
+        Assert.AreEqual(value, actual);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -0.1178645019844717, -0.081137805227897, 0.1178645019844717)]
+    public void CustomOperation_Binary_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        var y = _tape.CreateVariable(left);
+        var x = _tape.CreateVariable(right);
+
+        var u = y.Value * y.Value;
+        var v = x.Value * x.Value;
+        var a = Real.One / (u + v);
+        var b = a * a;
+        var dfyy = -2.0 * x.Value * b * y.Value;
+
+        _ = _tape.CustomOperation(
+            y,
+            x,
+            Real.Atan2,
+            (y, x) => x.Value * a,
+            (y, x) => dfyy,
+            (y, x) => (u - v) * b,
+            (y, x) => -y.Value * a,
+            (y, x) => -dfyy);
+
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian.ToArray();
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-14);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.942488801931697)]
+    public void CustomOperation_Unary_ReturnsHessian(double input, double expected)
+    {
+        var x = _tape.CreateVariable(input);
+        _ = _tape.CustomOperation(x, Real.Sin, Real.Cos, x => -Real.Sin(x));
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0, -0.1826283877565929, 0.1919939461030848)]
+    public void Divide_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Divide, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.1919939461030848)]
+    public void Divide_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Divide(left, x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Divide_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Divide(x, right);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 3.421229536289673)]
+    public void Exp_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Exp, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.126984172374114)]
+    public void Exp2_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Exp2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 90.0391481211886)]
+    public void Exp10_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Exp10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.6609822195782934)]
+    public void Ln_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Ln, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -0.7774880868134957, -0.4807142135095495, 0.1753670976636016)]
+    public void Log_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Log, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.953595770301384)]
+    public void Log2_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Log2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.2870609305990163)]
+    public void Log10_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Log10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0, 0, 0)]
+    public void Modulo_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Modulo, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Modulo_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Modulo(left, x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Modulo_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Modulo(x, right);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0, 1, 0)]
+    public void Multiply_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Multiply, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Multiply_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Multiply(left, x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Multiply_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Multiply(x, right);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0)]
+    public void Negate_Variable_ReturnsNegation(double input, double expected)
+    {
+        var x = _tape.CreateVariable(input);
+
+        var actual = ComputeHessian(_tape.Negate, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 3.364251027050465, 1.958969363947686, 0.06956296832768787)]
+    public void Pow_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Pow, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -0.1767192454212087, -0.1765629860861052, 0.03686389570982799)]
+    public void Root_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Root, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.942488801931697)]
+    public void Sin_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Sin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.564468479304407)]
+    public void Sinh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Sinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.1832661859080147)]
+    public void Sqrt_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Sqrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0, 0, 0)]
+    public void Subtract_TwoVariables_ReturnsHessian(double left, double right, double expectedXX, double expectedXY, double expectedYY)
+    {
+        Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
+
+        var actual = ComputeHessian(_tape.Subtract, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Subtract_ConstantAndVariable_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+        _ = _tape.Subtract(left, x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0)]
+    public void Subtract_VariableAndConstant_ReturnsHessian(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+        _ = _tape.Subtract(x, right);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+
+        var actual = hessian[0, 0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 50.4823759141874)]
+    public void Tan_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Tan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -0.4887972531670078)]
+    public void Tanh_Variable_ReturnsHessian(double input, double expected)
+    {
+        var actual = ComputeHessian(_tape.Tanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    //
+    // Helpers
+    //
+
+    private Real ComputeHessian(Func<Variable<Real>, Variable<Real>> function, Real input)
+    {
+        var x = _tape.CreateVariable(input);
+        _ = function(x);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+        return hessian[0, 0];
+    }
+
+    private Real[,] ComputeHessian(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
+    {
+        var x = _tape.CreateVariable(left);
+        var y = _tape.CreateVariable(right);
+        _ = function(x, y);
+        _tape.ReverseAccumulation(out var _, out var hessian);
+        return hessian.ToArray();
+    }
+}


### PR DESCRIPTION
- Add support for Hessian tapes which allow for the use of second-order, reverse-mode automatic differentiation
- Create `ITape<T>` interface which defines methods used in both `GradientTape<T>` and `HessianTape<T>`
- Add method for formatting 2D read-only spans
- Update tests
- Update documentation site
- Add method for computing Laplacians
- Various minor changes