### PR TITLE
Add autodiff vectors of lengths two and four

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,11 @@ indent_size = 2
 
 indent_size = 2
 
+### Csproj files ###
+[*.csproj]
+
+indent_size = 2
+
 ### C# ###
 [*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,117 +1,209 @@
+### Editor config for Mathematics.NET ###
+root = true
+
 ### General ###
 [*]
 
+# File header
 file_header_template = <copyright file="{fileName}" company="Mathematics.NET">\nMathematics.NET\nhttps://github.com/HamletTanyavong/Mathematics.NET\n\nMIT License\n\nCopyright (c) 2023 Hamlet Tanyavong\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n</copyright>
 
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
 indent_style = space
-trim_trailing_whitespace = true
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
 insert_final_newline = true
 
-### Json files ###
-[*.json]
+# Other
+trim_trailing_whitespace = true
 
+### Csproj, JSON, and XML Files ###
+[*.{csproj,json,xml}]
+
+# Indentation and spacing
 indent_size = 2
+tab_width = 2
 
-### Xml files ###
-[*.xml]
-
-indent_size = 2
-
-### Http files ###
-[*.http]
-
-indent_size = 2
-
-### Csproj files ###
-[*.csproj]
-
-indent_size = 2
-
-### C# ###
+### C# Files ###
 [*.cs]
 
-# Naming rules
+#### .NET Coding Conventions ####
 
-dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.severity = suggestion
-dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.symbols = private_or_internal_static_field
-dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.style = s_with_underscore
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
 
-dotnet_naming_rule.private_or_internal_field_should_be_underscore.severity = suggestion
-dotnet_naming_rule.private_or_internal_field_should_be_underscore.symbols = private_or_internal_field
-dotnet_naming_rule.private_or_internal_field_should_be_underscore.style = underscore
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
 
-# Symbol specifications
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
 
-dotnet_naming_symbols.private_or_internal_static_field.applicable_kinds = field
-dotnet_naming_symbols.private_or_internal_static_field.applicable_accessibilities = internal, private, private_protected
-dotnet_naming_symbols.private_or_internal_static_field.required_modifiers = static
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
 
-dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
-dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
-dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
 
-# Naming styles
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_collection_expression = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = false
+dotnet_style_prefer_conditional_expression_over_return = false
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
 
-dotnet_naming_style.s_with_underscore.required_prefix = s_
-dotnet_naming_style.s_with_underscore.required_suffix = 
-dotnet_naming_style.s_with_underscore.word_separator = 
-dotnet_naming_style.s_with_underscore.capitalization = camel_case
+# Field preferences
+dotnet_style_readonly_field = false
 
-dotnet_naming_style.underscore.required_prefix = _
-dotnet_naming_style.underscore.required_suffix = 
-dotnet_naming_style.underscore.word_separator = 
-dotnet_naming_style.underscore.capitalization = camel_case
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = when_on_single_line
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = when_on_single_line
+csharp_style_expression_bodied_lambdas = when_on_single_line
+csharp_style_expression_bodied_local_functions = when_on_single_line
+csharp_style_expression_bodied_methods = when_on_single_line
+csharp_style_expression_bodied_operators = when_on_single_line
+csharp_style_expression_bodied_properties = when_on_single_line
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+csharp_style_prefer_readonly_struct_member = true
+
+# Code-block preferences
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
+csharp_style_namespace_declarations = file_scoped
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_primary_constructors = true
+csharp_style_prefer_top_level_statements = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
 csharp_indent_labels = one_less_than_current
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_prefer_braces = true:silent
-csharp_style_namespace_declarations = file_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_expression_bodied_methods = when_on_single_line:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = when_on_single_line:silent
-csharp_style_expression_bodied_properties = when_on_single_line:silent
-csharp_style_expression_bodied_indexers = when_on_single_line:silent
-csharp_style_expression_bodied_accessors = when_on_single_line:silent
-csharp_style_expression_bodied_lambdas = when_on_single_line:silent
-csharp_style_expression_bodied_local_functions = when_on_single_line:silent
-csharp_style_throw_expression = true:suggestion
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_space_around_binary_operators = before_and_after
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
-csharp_style_prefer_readonly_struct_member = true:suggestion
-csharp_style_prefer_readonly_struct = true:suggestion
-csharp_prefer_static_local_function = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:silent
-csharp_style_prefer_primary_constructors = true:suggestion
-csharp_style_prefer_extended_property_pattern = true:suggestion
-csharp_style_prefer_not_pattern = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_prefer_pattern_matching = true:silent
-csharp_style_prefer_switch_expression = true:suggestion
-csharp_style_var_elsewhere = false:silent
-csharp_style_var_when_type_is_apparent = false:silent
-csharp_style_var_for_built_in_types = false:silent
+csharp_indent_switch_labels = true
 
-# C# and Visual Basic
-[*.{cs,vb}]
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
 
 # Naming rules
 
@@ -123,6 +215,14 @@ dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.severity = suggestion
+dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.symbols = private_or_internal_static_field
+dotnet_naming_rule.private_or_internal_static_field_should_be_s_with_underscore.style = s_with_underscore
+
+dotnet_naming_rule.private_or_internal_field_should_be_underscore.severity = suggestion
+dotnet_naming_rule.private_or_internal_field_should_be_underscore.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_underscore.style = underscore
+
 dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
@@ -132,6 +232,14 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_static_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_static_field.applicable_accessibilities = internal, private, private_protected
+dotnet_naming_symbols.private_or_internal_static_field.required_modifiers = static
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
@@ -143,39 +251,25 @@ dotnet_naming_symbols.non_field_members.required_modifiers =
 
 # Naming styles
 
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
 dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.s_with_underscore.required_prefix = s_
+dotnet_naming_style.s_with_underscore.required_suffix = 
+dotnet_naming_style.s_with_underscore.word_separator = 
+dotnet_naming_style.s_with_underscore.capitalization = camel_case
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-tab_width = 4
-indent_size = 4
-end_of_line = crlf
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = false:silent
-dotnet_style_prefer_conditional_expression_over_return = false:silent
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
+dotnet_naming_style.underscore.required_prefix = _
+dotnet_naming_style.underscore.required_suffix = 
+dotnet_naming_style.underscore.word_separator = 
+dotnet_naming_style.underscore.capitalization = camel_case
 
 # Diagnostics
 
@@ -187,18 +281,3 @@ dotnet_diagnostic.IDE0073.severity = warning
 
 # IDE0008: Use explicit type
 dotnet_diagnostic.IDE0008.severity = none
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_readonly_field = false:suggestion
-dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
-dotnet_style_allow_multiple_blank_lines_experimental = false:silent
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-dotnet_style_predefined_type_for_member_access = true:silent
-dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:silent
-dotnet_code_quality_unused_parameters = all:suggestion
-dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:silent
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_event = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_property = false:silent

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,7 +45,7 @@
     "postProcessors": [ "ExtractSearchIndex" ],
     "keepFileLink": false,
     "disableGitFeatures": false,
-    "globalMetadata" :{
+    "globalMetadata" : {
       "_appTitle": "Mathematics.NET",
       "_appFooter": "Copyright &copy; 2023 Hamlet Tanyavong",
       "_appLogoPath": "images/logo/mathematics.net.png",

--- a/docs/guide/autodiff/first-order-forward-mode.md
+++ b/docs/guide/autodiff/first-order-forward-mode.md
@@ -55,11 +55,11 @@ Dual<Real> y = CreateVariable(2.34, 1.0);
 // Repeat for each variable present
 ```
 
-## Dual Vectors
+## AutoDiff Vectors
 
-We can create dual vectors to help us keep track of multiple dual numbers.
+We can create autodiff vectors to help us keep track of multiple dual numbers.
 ```csharp
-DualVector3<Real> x = new(CreateVariable(1.23), CreateVariable(0.66), CreateVariable(2.34));
+AutoDiffVector3<Real> x = new(CreateVariable(1.23), CreateVariable(0.66), CreateVariable(2.34));
 ```
 We can use this to compute the vector-Jacobian product of the vector functions
 $$
@@ -75,10 +75,10 @@ using Mathematics.NET.AutoDiff;
 using Mathematics.NET.Core;
 using static Mathematics.NET.AutoDiff.Dual<Mathematics.NET.Core.Real>;
 
-DualVector3<Real> x = new(CreateVariable(1.23), CreateVariable(0.66), CreateVariable(2.34));
+AutoDiffVector3<Real> x = new(CreateVariable(1.23), CreateVariable(0.66), CreateVariable(2.34));
 Vector3<Real> v = new(0.23, 1.57, -1.71);
 
-var result = DualVector3<Real>.VJP(
+var result = AutoDiffVector3<Real>.VJP(
     v,
     x => Sin(x.X1) * (Cos(x.X2) + Sqrt(x.X3)),
     x => Sqrt(x.X1 + x.X2 + x.X3),

--- a/docs/guide/autodiff/first-order-reverse-mode.md
+++ b/docs/guide/autodiff/first-order-reverse-mode.md
@@ -21,7 +21,7 @@ var y = tape.CreateVariable(0.66);
 ```
 and so on. To simplify this process, we may choose to create a vector of variables.
 ```csharp
-VariableVector3 x = tape.CreateVariableVector(1.23, 0.66, 2.34);
+AutoDiffVector3 x = tape.CreateAutoDiffVector(1.23, 0.66, 2.34);
 ```
 Once we are satisfied, we may use these in our equations.
 
@@ -229,11 +229,11 @@ $$
 $$
 at our specified points.
 
-### Variable Vectors
+### AutoDiff Vectors
 
 Instead of tracking $ x $, $ y $, and $ z $ individually, we can create a vector of variables.
 ```csharp
-tape.CreateVariableVector(1.23, 0.66, 2.34);
+tape.CreateAutoDiffVector(1.23, 0.66, 2.34);
 ```
 We can use this to calculate, for example, a Jacobian-vector product with the vector functions
 $$
@@ -248,7 +248,7 @@ and the vector $ \textbf{v} = (0.23, 1.57, -1.71) $ for $ x_1,x_2,x_3>0 $.
 using Mathematics.NET.AutoDiff;
 
 GradientTape<Real> tape = new();
-var x = tape.CreateVariableVector(1.23, 0.66, 2.34);
+var x = tape.CreateAutoDiffVector(1.23, 0.66, 2.34);
 Vector3<Real> v = new(0.23, 1.57, -1.71);
 
 var result = tape.JVP(F1, F2, F3, x, v);
@@ -256,7 +256,7 @@ var result = tape.JVP(F1, F2, F3, x, v);
 Console.WriteLine(result);
 
 // f(x, y, z) = Sin(x) * (Cos(y) + Sqrt(z))
-static Variable F1(GradientTape tape, VariableVector3 x)
+static Variable F1(GradientTape tape, AutoDiffVector3 x)
 {
     return tape.Multiply(
         tape.Sin(x.X1),
@@ -264,7 +264,7 @@ static Variable F1(GradientTape tape, VariableVector3 x)
 }
 
 // f(x, y, z) = Sqrt(x + y + z)
-static Variable F2(GradientTape tape, VariableVector3 x)
+static Variable F2(GradientTape tape, AutoDiffVector3 x)
 {
     return tape.Sqrt(
         tape.Add(
@@ -273,7 +273,7 @@ static Variable F2(GradientTape tape, VariableVector3 x)
 }
 
 // f(x, y, z) = Sinh(Exp(x) * y / z)
-static Variable F3(GradientTape tape, VariableVector3 x)
+static Variable F3(GradientTape tape, AutoDiffVector3 x)
 {
     return tape.Sinh(
         tape.Multiply(

--- a/docs/guide/autodiff/second-order-reverse-mode.md
+++ b/docs/guide/autodiff/second-order-reverse-mode.md
@@ -34,7 +34,7 @@ using Mathematics.NET.AutoDiff;
 using Mathematics.NET.Core;
 
 HessianTape<Real> tape = new();
-var x = tape.CreateVariableVector(1.23, 0.66, 0.23);
+var x = tape.CreateAutoDiffVector(1.23, 0.66, 0.23);
 
 // f(r, θ, ϕ) = cos(r) / ((r + θ) * sin(ϕ))
 _ = tape.Divide(

--- a/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
@@ -33,28 +33,68 @@ namespace Mathematics.NET.AutoDiff;
 public static class AutoDiffExtensions
 {
     //
-    // Variable vector creation
+    // Autodiff vector creation
     //
 
-    /// <summary>Create a dual vector from a seed vector.</summary>
+    /// <summary>Create an autodiff vector from a seed vector.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
+    /// <param name="x">A vector of seed values</param>
+    /// <returns>A variable vector of length two</returns>
+    public static AutoDiffVector2<T> CreateAutoDiffVector<T>(this ITape<T> tape, Vector2<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+        => new(tape.CreateVariable(x.X1), tape.CreateVariable(x.X2));
+
+    /// <summary>Create an autodiff vector from seed values.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
+    /// <param name="x1Seed">The first seed value</param>
+    /// <param name="x2Seed">The second seed value</param>
+    /// <returns>A variable vector of length two</returns>
+    public static AutoDiffVector2<T> CreateAutoDiffVector<T>(this ITape<T> tape, T x1Seed, T x2Seed)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+        => new(tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed));
+
+    /// <summary>Create an autodiff vector from a seed vector.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x">A vector of seed values</param>
     /// <returns>A variable vector of length three</returns>
-    public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, Vector3<T> x)
+    public static AutoDiffVector3<T> CreateAutoDiffVector<T>(this ITape<T> tape, Vector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x.X1), tape.CreateVariable(x.X2), tape.CreateVariable(x.X3));
 
-    /// <summary>Create a vector from seed values.</summary>
+    /// <summary>Create an autodiff vector from seed values.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
     /// <param name="x1Seed">The first seed value</param>
     /// <param name="x2Seed">The second seed value</param>
     /// <param name="x3Seed">The third seed value</param>
     /// <returns>A variable vector of length three</returns>
-    public static VariableVector3<T> CreateVariableVector<T>(this ITape<T> tape, T x1Seed, T x2Seed, T x3Seed)
+    public static AutoDiffVector3<T> CreateAutoDiffVector<T>(this ITape<T> tape, T x1Seed, T x2Seed, T x3Seed)
         where T : IComplex<T>, IDifferentiableFunctions<T>
         => new(tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed), tape.CreateVariable(x3Seed));
+
+    /// <summary>Create an autodiff vector from a seed vector.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
+    /// <param name="x">A vector of seed values</param>
+    /// <returns>A variable vector of length four</returns>
+    public static AutoDiffVector4<T> CreateAutoDiffVector<T>(this ITape<T> tape, Vector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+        => new(tape.CreateVariable(x.X1), tape.CreateVariable(x.X2), tape.CreateVariable(x.X3), tape.CreateVariable(x.X4));
+
+    /// <summary>Create an autodiff vector from seed values.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
+    /// <param name="x1Seed">The first seed value</param>
+    /// <param name="x2Seed">The second seed value</param>
+    /// <param name="x3Seed">The third seed value</param>
+    /// <param name="x4Seed">The fourth seed value</param>
+    /// <returns>A variable vector of length four</returns>
+    public static AutoDiffVector4<T> CreateAutoDiffVector<T>(this ITape<T> tape, T x1Seed, T x2Seed, T x3Seed, T x4Seed)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+        => new(tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed), tape.CreateVariable(x3Seed), tape.CreateVariable(x4Seed));
 
     //
     // Vector calculus
@@ -65,32 +105,32 @@ public static class AutoDiffExtensions
     /// <summary>Compute the curl of a vector field using reverse-mode automatic differentiation: $ (\nabla\times\textbf{F})(\textbf{x}) $.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
-    /// <param name="fx">The x-component of the vector field</param>
-    /// <param name="fy">The y-component of the vector field</param>
-    /// <param name="fz">The z-component of the vector field</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
     /// <param name="x">The point at which to compute the curl</param>
     /// <returns>The curl of the vector field</returns>
     public static Vector3<T> Curl<T>(
         this ITape<T> tape,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
-        VariableVector3<T> x)
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        AutoDiffVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
-        _ = fx(tape, x);
-        tape.ReverseAccumulation(out var dfx);
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var df1);
 
-        _ = fy(tape, x);
-        tape.ReverseAccumulation(out var dfy);
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out var df2);
 
-        _ = fz(tape, x);
-        tape.ReverseAccumulation(out var dfz);
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out var df3);
 
         return new(
-            dfz[1] - dfy[2],
-            dfx[2] - dfz[0],
-            dfy[0] - dfx[1]);
+            df3[1] - df2[2],
+            df1[2] - df3[0],
+            df2[0] - df1[1]);
     }
 
     /// <summary>Compute the derivative of a scalar function along a particular direction using reverse-mode automatic differentiation: $ \nabla_{\textbf{v}}f(\textbf{x}) $.</summary>
@@ -100,45 +140,133 @@ public static class AutoDiffExtensions
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the directional derivative</param>
     /// <returns>The directional derivative</returns>
-    public static T DirectionalDerivative<T>(this ITape<T> tape, Vector3<T> v, Func<ITape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
+    public static T DirectionalDerivative<T>(this ITape<T> tape, Vector2<T> v, Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f, AutoDiffVector2<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
 
-        tape.ReverseAccumulation(out var gradients);
+        tape.ReverseAccumulation(out var gradient);
 
-        return gradients[0] * v.X1 + gradients[1] * v.X2 + gradients[2] * v.X3;
+        return gradient[0] * v.X1 + gradient[1] * v.X2;
+    }
+
+    /// <inheritdoc cref="DirectionalDerivative{T}(ITape{T}, Vector2{T}, Func{ITape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static T DirectionalDerivative<T>(this ITape<T> tape, Vector3<T> v, Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f, AutoDiffVector3<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out var gradient);
+
+        return gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3;
+    }
+
+    /// <inheritdoc cref="DirectionalDerivative{T}(ITape{T}, Vector2{T}, Func{ITape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static T DirectionalDerivative<T>(this ITape<T> tape, Vector4<T> v, Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f, AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out var gradient);
+
+        return gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3 + gradient[3] * v.X4;
     }
 
     /// <summary>Compute the divergence of a vector field using reverse-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
-    /// <param name="fx">The x-component of the vector field</param>
-    /// <param name="fy">The y-component of the vector field</param>
-    /// <param name="fz">The z-component of the vector field</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
     /// <param name="x">The point at which to compute the divergence</param>
     /// <returns>The divergence of the vector field</returns>
     public static T Divergence<T>(
         this ITape<T> tape,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
-        VariableVector3<T> x)
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f2,
+        AutoDiffVector2<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         var partialSum = T.Zero;
 
-        _ = fx(tape, x);
-        tape.ReverseAccumulation(out var gradients);
-        partialSum += gradients[0];
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        partialSum += gradient[0];
 
-        _ = fy(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        partialSum += gradients[1];
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[1];
 
-        _ = fz(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        partialSum += gradients[2];
+        return partialSum;
+    }
+
+    /// <summary>Compute the divergence of a vector field using reverse-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
+    /// <param name="x">The point at which to compute the divergence</param>
+    /// <returns>The divergence of the vector field</returns>
+    public static T Divergence<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        AutoDiffVector3<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        var partialSum = T.Zero;
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        partialSum += gradient[0];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[1];
+
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[2];
+
+        return partialSum;
+    }
+
+    /// <summary>Compute the divergence of a vector field using reverse-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
+    /// <param name="f4">The fourth component of the vector field</param>
+    /// <param name="x">The point at which to compute the divergence</param>
+    /// <returns>The divergence of the vector field</returns>
+    public static T Divergence<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f4,
+        AutoDiffVector3<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        var partialSum = T.Zero;
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        partialSum += gradient[0];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[1];
+
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[2];
+
+        _ = f4(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        partialSum += gradient[3];
 
         return partialSum;
     }
@@ -149,14 +277,36 @@ public static class AutoDiffExtensions
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the gradient</param>
     /// <returns>The gradient of the scalar function</returns>
-    public static Vector3<T> Gradient<T>(this ITape<T> tape, Func<ITape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
+    public static Vector2<T> Gradient<T>(this ITape<T> tape, Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f, AutoDiffVector2<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
 
-        tape.ReverseAccumulation(out var gradients);
+        tape.ReverseAccumulation(out var gradient);
 
-        return new(gradients[0], gradients[1], gradients[2]);
+        return new(gradient[0], gradient[1]);
+    }
+
+    /// <inheritdoc cref="Gradient{T}(ITape{T}, Func{ITape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static Vector3<T> Gradient<T>(this ITape<T> tape, Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f, AutoDiffVector3<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out var gradient);
+
+        return new(gradient[0], gradient[1], gradient[2]);
+    }
+
+    /// <inheritdoc cref="Gradient{T}(ITape{T}, Func{ITape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static Vector4<T> Gradient<T>(this ITape<T> tape, Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f, AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out var gradient);
+
+        return new(gradient[0], gradient[1], gradient[2], gradient[3]);
     }
 
     /// <summary>Compute the Hessian of a scaler function using reverse-mode automatic differentiation.</summary>
@@ -165,7 +315,20 @@ public static class AutoDiffExtensions
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the gradient</param>
     /// <returns>The Hessian of the scalar function</returns>
-    public static Matrix3x3<T> Hessian<T>(this HessianTape<T> tape, Func<HessianTape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
+    public static Matrix2x2<T> Hessian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector2<T>, Variable<T>> f, AutoDiffVector2<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out ReadOnlySpan2D<T> hessian);
+
+        return new(
+            hessian[0, 0], hessian[0, 1],
+            hessian[1, 0], hessian[1, 1]);
+    }
+
+    /// <inheritdoc cref="Hessian{T}(HessianTape{T}, Func{HessianTape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static Matrix3x3<T> Hessian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector3<T>, Variable<T>> f, AutoDiffVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
@@ -178,35 +341,116 @@ public static class AutoDiffExtensions
             hessian[2, 0], hessian[2, 1], hessian[2, 2]);
     }
 
+    /// <inheritdoc cref="Hessian{T}(HessianTape{T}, Func{HessianTape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static Matrix4x4<T> Hessian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector4<T>, Variable<T>> f, AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out ReadOnlySpan2D<T> hessian);
+
+        return new(
+            hessian[0, 0], hessian[0, 1], hessian[0, 2], hessian[0, 3],
+            hessian[1, 0], hessian[1, 1], hessian[1, 2], hessian[1, 3],
+            hessian[2, 0], hessian[2, 1], hessian[2, 2], hessian[2, 3],
+            hessian[3, 0], hessian[3, 1], hessian[3, 2], hessian[3, 3]);
+    }
+
     /// <summary>Compute the Jacobian of a vector function using reverse-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the Jacobian</param>
+    /// <returns>The Jacobian of the vector function</returns>
+    public static Matrix2x2<T> Jacobian<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f2,
+        AutoDiffVector2<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Matrix2x2<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0, 0] = gradient[0]; result[0, 1] = gradient[1];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1, 0] = gradient[0]; result[1, 1] = gradient[1];
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian of a vector function using reverse-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian</param>
     /// <returns>The Jacobian of the vector function</returns>
     public static Matrix3x3<T> Jacobian<T>(
         this ITape<T> tape,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
-        VariableVector3<T> x)
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        AutoDiffVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         Matrix3x3<T> result = new();
 
-        _ = fx(tape, x);
-        tape.ReverseAccumulation(out var gradients);
-        result[0, 0] = gradients[0]; result[0, 1] = gradients[1]; result[0, 2] = gradients[2];
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0, 0] = gradient[0]; result[0, 1] = gradient[1]; result[0, 2] = gradient[2];
 
-        _ = fy(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        result[1, 0] = gradients[0]; result[1, 1] = gradients[1]; result[1, 2] = gradients[2];
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1, 0] = gradient[0]; result[1, 1] = gradient[1]; result[1, 2] = gradient[2];
 
-        _ = fz(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        result[2, 0] = gradients[0]; result[2, 1] = gradients[1]; result[2, 2] = gradients[2];
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[2, 0] = gradient[0]; result[2, 1] = gradient[1]; result[2, 2] = gradient[2];
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian of a vector function using reverse-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the Jacobian</param>
+    /// <returns>The Jacobian of the vector function</returns>
+    public static Matrix4x4<T> Jacobian<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f3,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f4,
+        AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Matrix4x4<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0, 0] = gradient[0]; result[0, 1] = gradient[1]; result[0, 2] = gradient[2]; result[0, 3] = gradient[3];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1, 0] = gradient[0]; result[1, 1] = gradient[1]; result[1, 2] = gradient[2]; result[1, 3] = gradient[3];
+
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[2, 0] = gradient[0]; result[2, 1] = gradient[1]; result[2, 2] = gradient[2]; result[2, 3] = gradient[3];
+
+        _ = f4(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[3, 0] = gradient[0]; result[3, 1] = gradient[1]; result[3, 2] = gradient[2]; result[3, 3] = gradient[3];
 
         return result;
     }
@@ -214,34 +458,104 @@ public static class AutoDiffExtensions
     /// <summary>Compute the Jacobian-vector product of a vector function and a vector using reverse-mode automatic differentiation.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the Jacobian-vector product</param>
+    /// <param name="v">A vector</param>
+    /// <returns>The Jacobian-vector product of the vector function and vector</returns>
+    public static Vector2<T> JVP<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f2,
+        AutoDiffVector2<T> x,
+        Vector2<T> v)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Vector2<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0] = gradient[0] * v.X1 + gradient[1] * v.X2;
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1] = gradient[0] * v.X1 + gradient[1] * v.X2;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian-vector product of a vector function and a vector using reverse-mode automatic differentiation.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian-vector product</param>
     /// <param name="v">A vector</param>
     /// <returns>The Jacobian-vector product of the vector function and vector</returns>
     public static Vector3<T> JVP<T>(
         this ITape<T> tape,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
-        VariableVector3<T> x,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        AutoDiffVector3<T> x,
         Vector3<T> v)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         Vector3<T> result = new();
 
-        _ = fx(tape, x);
-        tape.ReverseAccumulation(out var gradients);
-        result[0] = gradients[0] * v.X1 + gradients[1] * v.X2 + gradients[2] * v.X3;
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3;
 
-        _ = fy(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        result[1] = gradients[0] * v.X1 + gradients[1] * v.X2 + gradients[2] * v.X3;
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3;
 
-        _ = fz(tape, x);
-        tape.ReverseAccumulation(out gradients);
-        result[2] = gradients[0] * v.X1 + gradients[1] * v.X2 + gradients[2] * v.X3;
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[2] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian-vector product of a vector function and a vector using reverse-mode automatic differentiation.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the Jacobian-vector product</param>
+    /// <param name="v">A vector</param>
+    /// <returns>The Jacobian-vector product of the vector function and vector</returns>
+    public static Vector4<T> JVP<T>(
+        this ITape<T> tape,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f3,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f4,
+        AutoDiffVector4<T> x,
+        Vector4<T> v)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Vector4<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient);
+        result[0] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3 + gradient[3] * v.X4;
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[1] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3 + gradient[3] * v.X4;
+
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[2] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3 + gradient[3] * v.X4;
+
+        _ = f4(tape, x);
+        tape.ReverseAccumulation(out gradient);
+        result[3] = gradient[0] * v.X1 + gradient[1] * v.X2 + gradient[2] * v.X3 + gradient[3] * v.X4;
 
         return result;
     }
@@ -252,7 +566,18 @@ public static class AutoDiffExtensions
     /// <param name="f">A scalar function</param>
     /// <param name="x">The point at which to compute the Laplacian</param>
     /// <returns>The Laplacian of the scalar function</returns>
-    public static T Laplacian<T>(this HessianTape<T> tape, Func<HessianTape<T>, VariableVector3<T>, Variable<T>> f, VariableVector3<T> x)
+    public static T Laplacian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector2<T>, Variable<T>> f, AutoDiffVector2<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out ReadOnlySpan2D<T> hessian);
+
+        return hessian[0, 0] + hessian[1, 1];
+    }
+
+    /// <inheritdoc cref="Laplacian{T}(HessianTape{T}, Func{HessianTape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static T Laplacian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector3<T>, Variable<T>> f, AutoDiffVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         _ = f(tape, x);
@@ -262,38 +587,119 @@ public static class AutoDiffExtensions
         return hessian[0, 0] + hessian[1, 1] + hessian[2, 2];
     }
 
+    /// <inheritdoc cref="Laplacian{T}(HessianTape{T}, Func{HessianTape{T}, AutoDiffVector2{T}, Variable{T}}, AutoDiffVector2{T})"/>
+    public static T Laplacian<T>(this HessianTape<T> tape, Func<HessianTape<T>, AutoDiffVector4<T>, Variable<T>> f, AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        _ = f(tape, x);
+
+        tape.ReverseAccumulation(out ReadOnlySpan2D<T> hessian);
+
+        return hessian[0, 0] + hessian[1, 1] + hessian[2, 2] + hessian[3, 3];
+    }
+
     /// <summary>Compute the vector-Jacobian product of a vector and a vector function using reverse-mode automatic differentiation.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="v">A vector</param>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the vector-Jacobian product</param>
+    /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
+    public static Vector2<T> VJP<T>(
+        this ITape<T> tape,
+        Vector2<T> v,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector2<T>, Variable<T>> f2,
+        AutoDiffVector2<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Vector2<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient, v.X1);
+        result[0] += gradient[0]; result[1] += gradient[1];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X2);
+        result[0] += gradient[0]; result[1] += gradient[1];
+
+        return new(result[0], result[1]);
+    }
+
+    /// <summary>Compute the vector-Jacobian product of a vector and a vector function using reverse-mode automatic differentiation.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="v">A vector</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the vector-Jacobian product</param>
     /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
     public static Vector3<T> VJP<T>(
         this ITape<T> tape,
         Vector3<T> v,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fx,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fy,
-        Func<ITape<T>, VariableVector3<T>, Variable<T>> fz,
-        VariableVector3<T> x)
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector3<T>, Variable<T>> f3,
+        AutoDiffVector3<T> x)
         where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         Vector3<T> result = new();
 
-        _ = fx(tape, x);
-        tape.ReverseAccumulation(out var gradients, v.X1);
-        result[0] += gradients[0]; result[1] += gradients[1]; result[2] += gradients[2];
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient, v.X1);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2];
 
-        _ = fy(tape, x);
-        tape.ReverseAccumulation(out gradients, v.X2);
-        result[0] += gradients[0]; result[1] += gradients[1]; result[2] += gradients[2];
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X2);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2];
 
-        _ = fz(tape, x);
-        tape.ReverseAccumulation(out gradients, v.X3);
-        result[0] += gradients[0]; result[1] += gradients[1]; result[2] += gradients[2];
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X3);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2];
 
         return new(result[0], result[1], result[2]);
+    }
+
+    /// <summary>Compute the vector-Jacobian product of a vector and a vector function using reverse-mode automatic differentiation.</summary>
+    /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="v">A vector</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the vector-Jacobian product</param>
+    /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
+    public static Vector4<T> VJP<T>(
+        this ITape<T> tape,
+        Vector4<T> v,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f1,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f2,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f3,
+        Func<ITape<T>, AutoDiffVector4<T>, Variable<T>> f4,
+        AutoDiffVector4<T> x)
+        where T : IComplex<T>, IDifferentiableFunctions<T>
+    {
+        Vector4<T> result = new();
+
+        _ = f1(tape, x);
+        tape.ReverseAccumulation(out var gradient, v.X1);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2]; result[3] += gradient[3];
+
+        _ = f2(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X2);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2]; result[3] += gradient[3];
+
+        _ = f3(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X3);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2]; result[3] += gradient[3];
+
+        _ = f4(tape, x);
+        tape.ReverseAccumulation(out gradient, v.X4);
+        result[0] += gradient[0]; result[1] += gradient[1]; result[2] += gradient[2]; result[3] += gradient[3];
+
+        return new(result[0], result[1], result[2], result[3]);
     }
 }

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector2`1.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector2`1.cs
@@ -1,0 +1,106 @@
+﻿// <copyright file="AutoDiffVector2`1.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a vector of two variables for use in reverse-mode automatic differentiation</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public record struct AutoDiffVector2<T>
+    where T : IComplex<T>
+{
+    /// <summary>The first element of the vector</summary>
+    public Variable<T> X1;
+
+    /// <summary>The second element of the vector</summary>
+    public Variable<T> X2;
+
+    public AutoDiffVector2(Variable<T> x1, Variable<T> x2)
+    {
+        X1 = x1;
+        X2 = x2;
+    }
+
+    /// <summary>Get the element at the specified index</summary>
+    /// <param name="index">An index</param>
+    /// <returns>The element at the index</returns>
+    public Variable<T> this[int index]
+    {
+        readonly get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static Variable<T> GetElement(AutoDiffVector2<T> vector, int index)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Variable<T> GetElementUnsafe(ref AutoDiffVector2<T> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector2<T>, Variable<T>>(ref vector), index);
+    }
+
+    // Set
+
+    internal static AutoDiffVector2<T> WithElement(AutoDiffVector2<T> vector, int index, Variable<T> value)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        AutoDiffVector2<T> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref AutoDiffVector2<T> vector, int index, Variable<T> value)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector2<T>, Variable<T>>(ref vector), index) = value;
+    }
+
+    //
+    // Formatting
+    //
+
+    public override readonly string ToString() => $"({X1}, {X2})";
+}

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector2`2.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector2`2.cs
@@ -1,0 +1,251 @@
+﻿// <copyright file="AutoDiffVector2`2.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mathematics.NET.LinearAlgebra;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a vector of two dual numbers for use in forward-mode automatic differentiation</summary>
+/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
+/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public record struct AutoDiffVector2<T, U>
+    where T : IDual<T, U>
+    where U : IComplex<U>, IDifferentiableFunctions<U>
+{
+    /// <summary>The first element of the vector</summary>
+    public T X1;
+
+    /// <summary>The second element of the vector</summary>
+    public T X2;
+
+    public AutoDiffVector2(T x1, T x2)
+    {
+        X1 = x1;
+        X2 = x2;
+    }
+
+    //
+    // Indexer
+    //
+
+    public T this[int index]
+    {
+        get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static T GetElement(AutoDiffVector2<T, U> vector, int index)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T GetElementUnsafe(ref AutoDiffVector2<T, U> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector2<T, U>, T>(ref vector), index);
+    }
+
+    // Set
+
+    internal static AutoDiffVector2<T, U> WithElement(AutoDiffVector2<T, U> vector, int index, T value)
+    {
+        if ((uint)index >= 2)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        AutoDiffVector2<T, U> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref AutoDiffVector2<T, U> vector, int index, T value)
+    {
+        Debug.Assert(index is >= 0 and < 2);
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector2<T, U>, T>(ref vector), index) = value;
+    }
+
+    //
+    // Methods
+    //
+
+    //
+    // Vector Calculus
+    //
+
+    /// <summary>Compute the derivative of a scalar function along a particular direction using forward-mode automatic differentiation: $ \nabla_{\textbf{v}}f(\textbf{x}) $.</summary>
+    /// <param name="v">A direction</param>
+    /// <param name="f">A scalar function</param>
+    /// <param name="x">The point at which to compute the directional derivative</param>
+    /// <returns>A directional derivative</returns>
+    public static U DirectionalDerivative(
+        Vector2<U> v,
+        Func<AutoDiffVector2<T, U>, T> f,
+        AutoDiffVector2<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<T, U>> seeds = [
+            new(x.X1.WithSeed(v.X1), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(v.X2))];
+
+        return f(seeds[0]).D1 + f(seeds[1]).D1;
+    }
+
+    /// <summary>Compute the divergence of a vector field using forward-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="x">The point at which to compute the divergence</param>
+    /// <returns>The divergence of the vector field</returns>
+    public static U Divergence(
+        Func<AutoDiffVector2<T, U>, T> f1,
+        Func<AutoDiffVector2<T, U>, T> f2,
+        AutoDiffVector2<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One))];
+
+        return f1(seeds[0]).D1 + f2(seeds[1]).D1;
+    }
+
+    /// <summary>Compute the gradient of a scalar function using forward-mode automatic differentiation: $ \nabla f(\textbf{x}) $.</summary>
+    /// <param name="f">A scalar function</param>
+    /// <param name="x">The point at which to compute the gradient</param>
+    /// <returns>The gradient of the scalar function</returns>
+    public static Vector2<U> Gradient(Func<AutoDiffVector2<T, U>, T> f, AutoDiffVector2<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One))];
+
+        return new(f(seeds[0]).D1, f(seeds[1]).D1);
+    }
+
+    /// <summary>Compute the Hessian of a scalar function using forward-mode automatic differentiation.</summary>
+    /// <param name="f">A scalar function</param>
+    /// <param name="x">The point at which to compute the gradient</param>
+    /// <returns>The Hessian of the scalar function</returns>
+    public static Matrix2x2<U> Hessian(Func<AutoDiffVector2<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector2<HyperDual<U>, U> x)
+    {
+        Matrix2x2<U> result = new();
+
+        result[0, 0] = f(new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero))).D3;
+        result[1, 1] = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One, U.One))).D3;
+
+        var e12 = f(new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero, U.One)));
+        result[0, 1] = e12.D3; result[1, 0] = e12.D3;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian of a vector function using forward-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the Jacobian</param>
+    /// <returns>The Jacobian of the vector function</returns>
+    public static Matrix2x2<U> Jacobian(
+        Func<AutoDiffVector2<T, U>, T> f1,
+        Func<AutoDiffVector2<T, U>, T> f2,
+        AutoDiffVector2<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One))];
+
+        Matrix2x2<U> result = new();
+
+        result[0, 0] = f1(seeds[0]).D1; result[0, 1] = f1(seeds[1]).D1;
+        result[1, 0] = f2(seeds[0]).D1; result[1, 1] = f2(seeds[1]).D1;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian-vector product of a vector function and a vector using forward-mode automatic differentiation.</summary>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the Jacobian-vector product</param>
+    /// <param name="v">A vector</param>
+    /// <returns>The Jacobian-vector product of the vector function and vector</returns>
+    public static Vector2<U> JVP(
+        Func<AutoDiffVector2<T, U>, T> f1,
+        Func<AutoDiffVector2<T, U>, T> f2,
+        AutoDiffVector2<T, U> x,
+        Vector2<U> v)
+    {
+        AutoDiffVector2<T, U> seed = new(x.X1.WithSeed(v.X1), x.X2.WithSeed(v.X2));
+        return new(f1(seed).D1, f2(seed).D1);
+    }
+
+    /// <summary>Compute the Laplacian of a scalar function using forward-mode automatic differentiation:  $ \nabla^2f $.</summary>
+    /// <param name="f">A scalar function</param>
+    /// <param name="x">The point at which to compute the gradient</param>
+    /// <returns>The gradient of the scalar function</returns>
+    public static U Laplacian(Func<AutoDiffVector2<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector2<HyperDual<U>, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<HyperDual<U>, U>> seeds = [
+            new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One, U.One))];
+
+        return f(seeds[0]).D3 + f(seeds[1]).D3;
+    }
+
+    /// <summary>Compute the vector-Jacobian product of a vector and a vector function using forward-mode automatic differentiation.</summary>
+    /// <param name="v">A vector</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="x">The point at which to compute the vector-Jacobian product</param>
+    /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
+    public static Vector2<U> VJP(
+        Vector2<U> v,
+        Func<AutoDiffVector2<T, U>, T> f1,
+        Func<AutoDiffVector2<T, U>, T> f2,
+        AutoDiffVector2<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector2<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One))];
+
+        Vector2<U> result = new();
+
+        result[0] = v.X1 * f1(seeds[0]).D1 + v.X2 * f2(seeds[0]).D1;
+        result[1] = v.X1 * f1(seeds[1]).D1 + v.X2 * f2(seeds[1]).D1;
+
+        return result;
+    }
+}

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector3`1.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector3`1.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="VariableVector3.cs" company="Mathematics.NET">
+﻿// <copyright file="AutoDiffVector3`1.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -34,7 +34,7 @@ namespace Mathematics.NET.AutoDiff;
 /// <summary>Represents a vector of three variables for use in reverse-mode automatic differentiation</summary>
 /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
 [StructLayout(LayoutKind.Sequential)]
-public record struct VariableVector3<T>
+public record struct AutoDiffVector3<T>
     where T : IComplex<T>
 {
     /// <summary>The first element of the vector</summary>
@@ -46,7 +46,7 @@ public record struct VariableVector3<T>
     /// <summary>The third element of the vector</summary>
     public Variable<T> X3;
 
-    public VariableVector3(Variable<T> x1, Variable<T> x2, Variable<T> x3)
+    public AutoDiffVector3(Variable<T> x1, Variable<T> x2, Variable<T> x3)
     {
         X1 = x1;
         X2 = x2;
@@ -68,7 +68,7 @@ public record struct VariableVector3<T>
 
     // Get
 
-    internal static Variable<T> GetElement(VariableVector3<T> vector, int index)
+    internal static Variable<T> GetElement(AutoDiffVector3<T> vector, int index)
     {
         if ((uint)index >= 3)
         {
@@ -79,31 +79,31 @@ public record struct VariableVector3<T>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Variable<T> GetElementUnsafe(ref VariableVector3<T> vector, int index)
+    private static Variable<T> GetElementUnsafe(ref AutoDiffVector3<T> vector, int index)
     {
         Debug.Assert(index is >= 0 and < 3);
-        return Unsafe.Add(ref Unsafe.As<VariableVector3<T>, Variable<T>>(ref vector), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector3<T>, Variable<T>>(ref vector), index);
     }
 
     // Set
 
-    internal static VariableVector3<T> WithElement(VariableVector3<T> vector, int index, Variable<T> value)
+    internal static AutoDiffVector3<T> WithElement(AutoDiffVector3<T> vector, int index, Variable<T> value)
     {
         if ((uint)index >= 3)
         {
             throw new IndexOutOfRangeException();
         }
 
-        VariableVector3<T> result = vector;
+        AutoDiffVector3<T> result = vector;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref VariableVector3<T> vector, int index, Variable<T> value)
+    private static void SetElementUnsafe(ref AutoDiffVector3<T> vector, int index, Variable<T> value)
     {
         Debug.Assert(index is >= 0 and < 3);
-        Unsafe.Add(ref Unsafe.As<VariableVector3<T>, Variable<T>>(ref vector), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector3<T>, Variable<T>>(ref vector), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector3`2.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector3`2.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DualVector3.cs" company="Mathematics.NET">
+﻿// <copyright file="AutoDiffVector3`2.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -33,10 +33,10 @@ using Mathematics.NET.LinearAlgebra;
 namespace Mathematics.NET.AutoDiff;
 
 /// <summary>Represents a vector of three dual numbers for use in forward-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
 /// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
 [StructLayout(LayoutKind.Sequential)]
-public record struct DualVector3<T, U>
+public record struct AutoDiffVector3<T, U>
     where T : IDual<T, U>
     where U : IComplex<U>, IDifferentiableFunctions<U>
 {
@@ -49,7 +49,7 @@ public record struct DualVector3<T, U>
     /// <summary>The third element of the vector</summary>
     public T X3;
 
-    public DualVector3(T x1, T x2, T x3)
+    public AutoDiffVector3(T x1, T x2, T x3)
     {
         X1 = x1;
         X2 = x2;
@@ -68,7 +68,7 @@ public record struct DualVector3<T, U>
 
     // Get
 
-    internal static T GetElement(DualVector3<T, U> vector, int index)
+    internal static T GetElement(AutoDiffVector3<T, U> vector, int index)
     {
         if ((uint)index >= 3)
         {
@@ -79,31 +79,31 @@ public record struct DualVector3<T, U>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static T GetElementUnsafe(ref DualVector3<T, U> vector, int index)
+    private static T GetElementUnsafe(ref AutoDiffVector3<T, U> vector, int index)
     {
         Debug.Assert(index is >= 0 and < 3);
-        return Unsafe.Add(ref Unsafe.As<DualVector3<T, U>, T>(ref vector), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector3<T, U>, T>(ref vector), index);
     }
 
     // Set
 
-    internal static DualVector3<T, U> WithElement(DualVector3<T, U> vector, int index, T value)
+    internal static AutoDiffVector3<T, U> WithElement(AutoDiffVector3<T, U> vector, int index, T value)
     {
         if ((uint)index >= 3)
         {
             throw new IndexOutOfRangeException();
         }
 
-        DualVector3<T, U> result = vector;
+        AutoDiffVector3<T, U> result = vector;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref DualVector3<T, U> vector, int index, T value)
+    private static void SetElementUnsafe(ref AutoDiffVector3<T, U> vector, int index, T value)
     {
         Debug.Assert(index is >= 0 and < 3);
-        Unsafe.Add(ref Unsafe.As<DualVector3<T, U>, T>(ref vector), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector3<T, U>, T>(ref vector), index) = value;
     }
 
     //
@@ -111,7 +111,7 @@ public record struct DualVector3<T, U>
     //
 
     /// <inheritdoc cref="Vector3{T}.Cross(Vector3{T}, Vector3{T})"/>
-    public static DualVector3<T, U> Cross(DualVector3<T, U> left, DualVector3<T, U> right)
+    public static AutoDiffVector3<T, U> Cross(AutoDiffVector3<T, U> left, AutoDiffVector3<T, U> right)
     {
         return new(
             left.X2 * right.X3 - left.X3 * right.X2,
@@ -124,43 +124,39 @@ public record struct DualVector3<T, U>
     //
 
     /// <summary>Compute the curl of a vector field using forward-mode automatic differentiation: $ (\nabla\times\textbf{F})(\textbf{x}) $.</summary>
-    /// <param name="fx">The x-component of the vector field</param>
-    /// <param name="fy">The y-component of the vector field</param>
-    /// <param name="fz">The z-component of the vector field</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
     /// <param name="x">The point at which to compute the curl</param>
     /// <returns>The curl of the vector field</returns>
     public static Vector3<U> Curl(
-        Func<DualVector3<T, U>, T> fx,
-        Func<DualVector3<T, U>, T> fy,
-        Func<DualVector3<T, U>, T> fz,
-        DualVector3<T, U> x)
+        Func<AutoDiffVector3<T, U>, T> f1,
+        Func<AutoDiffVector3<T, U>, T> f2,
+        Func<AutoDiffVector3<T, U>, T> f3,
+        AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
 
-        ReadOnlySpan<U> dfx = [fx(seeds[0]).D1, fx(seeds[1]).D1, fx(seeds[2]).D1];
-        ReadOnlySpan<U> dfy = [fy(seeds[0]).D1, fy(seeds[1]).D1, fy(seeds[2]).D1];
-        ReadOnlySpan<U> dfz = [fz(seeds[0]).D1, fz(seeds[1]).D1, fz(seeds[2]).D1];
+        ReadOnlySpan<U> df1 = [f1(seeds[0]).D1, f1(seeds[1]).D1, f1(seeds[2]).D1];
+        ReadOnlySpan<U> df2 = [f2(seeds[0]).D1, f2(seeds[1]).D1, f2(seeds[2]).D1];
+        ReadOnlySpan<U> df3 = [f3(seeds[0]).D1, f3(seeds[1]).D1, f3(seeds[2]).D1];
 
         return new(
-            dfz[1] - dfy[2],
-            dfx[2] - dfz[0],
-            dfy[0] - dfx[1]);
+            df3[1] - df2[2],
+            df1[2] - df3[0],
+            df2[0] - df1[1]);
     }
 
-    /// <summary>Compute the derivative of a scalar function along a particular direction using forward-mode automatic differentiation: $ \nabla_{\textbf{v}}f(\textbf{x}) $.</summary>
-    /// <param name="v">A direction</param>
-    /// <param name="f">A scalar function</param>
-    /// <param name="x">The point at which to compute the directional derivative</param>
-    /// <returns>A directional derivative</returns>
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.DirectionalDerivative(Vector2{U}, Func{AutoDiffVector2{T, U}, T}, AutoDiffVector2{T, U})"/>
     public static U DirectionalDerivative(
         Vector3<U> v,
-        Func<DualVector3<T, U>, T> f,
-        DualVector3<T, U> x)
+        Func<AutoDiffVector3<T, U>, T> f,
+        AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(v.X1), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(v.X2), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(v.X3))];
@@ -169,32 +165,29 @@ public record struct DualVector3<T, U>
     }
 
     /// <summary>Compute the divergence of a vector field using forward-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
-    /// <param name="fx">The x-component of the vector field</param>
-    /// <param name="fy">The y-component of the vector field</param>
-    /// <param name="fz">The z-component of the vector field</param>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
     /// <param name="x">The point at which to compute the divergence</param>
     /// <returns>The divergence of the vector field</returns>
     public static U Divergence(
-        Func<DualVector3<T, U>, T> fx,
-        Func<DualVector3<T, U>, T> fy,
-        Func<DualVector3<T, U>, T> fz,
-        DualVector3<T, U> x)
+        Func<AutoDiffVector3<T, U>, T> f1,
+        Func<AutoDiffVector3<T, U>, T> f2,
+        Func<AutoDiffVector3<T, U>, T> f3,
+        AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
 
-        return fx(seeds[0]).D1 + fy(seeds[1]).D1 + fz(seeds[2]).D1;
+        return f1(seeds[0]).D1 + f2(seeds[1]).D1 + f3(seeds[2]).D1;
     }
 
-    /// <summary>Compute the gradient of a scalar function using forward-mode automatic differentiation: $ \nabla f(\textbf{x}) $.</summary>
-    /// <param name="f">A scalar function</param>
-    /// <param name="x">The point at which to compute the gradient</param>
-    /// <returns>The gradient of the scalar function</returns>
-    public static Vector3<U> Gradient(Func<DualVector3<T, U>, T> f, DualVector3<T, U> x)
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Gradient(Func{AutoDiffVector2{T, U}, T}, AutoDiffVector2{T, U})"/>
+    public static Vector3<U> Gradient(Func<AutoDiffVector3<T, U>, T> f, AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
@@ -202,17 +195,9 @@ public record struct DualVector3<T, U>
         return new(f(seeds[0]).D1, f(seeds[1]).D1, f(seeds[2]).D1);
     }
 
-    /// <summary>Compute the Hessian of a scalar function using forward-mode automatic differentiation.</summary>
-    /// <param name="f">A scalar function</param>
-    /// <param name="x">The point at which to compute the gradient</param>
-    /// <returns>The Hessian of the scalar function</returns>
-    public static Matrix3x3<U> Hessian(Func<DualVector3<HyperDual<U>, U>, HyperDual<U>> f, DualVector3<HyperDual<U>, U> x)
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Hessian(Func{AutoDiffVector2{HyperDual{U}, U}, HyperDual{U}}, AutoDiffVector2{HyperDual{U}, U})"/>
+    public static Matrix3x3<U> Hessian(Func<AutoDiffVector3<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector3<HyperDual<U>, U> x)
     {
-        ReadOnlySpan<DualVector3<HyperDual<U>, U>> seeds = [
-            new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
-            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
-            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
-
         Matrix3x3<U> result = new();
 
         result[0, 0] = f(new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero))).D3;
@@ -232,56 +217,53 @@ public record struct DualVector3<T, U>
     }
 
     /// <summary>Compute the Jacobian of a vector function using forward-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian</param>
     /// <returns>The Jacobian of the vector function</returns>
     public static Matrix3x3<U> Jacobian(
-        Func<DualVector3<T, U>, T> fx,
-        Func<DualVector3<T, U>, T> fy,
-        Func<DualVector3<T, U>, T> fz,
-        DualVector3<T, U> x)
+        Func<AutoDiffVector3<T, U>, T> f1,
+        Func<AutoDiffVector3<T, U>, T> f2,
+        Func<AutoDiffVector3<T, U>, T> f3,
+        AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
 
         Matrix3x3<U> result = new();
 
-        result[0, 0] = fx(seeds[0]).D1; result[0, 1] = fx(seeds[1]).D1; result[0, 2] = fx(seeds[2]).D1;
-        result[1, 0] = fy(seeds[0]).D1; result[1, 1] = fy(seeds[1]).D1; result[1, 2] = fy(seeds[2]).D1;
-        result[2, 0] = fz(seeds[0]).D1; result[2, 1] = fz(seeds[1]).D1; result[2, 2] = fz(seeds[2]).D1;
+        result[0, 0] = f1(seeds[0]).D1; result[0, 1] = f1(seeds[1]).D1; result[0, 2] = f1(seeds[2]).D1;
+        result[1, 0] = f2(seeds[0]).D1; result[1, 1] = f2(seeds[1]).D1; result[1, 2] = f2(seeds[2]).D1;
+        result[2, 0] = f3(seeds[0]).D1; result[2, 1] = f3(seeds[1]).D1; result[2, 2] = f3(seeds[2]).D1;
 
         return result;
     }
 
     /// <summary>Compute the Jacobian-vector product of a vector function and a vector using forward-mode automatic differentiation.</summary>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the Jacobian-vector product</param>
     /// <param name="v">A vector</param>
     /// <returns>The Jacobian-vector product of the vector function and vector</returns>
     public static Vector3<U> JVP(
-        Func<DualVector3<T, U>, T> fx,
-        Func<DualVector3<T, U>, T> fy,
-        Func<DualVector3<T, U>, T> fz,
-        DualVector3<T, U> x,
+        Func<AutoDiffVector3<T, U>, T> f1,
+        Func<AutoDiffVector3<T, U>, T> f2,
+        Func<AutoDiffVector3<T, U>, T> f3,
+        AutoDiffVector3<T, U> x,
         Vector3<U> v)
     {
-        DualVector3<T, U> seed = new(x.X1.WithSeed(v.X1), x.X2.WithSeed(v.X2), x.X3.WithSeed(v.X3));
-        return new(fx(seed).D1, fy(seed).D1, fz(seed).D1);
+        AutoDiffVector3<T, U> seed = new(x.X1.WithSeed(v.X1), x.X2.WithSeed(v.X2), x.X3.WithSeed(v.X3));
+        return new(f1(seed).D1, f2(seed).D1, f3(seed).D1);
     }
 
-    /// <summary>Compute the Laplacian of a scalar function using forward-mode automatic differentiation:  $ \nabla^2f $.</summary>
-    /// <param name="f">A scalar function</param>
-    /// <param name="x">The point at which to compute the gradient</param>
-    /// <returns>The gradient of the scalar function</returns>
-    public static U Laplacian(Func<DualVector3<HyperDual<U>, U>, HyperDual<U>> f, DualVector3<HyperDual<U>, U> x)
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Laplacian(Func{AutoDiffVector2{HyperDual{U}, U}, HyperDual{U}}, AutoDiffVector2{HyperDual{U}, U})"/>
+    public static U Laplacian(Func<AutoDiffVector3<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector3<HyperDual<U>, U> x)
     {
-        ReadOnlySpan<DualVector3<HyperDual<U>, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<HyperDual<U>, U>> seeds = [
             new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One, U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One, U.One))];
@@ -291,28 +273,28 @@ public record struct DualVector3<T, U>
 
     /// <summary>Compute the vector-Jacobian product of a vector and a vector function using forward-mode automatic differentiation.</summary>
     /// <param name="v">A vector</param>
-    /// <param name="fx">The first function</param>
-    /// <param name="fy">The second function</param>
-    /// <param name="fz">The third function</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
     /// <param name="x">The point at which to compute the vector-Jacobian product</param>
     /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
     public static Vector3<U> VJP(
         Vector3<U> v,
-        Func<DualVector3<T, U>, T> fx,
-        Func<DualVector3<T, U>, T> fy,
-        Func<DualVector3<T, U>, T> fz,
-        DualVector3<T, U> x)
+        Func<AutoDiffVector3<T, U>, T> f1,
+        Func<AutoDiffVector3<T, U>, T> f2,
+        Func<AutoDiffVector3<T, U>, T> f3,
+        AutoDiffVector3<T, U> x)
     {
-        ReadOnlySpan<DualVector3<T, U>> seeds = [
+        ReadOnlySpan<AutoDiffVector3<T, U>> seeds = [
             new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero)),
             new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One))];
 
         Vector3<U> result = new();
 
-        result[0] = v.X1 * fx(seeds[0]).D1 + v.X2 * fy(seeds[0]).D1 + v.X3 * fz(seeds[0]).D1;
-        result[1] = v.X1 * fx(seeds[1]).D1 + v.X2 * fy(seeds[1]).D1 + v.X3 * fz(seeds[1]).D1;
-        result[2] = v.X1 * fx(seeds[2]).D1 + v.X2 * fy(seeds[2]).D1 + v.X3 * fz(seeds[2]).D1;
+        result[0] = v.X1 * f1(seeds[0]).D1 + v.X2 * f2(seeds[0]).D1 + v.X3 * f3(seeds[0]).D1;
+        result[1] = v.X1 * f1(seeds[1]).D1 + v.X2 * f2(seeds[1]).D1 + v.X3 * f3(seeds[1]).D1;
+        result[2] = v.X1 * f1(seeds[2]).D1 + v.X2 * f2(seeds[2]).D1 + v.X3 * f3(seeds[2]).D1;
 
         return result;
     }

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector4`1.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector4`1.cs
@@ -1,0 +1,118 @@
+﻿// <copyright file="AutoDiffVector4`1.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a vector of four variables for use in reverse-mode automatic differentiation</summary>
+/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public record struct AutoDiffVector4<T>
+    where T : IComplex<T>
+{
+    /// <summary>The first element of the vector</summary>
+    public Variable<T> X1;
+
+    /// <summary>The second element of the vector</summary>
+    public Variable<T> X2;
+
+    /// <summary>The third element of the vector</summary>
+    public Variable<T> X3;
+
+    /// <summary>The fourth element of the vector</summary>
+    public Variable<T> X4;
+
+    public AutoDiffVector4(Variable<T> x1, Variable<T> x2, Variable<T> x3, Variable<T> x4)
+    {
+        X1 = x1;
+        X2 = x2;
+        X3 = x3;
+        X4 = x4;
+    }
+
+    //
+    // Indexer
+    //
+
+    /// <summary>Get the element at the specified index</summary>
+    /// <param name="index">An index</param>
+    /// <returns>The element at the index</returns>
+    public Variable<T> this[int index]
+    {
+        readonly get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static Variable<T> GetElement(AutoDiffVector4<T> vector, int index)
+    {
+        if ((uint)index >= 4)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Variable<T> GetElementUnsafe(ref AutoDiffVector4<T> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 4);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector4<T>, Variable<T>>(ref vector), index);
+    }
+
+    // Set
+
+    internal static AutoDiffVector4<T> WithElement(AutoDiffVector4<T> vector, int index, Variable<T> value)
+    {
+        if ((uint)index >= 4)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        AutoDiffVector4<T> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref AutoDiffVector4<T> vector, int index, Variable<T> value)
+    {
+        Debug.Assert(index is >= 0 and < 4);
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector4<T>, Variable<T>>(ref vector), index) = value;
+    }
+
+    //
+    // Formatting
+    //
+
+    public override readonly string ToString() => $"({X1}, {X2}, {X3}, {X4})";
+}

--- a/src/Mathematics.NET/AutoDiff/AutoDiffVector4`2.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffVector4`2.cs
@@ -1,0 +1,295 @@
+﻿// <copyright file="AutoDiffVector4`2.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mathematics.NET.LinearAlgebra;
+
+namespace Mathematics.NET.AutoDiff;
+
+/// <summary>Represents a vector of four dual numbers for use in forward-mode automatic differentiation</summary>
+/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
+/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+[StructLayout(LayoutKind.Sequential)]
+public record struct AutoDiffVector4<T, U>
+    where T : IDual<T, U>
+    where U : IComplex<U>, IDifferentiableFunctions<U>
+{
+    /// <summary>The first element of the vector</summary>
+    public T X1;
+
+    /// <summary>The second element of the vector</summary>
+    public T X2;
+
+    /// <summary>The third element of the vector</summary>
+    public T X3;
+
+    /// <summary>The fourth element of the vector</summary>
+    public T X4;
+
+    public AutoDiffVector4(T x1, T x2, T x3, T x4)
+    {
+        X1 = x1;
+        X2 = x2;
+        X3 = x3;
+        X4 = x4;
+    }
+
+    //
+    // Indexer
+    //
+
+    public T this[int index]
+    {
+        get => GetElement(this, index);
+        set => this = WithElement(this, index, value);
+    }
+
+    // Get
+
+    internal static T GetElement(AutoDiffVector4<T, U> vector, int index)
+    {
+        if ((uint)index >= 4)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        return GetElementUnsafe(ref vector, index);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T GetElementUnsafe(ref AutoDiffVector4<T, U> vector, int index)
+    {
+        Debug.Assert(index is >= 0 and < 4);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffVector4<T, U>, T>(ref vector), index);
+    }
+
+    // Set
+
+    internal static AutoDiffVector4<T, U> WithElement(AutoDiffVector4<T, U> vector, int index, T value)
+    {
+        if ((uint)index >= 4)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        AutoDiffVector4<T, U> result = vector;
+        SetElementUnsafe(ref result, index, value);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementUnsafe(ref AutoDiffVector4<T, U> vector, int index, T value)
+    {
+        Debug.Assert(index is >= 0 and < 4);
+        Unsafe.Add(ref Unsafe.As<AutoDiffVector4<T, U>, T>(ref vector), index) = value;
+    }
+
+    //
+    // Methods
+    //
+
+    //
+    // Vector Calculus
+    //
+
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.DirectionalDerivative(Vector2{U}, Func{AutoDiffVector2{T, U}, T}, AutoDiffVector2{T, U})"/>
+    public static U DirectionalDerivative(
+        Vector4<U> v,
+        Func<AutoDiffVector4<T, U>, T> f,
+        AutoDiffVector4<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<T, U>> seeds = [
+            new(x.X1.WithSeed(v.X1), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(v.X2), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(v.X3), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(v.X4))];
+
+        return f(seeds[0]).D1 + f(seeds[1]).D1 + f(seeds[2]).D1 + f(seeds[3]).D1;
+    }
+
+    /// <summary>Compute the divergence of a vector field using forward-mode automatic differentiation: $ (\nabla\cdot\textbf{F})(\textbf{x}) $.</summary>
+    /// <param name="f1">The first component of the vector field</param>
+    /// <param name="f2">The second component of the vector field</param>
+    /// <param name="f3">The third component of the vector field</param>
+    /// <param name="f4">The fourth component of the vector field</param>
+    /// <param name="x">The point at which to compute the divergence</param>
+    /// <returns>The divergence of the vector field</returns>
+    public static U Divergence(
+        Func<AutoDiffVector4<T, U>, T> f1,
+        Func<AutoDiffVector4<T, U>, T> f2,
+        Func<AutoDiffVector4<T, U>, T> f3,
+        Func<AutoDiffVector4<T, U>, T> f4,
+        AutoDiffVector4<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One))];
+
+        return f1(seeds[0]).D1 + f2(seeds[1]).D1 + f3(seeds[2]).D1 + f4(seeds[3]).D1;
+    }
+
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Gradient(Func{AutoDiffVector2{T, U}, T}, AutoDiffVector2{T, U})"/>
+    public static Vector4<U> Gradient(Func<AutoDiffVector4<T, U>, T> f, AutoDiffVector4<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One))];
+
+        return new(f(seeds[0]).D1, f(seeds[1]).D1, f(seeds[2]).D1, f(seeds[3]).D1);
+    }
+
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Hessian(Func{AutoDiffVector2{HyperDual{U}, U}, HyperDual{U}}, AutoDiffVector2{HyperDual{U}, U})"/>
+    public static Matrix4x4<U> Hessian(Func<AutoDiffVector4<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector4<HyperDual<U>, U> x)
+    {
+        Matrix4x4<U> result = new();
+
+        result[0, 0] = f(new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero))).D3;
+        result[1, 1] = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One, U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero))).D3;
+        result[2, 2] = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One, U.One), x.X4.WithSeed(U.Zero))).D3;
+        result[3, 3] = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One, U.One))).D3;
+
+        var e12 = f(new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero, U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)));
+        result[0, 1] = e12.D3; result[1, 0] = e12.D3;
+
+        var e13 = f(new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero, U.One), x.X4.WithSeed(U.Zero)));
+        result[0, 2] = e13.D3; result[2, 0] = e13.D3;
+
+        var e14 = f(new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero, U.One)));
+        result[0, 3] = e14.D3; result[3, 0] = e14.D3;
+
+        var e23 = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero, U.One), x.X4.WithSeed(U.Zero)));
+        result[1, 2] = e23.D3; result[2, 1] = e23.D3;
+
+        var e24 = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero, U.One)));
+        result[1, 3] = e24.D3; result[3, 1] = e24.D3;
+
+        var e34 = f(new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One), x.X4.WithSeed(U.Zero, U.One)));
+        result[2, 3] = e34.D3; result[3, 2] = e34.D3;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian of a vector function using forward-mode automatic differentiation: $ \nabla^\text{T}f_i(\textbf{x}) $ for $ i=\left\{1,2,3\right\} $.</summary>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the Jacobian</param>
+    /// <returns>The Jacobian of the vector function</returns>
+    public static Matrix4x4<U> Jacobian(
+        Func<AutoDiffVector4<T, U>, T> f1,
+        Func<AutoDiffVector4<T, U>, T> f2,
+        Func<AutoDiffVector4<T, U>, T> f3,
+        Func<AutoDiffVector4<T, U>, T> f4,
+        AutoDiffVector4<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One))];
+
+        Matrix4x4<U> result = new();
+
+        result[0, 0] = f1(seeds[0]).D1; result[0, 1] = f1(seeds[1]).D1; result[0, 2] = f1(seeds[2]).D1; result[0, 3] = f1(seeds[3]).D1;
+        result[1, 0] = f2(seeds[0]).D1; result[1, 1] = f2(seeds[1]).D1; result[1, 2] = f2(seeds[2]).D1; result[1, 3] = f2(seeds[3]).D1;
+        result[2, 0] = f3(seeds[0]).D1; result[2, 1] = f3(seeds[1]).D1; result[2, 2] = f3(seeds[2]).D1; result[2, 3] = f3(seeds[3]).D1;
+        result[3, 0] = f4(seeds[0]).D1; result[3, 1] = f4(seeds[1]).D1; result[3, 2] = f4(seeds[2]).D1; result[3, 3] = f4(seeds[3]).D1;
+
+        return result;
+    }
+
+    /// <summary>Compute the Jacobian-vector product of a vector function and a vector using forward-mode automatic differentiation.</summary>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the Jacobian-vector product</param>
+    /// <param name="v">A vector</param>
+    /// <returns>The Jacobian-vector product of the vector function and vector</returns>
+    public static Vector4<U> JVP(
+        Func<AutoDiffVector4<T, U>, T> f1,
+        Func<AutoDiffVector4<T, U>, T> f2,
+        Func<AutoDiffVector4<T, U>, T> f3,
+        Func<AutoDiffVector4<T, U>, T> f4,
+        AutoDiffVector4<T, U> x,
+        Vector4<U> v)
+    {
+        AutoDiffVector4<T, U> seed = new(x.X1.WithSeed(v.X1), x.X2.WithSeed(v.X2), x.X3.WithSeed(v.X3), x.X4.WithSeed(v.X4));
+        return new(f1(seed).D1, f2(seed).D1, f3(seed).D1, f4(seed).D1);
+    }
+
+    /// <inheritdoc cref="AutoDiffVector2{T, U}.Laplacian(Func{AutoDiffVector2{HyperDual{U}, U}, HyperDual{U}}, AutoDiffVector2{HyperDual{U}, U})"/>
+    public static U Laplacian(Func<AutoDiffVector4<HyperDual<U>, U>, HyperDual<U>> f, AutoDiffVector4<HyperDual<U>, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<HyperDual<U>, U>> seeds = [
+            new(x.X1.WithSeed(U.One, U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One, U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One, U.One), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One, U.One))];
+
+        return f(seeds[0]).D3 + f(seeds[1]).D3 + f(seeds[2]).D3 + f(seeds[3]).D3;
+    }
+
+    /// <summary>Compute the vector-Jacobian product of a vector and a vector function using forward-mode automatic differentiation.</summary>
+    /// <param name="v">A vector</param>
+    /// <param name="f1">The first function</param>
+    /// <param name="f2">The second function</param>
+    /// <param name="f3">The third function</param>
+    /// <param name="f4">The fourth function</param>
+    /// <param name="x">The point at which to compute the vector-Jacobian product</param>
+    /// <returns>The vector-Jacobian product of the vector and vector-function</returns>
+    public static Vector4<U> VJP(
+        Vector4<U> v,
+        Func<AutoDiffVector4<T, U>, T> f1,
+        Func<AutoDiffVector4<T, U>, T> f2,
+        Func<AutoDiffVector4<T, U>, T> f3,
+        Func<AutoDiffVector4<T, U>, T> f4,
+        AutoDiffVector4<T, U> x)
+    {
+        ReadOnlySpan<AutoDiffVector4<T, U>> seeds = [
+            new(x.X1.WithSeed(U.One), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.One), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.One), x.X4.WithSeed(U.Zero)),
+            new(x.X1.WithSeed(U.Zero), x.X2.WithSeed(U.Zero), x.X3.WithSeed(U.Zero), x.X4.WithSeed(U.One))];
+
+        Vector4<U> result = new();
+
+        result[0] = v.X1 * f1(seeds[0]).D1 + v.X2 * f2(seeds[0]).D1 + v.X3 * f3(seeds[0]).D1 + v.X4 * f4(seeds[0]).D1;
+        result[1] = v.X1 * f1(seeds[1]).D1 + v.X2 * f2(seeds[1]).D1 + v.X3 * f3(seeds[1]).D1 + v.X4 * f4(seeds[1]).D1;
+        result[2] = v.X1 * f1(seeds[2]).D1 + v.X2 * f2(seeds[2]).D1 + v.X3 * f3(seeds[2]).D1 + v.X4 * f4(seeds[2]).D1;
+        result[3] = v.X1 * f1(seeds[3]).D1 + v.X2 * f2(seeds[3]).D1 + v.X3 * f3(seeds[3]).D1 + v.X4 * f4(seeds[3]).D1;
+
+        return result;
+    }
+}

--- a/src/Mathematics.NET/AutoDiff/Dual.cs
+++ b/src/Mathematics.NET/AutoDiff/Dual.cs
@@ -242,6 +242,6 @@ public readonly struct Dual<T>(T d0, T d1) : IDual<Dual<T>, T>
     // Dual vector creation
     //
 
-    public static DualVector3<Dual<T>, T> CreateDualVector(Dual<T> x1Seed, Dual<T> x2Seed, Dual<T> x3Seed)
+    public static AutoDiffVector3<Dual<T>, T> CreateDualVector(Dual<T> x1Seed, Dual<T> x2Seed, Dual<T> x3Seed)
         => new(x1Seed, x2Seed, x3Seed);
 }

--- a/src/Mathematics.NET/AutoDiff/HyperDual.cs
+++ b/src/Mathematics.NET/AutoDiff/HyperDual.cs
@@ -256,6 +256,6 @@ public readonly struct HyperDual<T>(Dual<T> d0, Dual<T> d1) : IDual<HyperDual<T>
     // Dual vector creation
     //
 
-    public static DualVector3<HyperDual<T>, T> CreateDualVector(HyperDual<T> x1Seed, HyperDual<T> x2Seed, HyperDual<T> x3Seed)
+    public static AutoDiffVector3<HyperDual<T>, T> CreateDualVector(HyperDual<T> x1Seed, HyperDual<T> x2Seed, HyperDual<T> x3Seed)
         => new(x1Seed, x2Seed, x3Seed);
 }

--- a/src/Mathematics.NET/AutoDiff/HyperDual.cs
+++ b/src/Mathematics.NET/AutoDiff/HyperDual.cs
@@ -127,6 +127,10 @@ public readonly struct HyperDual<T>(Dual<T> d0, Dual<T> d1) : IDual<HyperDual<T>
 
     public HyperDual<T> WithSeed(T seed) => new(new(_d0.D0, seed));
 
+    /// <summary>Create a seeded instance of this type</summary>
+    /// <param name="e1Seed">The first seed</param>
+    /// <param name="e2Seed">The second seed</param>
+    /// <returns>A seeded value</returns>
     public HyperDual<T> WithSeed(T e1Seed, T e2Seed) => new(new(_d0.D0, e1Seed), new(e2Seed));
 
     // Exponential functions

--- a/src/Mathematics.NET/AutoDiff/IDual.cs
+++ b/src/Mathematics.NET/AutoDiff/IDual.cs
@@ -58,7 +58,7 @@ public interface IDual<T, U>
     /// <param name="x2Seed">The second seed value</param>
     /// <param name="x3Seed">The third seed value</param>
     /// <returns>A dual vector of length three</returns>
-    static abstract DualVector3<T, U> CreateDualVector(T x1Seed, T x2Seed, T x3Seed);
+    static abstract AutoDiffVector3<T, U> CreateDualVector(T x1Seed, T x2Seed, T x3Seed);
 
     /// <summary>Create an instance of the type with a specified value.</summary>
     /// <param name="value">A value</param>

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -35,8 +35,8 @@
       <PackagePath>\</PackagePath>
     </None>
     <None Update="README.md">
-        <Pack>True</Pack>
-        <PackagePath>\</PackagePath>
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Mathematics.NET.Benchmarks.Implementations"/>
+    <InternalsVisibleTo Include="Mathematics.NET.Benchmarks.Implementations" />
   </ItemGroup>
 
 </Project>

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -50,4 +50,8 @@
     <Using Include="Mathematics.NET.Core" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mathematics.NET.Benchmarks.Implementations"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
     <Title>Mathematics.NET</Title>
-    <Version>0.1.0-alpha.12</Version>
+    <Version>0.2.0-alpha.1</Version>
     <PackageIcon>mathematics.net.png</PackageIcon>
     <Authors>Hamlet Tanyavong</Authors>
     <Description>Mathematics.NET is a C# class library that provides tools for solving mathematical problems. Included are custom types for real, complex, and rational numbers as well as other mathematical objects such as vectors, matrices, and tensors. The library also contains methods for performing first and second-order, forward and reverse-mode automatic differentiation.</Description>

--- a/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
+++ b/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
@@ -1,0 +1,386 @@
+﻿// <copyright file="GradientTapeWithLinkedList.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+
+namespace Mathematics.NET.Benchmarks.Implementations.AutoDiff;
+
+// For small tapes, this seems to be slower. This may be different for large
+// tapes because of the way lists expand internally.
+
+public record class GradientTapeWithLinkedList<T> : ITape<T>
+    where T : IComplex<T>, IDifferentiableFunctions<T>
+{
+    private LinkedList<GradientNode<T>> _nodes;
+    private int _variableCount;
+
+    public GradientTapeWithLinkedList()
+    {
+        _nodes = [];
+    }
+
+    public int NodeCount => _nodes.Count;
+
+    public int VariableCount => _variableCount;
+
+    //
+    // Methods
+    //
+
+    public Variable<T> CreateVariable(T seed)
+    {
+        _nodes.AddLast(new GradientNode<T>(_variableCount));
+        Variable<T> variable = new(_variableCount++, seed);
+        return variable;
+    }
+
+    // There is no need to benchmark this.
+    public void PrintNodes(CancellationToken cancellationToken, int limit = 100)
+        => throw new NotImplementedException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient)
+        => ReverseAccumulation(out gradient, T.One);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public void ReverseAccumulation(out ReadOnlySpan<T> gradient, T seed)
+    {
+        if (_variableCount == 0)
+        {
+            throw new Exception("Gradient tape contains no root nodes");
+        }
+
+        var length = _nodes.Count;
+        Span<T> gradientSpan = new T[length];
+        gradientSpan[length - 1] = seed;
+
+#nullable disable
+        LinkedListNode<GradientNode<T>> current = _nodes.Last;
+        for (int i = length - 1; i >= _variableCount; i--)
+        {
+            var gradientElement = gradientSpan[i];
+
+            gradientSpan[current.Value.PX] += gradientElement * current.Value.DX;
+            gradientSpan[current.Value.PY] += gradientElement * current.Value.DY;
+            current = current.Previous;
+        }
+#nullable enable
+
+        gradient = gradientSpan[.._variableCount];
+    }
+
+    //
+    // Basic operations
+    //
+
+    public Variable<T> Add(Variable<T> x, Variable<T> y)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, T.One, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value + y.Value);
+    }
+
+    public Variable<T> Add(T c, Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c + x.Value);
+    }
+
+    public Variable<T> Add(Variable<T> x, T c)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value + c);
+    }
+
+    public Variable<T> Divide(Variable<T> x, Variable<T> y)
+    {
+        var u = T.One / y.Value;
+        _nodes.AddLast(new GradientNode<T>(T.One / y.Value, -x.Value * u * u, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value * u);
+    }
+
+    public Variable<T> Divide(T c, Variable<T> x)
+    {
+        var u = T.One / x.Value;
+        _nodes.AddLast(new GradientNode<T>(-c * u * u, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value * u);
+    }
+
+    public Variable<T> Divide(Variable<T> x, T c)
+    {
+        var u = T.One / c;
+        _nodes.AddLast(new GradientNode<T>(u, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value * u);
+    }
+
+    public Variable<Real> Modulo(Variable<Real> x, Variable<Real> y)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, x.Value * Real.Floor(x.Value / y.Value), x._index, y._index));
+        return new(_nodes.Count - 1, x.Value % y.Value);
+    }
+
+    public Variable<Real> Modulo(Real c, Variable<Real> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c % x.Value);
+    }
+
+    public Variable<Real> Modulo(Variable<Real> x, Real c)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value % c);
+    }
+
+    public Variable<T> Multiply(Variable<T> x, Variable<T> y)
+    {
+        _nodes.AddLast(new GradientNode<T>(y.Value, x.Value, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value * y.Value);
+    }
+
+    public Variable<T> Multiply(T c, Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(c, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c * x.Value);
+    }
+
+    public Variable<T> Multiply(Variable<T> x, T c)
+    {
+        _nodes.AddLast(new GradientNode<T>(c, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value * c);
+    }
+
+    public Variable<T> Subtract(Variable<T> x, Variable<T> y)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, -T.One, x._index, y._index));
+        return new(_nodes.Count - 1, x.Value - y.Value);
+    }
+
+    public Variable<T> Subtract(T c, Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(-T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, c - x.Value);
+    }
+
+    public Variable<T> Subtract(Variable<T> x, T c)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, x.Value - c);
+    }
+
+    //
+    // Other operations
+    //
+
+    public Variable<T> Negate(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(-T.One, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, -x.Value);
+    }
+
+    // Exponential functions
+
+    public Variable<T> Exp(Variable<T> x)
+    {
+        var exp = T.Exp(x.Value);
+        _nodes.AddLast(new GradientNode<T>(exp, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp);
+    }
+
+    public Variable<T> Exp2(Variable<T> x)
+    {
+        var exp2 = T.Exp2(x.Value);
+        _nodes.AddLast(new GradientNode<T>(Real.Ln2 * exp2, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp2);
+    }
+
+    public Variable<T> Exp10(Variable<T> x)
+    {
+        var exp10 = T.Exp10(x.Value);
+        _nodes.AddLast(new GradientNode<T>(Real.Ln10 * exp10, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, exp10);
+    }
+
+    // Hyperbolic functions
+
+    public Variable<T> Acosh(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Acosh(x.Value));
+    }
+
+    public Variable<T> Asinh(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(x.Value * x.Value + T.One), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Asinh(x.Value));
+    }
+
+    public Variable<T> Atanh(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / (T.One - x.Value * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Atanh(x.Value));
+    }
+
+    public Variable<T> Cosh(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.Sinh(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Cosh(x.Value));
+    }
+
+    public Variable<T> Sinh(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.Cosh(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Sinh(x.Value));
+    }
+
+    public Variable<T> Tanh(Variable<T> x)
+    {
+        var u = T.One / T.Cosh(x.Value);
+        _nodes.AddLast(new GradientNode<T>(u * u, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Tanh(x.Value));
+    }
+
+    // Logarithmic functions
+
+    public Variable<T> Ln(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / x.Value, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Ln(x.Value));
+    }
+
+    public Variable<T> Log(Variable<T> x, Variable<T> b)
+    {
+        var lnB = T.Ln(b.Value);
+        _nodes.AddLast(new GradientNode<T>(T.One / (x.Value * lnB), -T.Ln(x.Value) / (b.Value * lnB * lnB), x._index, b._index));
+        return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
+    }
+
+    public Variable<T> Log2(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln2 * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Log2(x.Value));
+    }
+
+    public Variable<T> Log10(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln10 * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Log10(x.Value));
+    }
+
+    // Power functions
+
+    public Variable<T> Pow(Variable<T> x, Variable<T> y)
+    {
+        var pow = T.Pow(x.Value, y.Value);
+        _nodes.AddLast(new GradientNode<T>(y.Value * T.Pow(x.Value, y.Value - T.One), T.Ln(x.Value) * pow, x._index, y._index));
+        return new(_nodes.Count - 1, pow);
+    }
+
+    // Root functions
+
+    public Variable<T> Cbrt(Variable<T> x)
+    {
+        var cbrt = T.Cbrt(x.Value);
+        _nodes.AddLast(new GradientNode<T>(T.One / (3.0 * cbrt * cbrt), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, cbrt);
+    }
+
+    public Variable<T> Root(Variable<T> x, Variable<T> n)
+    {
+        var root = T.Root(x.Value, n.Value);
+        _nodes.AddLast(new GradientNode<T>(root / (n.Value * x.Value), -T.Ln(x.Value) * root / (n.Value * n.Value), x._index, n._index));
+        return new(_nodes.Count - 1, root);
+    }
+
+    public Variable<T> Sqrt(Variable<T> x)
+    {
+        var sqrt = T.Sqrt(x.Value);
+        _nodes.AddLast(new GradientNode<T>(0.5 / sqrt, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, sqrt);
+    }
+
+    // Trigonometric functions
+
+    public Variable<T> Acos(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(-T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Acos(x.Value));
+    }
+
+    public Variable<T> Asin(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Asin(x.Value));
+    }
+
+    public Variable<T> Atan(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.One / (T.One + x.Value * x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Atan(x.Value));
+    }
+
+    public Variable<Real> Atan2(Variable<Real> y, Variable<Real> x)
+    {
+        var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
+        _nodes.AddLast(new GradientNode<T>(x.Value * u, -y.Value * u, y._index, x._index));
+        return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
+    }
+
+    public Variable<T> Cos(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(-T.Sin(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Cos(x.Value));
+    }
+
+    public Variable<T> Sin(Variable<T> x)
+    {
+        _nodes.AddLast(new GradientNode<T>(T.Cos(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Sin(x.Value));
+    }
+
+    public Variable<T> Tan(Variable<T> x)
+    {
+        var sec = T.One / T.Cos(x.Value);
+        _nodes.AddLast(new GradientNode<T>(sec * sec, x._index, _nodes.Count));
+        return new(_nodes.Count - 1, T.Tan(x.Value));
+    }
+
+    //
+    // Custom operations
+    //
+
+    public Variable<T> CustomOperation(Variable<T> x, Func<T, T> f, Func<T, T> df)
+    {
+        _nodes.AddLast(new GradientNode<T>(df(x.Value), x._index, _nodes.Count));
+        return new(_nodes.Count - 1, f(x.Value));
+    }
+
+    public Variable<T> CustomOperation(Variable<T> x, Variable<T> y, Func<T, T, T> f, Func<T, T, T> dfx, Func<T, T, T> dfy)
+    {
+        _nodes.AddLast(new GradientNode<T>(dfx(x.Value, y.Value), dfy(x.Value, y.Value), x._index, y._index));
+        return new(_nodes.Count - 1, f(x.Value, y.Value));
+    }
+}

--- a/tests/Mathematics.NET.Benchmarks/AutoDiff/GradientTapeBenchmarks.cs
+++ b/tests/Mathematics.NET.Benchmarks/AutoDiff/GradientTapeBenchmarks.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="GradientTapeBenchmarks.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Benchmarks.Implementations.AutoDiff;
+
+namespace Mathematics.NET.Benchmarks.AutoDiff;
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class GradientTapeBenchmarks
+{
+    public Real X { get; set; }
+    public Real Y { get; set; }
+    public Real Z { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        X = 1.23;
+        Y = 2.34;
+        Z = 3.45;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Real GradientTapeWithList()
+    {
+        GradientTape<Real> tape = new();
+
+        var x = tape.CreateVariable(1.23);
+        var y = tape.CreateVariable(2.34);
+        var z = tape.CreateVariable(3.45);
+
+        _ = tape.Sin(
+            tape.Multiply(
+                x,
+                tape.Ln(
+                    tape.Divide(
+                        tape.Sqrt(y), z))));
+
+        tape.ReverseAccumulation(out var gradient);
+        return gradient[0] + gradient[1] + gradient[2];
+    }
+
+    [Benchmark]
+    public Real GradientTapeWithLinkedList()
+    {
+        GradientTapeWithLinkedList<Real> tape = new();
+
+        var x = tape.CreateVariable(1.23);
+        var y = tape.CreateVariable(2.34);
+        var z = tape.CreateVariable(3.45);
+
+        _ = tape.Sin(
+            tape.Multiply(
+                x,
+                tape.Ln(
+                    tape.Divide(
+                        tape.Sqrt(y), z))));
+
+        tape.ReverseAccumulation(out var gradient);
+        return gradient[0] + gradient[1] + gradient[2];
+    }
+}

--- a/tests/Mathematics.NET.Tests/AutoDiff/AutoDiffVector3OfDualOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/AutoDiffVector3OfDualOfRealTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DualVector3OfHyperDualOfRealTests.cs" company="Mathematics.NET">
+﻿// <copyright file="AutoDiffVector3OfDualOfRealTests.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -32,17 +32,17 @@ namespace Mathematics.NET.Tests.AutoDiff;
 
 [TestClass]
 [TestCategory("AutoDiff"), TestCategory("Real Number")]
-public sealed class DualVector3OfHyperDualOfRealTests
+public sealed class AutoDiffVector3OfDualOfRealTests
 {
     [TestMethod]
     [TestCategory("Vector Calculus")]
     [DataRow(1.23, 0.66, 2.34, 1.954144178335244, -1.142124546272508, 0.820964086423733)]
     public void Curl_VectorField_ReturnsCurl(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.Curl(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.Curl(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -52,10 +52,10 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -0.801549048972843)]
     public void DirectionalDerivative_ScalarFunctionAndDirection_ReturnsDirectionalDerivative(double vx, double vy, double vz, double x, double y, double z, double expected)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.DirectionalDerivative(v, F, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.DirectionalDerivative(v, F, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -65,9 +65,9 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.3987010509910668)]
     public void Divergence_VectorField_ReturnsDivergence(double x, double y, double z, double expected)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
 
-        var actual = DualVector3<HyperDual<Real>, Real>.Divergence(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.Divergence(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -77,10 +77,10 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, -0.824313594924351, -0.1302345967828155, 0.2382974299363869)]
     public void Gradient_ScalarFunction_ReturnsGradient(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.Gradient(F, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.Gradient(F, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -90,13 +90,13 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(1.23, 0.66, 2.34)]
     public void Jacobian_R3VectorFunction_ReturnsJacobian(double x, double y, double z)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Matrix3x3<Real> expected = new(
             0.775330615737715, -0.5778557672605755, 0.3080621020764366,
             0.2431083191631576, 0.2431083191631576, 0.2431083191631576,
             1.450186648348945, 2.197252497498402, -0.6197378839098056);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.Jacobian(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.Jacobian(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -106,23 +106,11 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.23, 1.57, -1.71, -1.255693707530136, 0.0218797487246842, 4.842981131678516)]
     public void JVP_R3VectorFunctionAndVector_ReturnsJVP(double x, double y, double z, double vx, double vy, double vz, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.JVP(FX, FY, FZ, u, v);
-
-        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
-    }
-
-    [TestMethod]
-    [TestCategory("Vector Calculus")]
-    [DataRow(1.23, 0.66, 2.34, 1.471507039061705)]
-    public void Laplacian_ScalarFunction_ReturnsLaplacian(double x, double y, double z, double expected)
-    {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
-
-        var actual = DualVector3<HyperDual<Real>, Real>.Laplacian(F, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.JVP(FX, FY, FZ, u, v);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -132,11 +120,11 @@ public sealed class DualVector3OfHyperDualOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -1.919813065970865, -3.508528536106042, 1.512286126049506)]
     public void VJP_VectorAndR3VectorFunction_ReturnsVJP(double vx, double vy, double vz, double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+        AutoDiffVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<HyperDual<Real>, Real>.VJP(v, FX, FY, FZ, u);
+        var actual = AutoDiffVector3<Dual<Real>, Real>.VJP(v, FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -145,22 +133,22 @@ public sealed class DualVector3OfHyperDualOfRealTests
     // Helpers
     //
 
-    private static T F<T, U>(DualVector3<T, U> x)
+    private static T F<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Cos(x.X1) / ((x.X1 + x.X2) * T.Sin(x.X3));
 
-    private static T FX<T, U>(DualVector3<T, U> x)
+    private static T FX<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sin(x.X1) * (T.Cos(x.X2) + T.Sqrt(x.X3));
 
-    private static T FY<T, U>(DualVector3<T, U> x)
+    private static T FY<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sqrt(x.X1 + x.X2 + x.X3);
 
-    private static T FZ<T, U>(DualVector3<T, U> x)
+    private static T FZ<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sinh(T.Exp(x.X1) * x.X2 / x.X3);

--- a/tests/Mathematics.NET.Tests/AutoDiff/AutoDiffVector3OfHyperDualOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/AutoDiffVector3OfHyperDualOfRealTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DualVector3OfDualOfRealTests.cs" company="Mathematics.NET">
+﻿// <copyright file="AutoDiffVector3OfHyperDualOfRealTests.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -32,17 +32,17 @@ namespace Mathematics.NET.Tests.AutoDiff;
 
 [TestClass]
 [TestCategory("AutoDiff"), TestCategory("Real Number")]
-public sealed class DualVector3OfDualOfRealTests
+public sealed class AutoDiffVector3OfHyperDualOfRealTests
 {
     [TestMethod]
     [TestCategory("Vector Calculus")]
     [DataRow(1.23, 0.66, 2.34, 1.954144178335244, -1.142124546272508, 0.820964086423733)]
     public void Curl_VectorField_ReturnsCurl(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<Dual<Real>, Real>.Curl(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.Curl(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -52,10 +52,10 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -0.801549048972843)]
     public void DirectionalDerivative_ScalarFunctionAndDirection_ReturnsDirectionalDerivative(double vx, double vy, double vz, double x, double y, double z, double expected)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
 
-        var actual = DualVector3<Dual<Real>, Real>.DirectionalDerivative(v, F, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.DirectionalDerivative(v, F, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -65,9 +65,9 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.3987010509910668)]
     public void Divergence_VectorField_ReturnsDivergence(double x, double y, double z, double expected)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
 
-        var actual = DualVector3<Dual<Real>, Real>.Divergence(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.Divergence(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -77,10 +77,10 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, -0.824313594924351, -0.1302345967828155, 0.2382974299363869)]
     public void Gradient_ScalarFunction_ReturnsGradient(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<Dual<Real>, Real>.Gradient(F, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.Gradient(F, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -90,13 +90,13 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(1.23, 0.66, 2.34)]
     public void Jacobian_R3VectorFunction_ReturnsJacobian(double x, double y, double z)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Matrix3x3<Real> expected = new(
             0.775330615737715, -0.5778557672605755, 0.3080621020764366,
             0.2431083191631576, 0.2431083191631576, 0.2431083191631576,
             1.450186648348945, 2.197252497498402, -0.6197378839098056);
 
-        var actual = DualVector3<Dual<Real>, Real>.Jacobian(FX, FY, FZ, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.Jacobian(FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -106,11 +106,23 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.23, 1.57, -1.71, -1.255693707530136, 0.0218797487246842, 4.842981131678516)]
     public void JVP_R3VectorFunctionAndVector_ReturnsJVP(double x, double y, double z, double vx, double vy, double vz, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<Dual<Real>, Real>.JVP(FX, FY, FZ, u, v);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.JVP(FX, FY, FZ, u, v);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [TestCategory("Vector Calculus")]
+    [DataRow(1.23, 0.66, 2.34, 1.471507039061705)]
+    public void Laplacian_ScalarFunction_ReturnsLaplacian(double x, double y, double z, double expected)
+    {
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
+
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.Laplacian(F, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -120,11 +132,11 @@ public sealed class DualVector3OfDualOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -1.919813065970865, -3.508528536106042, 1.512286126049506)]
     public void VJP_VectorAndR3VectorFunction_ReturnsVJP(double vx, double vy, double vz, double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        DualVector3<Dual<Real>, Real> u = new(Dual<Real>.CreateVariable(x), Dual<Real>.CreateVariable(y), Dual<Real>.CreateVariable(z));
+        AutoDiffVector3<HyperDual<Real>, Real> u = new(HyperDual<Real>.CreateVariable(x), HyperDual<Real>.CreateVariable(y), HyperDual<Real>.CreateVariable(z));
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
-        var actual = DualVector3<Dual<Real>, Real>.VJP(v, FX, FY, FZ, u);
+        var actual = AutoDiffVector3<HyperDual<Real>, Real>.VJP(v, FX, FY, FZ, u);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -133,22 +145,22 @@ public sealed class DualVector3OfDualOfRealTests
     // Helpers
     //
 
-    private static T F<T, U>(DualVector3<T, U> x)
+    private static T F<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Cos(x.X1) / ((x.X1 + x.X2) * T.Sin(x.X3));
 
-    private static T FX<T, U>(DualVector3<T, U> x)
+    private static T FX<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sin(x.X1) * (T.Cos(x.X2) + T.Sqrt(x.X3));
 
-    private static T FY<T, U>(DualVector3<T, U> x)
+    private static T FY<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sqrt(x.X1 + x.X2 + x.X3);
 
-    private static T FZ<T, U>(DualVector3<T, U> x)
+    private static T FZ<T, U>(AutoDiffVector3<T, U> x)
         where T : IDual<T, U>
         where U : IComplex<U>, IDifferentiableFunctions<U>
         => T.Sinh(T.Exp(x.X1) * x.X2 / x.X3);

--- a/tests/Mathematics.NET.Tests/AutoDiff/TapeExtensionsOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/TapeExtensionsOfRealTests.cs
@@ -46,7 +46,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(1.23, 0.66, 2.34, 1.954144178335244, -1.142124546272508, 0.820964086423733)]
     public void Curl_VectorField_ReturnsCurl(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
         var actual = _tape.Curl(FX, FY, FZ, u);
@@ -59,7 +59,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -0.801549048972843)]
     public void DirectionalDerivative_ScalarFunctionAndDirection_ReturnsDirectionalDerivative(double vx, double vy, double vz, double x, double y, double z, double expected)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
         Vector3<Real> v = new(vx, vy, vz);
 
         var actual = _tape.DirectionalDerivative(v, F, u);
@@ -72,7 +72,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.3987010509910668)]
     public void Divergence_VectorField_ReturnsDivergence(double x, double y, double z, double expected)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
 
         var actual = _tape.Divergence(FX, FY, FZ, u);
 
@@ -84,7 +84,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(1.23, 0.66, 2.34, -0.824313594924351, -0.1302345967828155, 0.2382974299363869)]
     public void Gradient_ScalarFunction_ReturnsGradient(double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
         var actual = _tape.Gradient(F, u);
@@ -97,7 +97,7 @@ public sealed class TapeExtensionsOfRealTests
     public void Hessian_ScalarFunction_ReturnsHessian()
     {
         HessianTape<Real> tape = new();
-        var u = tape.CreateVariableVector(1.23, 0.66, 2.34);
+        var u = tape.CreateAutoDiffVector(1.23, 0.66, 2.34);
         Matrix3x3<Real> expected = new(
             0.6261461305189455, 0.5050519532842152, -0.7980381386329245,
             0.5050519532842152, 0.1378143881299635, -0.1260832962626385,
@@ -112,7 +112,7 @@ public sealed class TapeExtensionsOfRealTests
     [TestCategory("Vector Calculus")]
     public void Jacobian_R3VectorFunction_ReturnsJacobian()
     {
-        var u = _tape.CreateVariableVector(1.23, 0.66, 2.34);
+        var u = _tape.CreateAutoDiffVector(1.23, 0.66, 2.34);
         Matrix3x3<Real> expected = new(
             0.775330615737715, -0.5778557672605755, 0.3080621020764366,
             0.2431083191631576, 0.2431083191631576, 0.2431083191631576,
@@ -128,7 +128,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(1.23, 0.66, 2.34, 0.23, 1.57, -1.71, -1.255693707530136, 0.0218797487246842, 4.842981131678516)]
     public void JVP_R3VectorFunctionAndVector_ReturnsJVP(double x, double y, double z, double vx, double vy, double vz, double expectedX, double expectedY, double expectedZ)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
@@ -143,7 +143,7 @@ public sealed class TapeExtensionsOfRealTests
     public void Laplacian_ScalarFunction_ReturnsLaplacian(double x, double y, double z, double expected)
     {
         HessianTape<Real> tape = new();
-        var u = tape.CreateVariableVector(x, y, z);
+        var u = tape.CreateAutoDiffVector(x, y, z);
 
         var actual = tape.Laplacian(F, u);
 
@@ -155,7 +155,7 @@ public sealed class TapeExtensionsOfRealTests
     [DataRow(0.23, 1.57, -1.71, 1.23, 0.66, 2.34, -1.919813065970865, -3.508528536106042, 1.512286126049506)]
     public void VJP_VectorAndR3VectorFunction_ReturnsVJP(double vx, double vy, double vz, double x, double y, double z, double expectedX, double expectedY, double expectedZ)
     {
-        var u = _tape.CreateVariableVector(x, y, z);
+        var u = _tape.CreateAutoDiffVector(x, y, z);
         Vector3<Real> v = new(vx, vy, vz);
         Vector3<Real> expected = new(expectedX, expectedY, expectedZ);
 
@@ -169,7 +169,7 @@ public sealed class TapeExtensionsOfRealTests
     //
 
     // f(x, y, z) = Cos(x) / ((x + y) * Sin(z))
-    private static Variable<Real> F(ITape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> F(ITape<Real> tape, AutoDiffVector3<Real> x)
     {
         return tape.Divide(
             tape.Cos(x.X1),
@@ -179,7 +179,7 @@ public sealed class TapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sin(x) * (Cos(y) + Sqrt(z))
-    private static Variable<Real> FX(ITape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FX(ITape<Real> tape, AutoDiffVector3<Real> x)
     {
         return tape.Multiply(
             tape.Sin(x.X1),
@@ -189,7 +189,7 @@ public sealed class TapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sqrt(x + y + z)
-    private static Variable<Real> FY(ITape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FY(ITape<Real> tape, AutoDiffVector3<Real> x)
     {
         return tape.Sqrt(
             tape.Add(
@@ -200,7 +200,7 @@ public sealed class TapeExtensionsOfRealTests
     }
 
     // f(x, y, z) = Sinh(Exp(x) * y / z)
-    private static Variable<Real> FZ(ITape<Real> tape, VariableVector3<Real> x)
+    private static Variable<Real> FZ(ITape<Real> tape, AutoDiffVector3<Real> x)
     {
         return tape.Sinh(
             tape.Multiply(


### PR DESCRIPTION
- Rename `DualVector3<T, U>` to `AutoDiffVector3<T, U>`
- Rename `VariableVector3<T>` to `AutoDiffVector3<T>`
- Update methods, tests, and documentation comments that used the old names of autodiff vectors
- Make internals visible to benchmark implementations project
- Add benchmark for gradient tape with linked list
- Other minor changes