### PR TITLE
Rename tensors

### DIFF
--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -65,7 +65,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankOneTensor<Vector4<V>, V, I> Contract<T, U, V, IC, I>(
+    public static Tensor<Vector4<V>, V, I> Contract<T, U, V, IC, I>(
         IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>> a,
         IRankTwoTensor<U, Matrix4x4<V>, V, Index<Upper, IC>, I> b)
         where T : IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>>
@@ -86,7 +86,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorContractions]
-    public static RankOneTensor<Vector4<V>, V, I> Contract<T, U, V, IC, I>(
+    public static Tensor<Vector4<V>, V, I> Contract<T, U, V, IC, I>(
         IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I> a,
         IRankOneTensor<U, Vector4<V>, V, Index<Upper, IC>> b)
         where T : IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I>
@@ -111,7 +111,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankTwoTensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
+    public static Tensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
         IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>> a,
         IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> b)
         where T : IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>>
@@ -136,7 +136,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorContractions]
-    public static RankTwoTensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
+    public static Tensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
         IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a,
         IRankOneTensor<U, Vector4<V>, V, Index<Upper, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2>
@@ -165,7 +165,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
         IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>> a,
         IRankFourTensor<U, Array4x4x4x4<V>, V, Index<Upper, IC>, I1, I2, I3> b)
         where T : IRankOneTensor<T, Vector4<V>, V, Index<Lower, IC>>
@@ -194,7 +194,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorContractions]
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
         IRankFourTensor<T, Array4x4x4x4<V>, V, Index<Lower, IC>, I1, I2, I3> a,
         IRankOneTensor<U, Vector4<V>, V, Index<Upper, IC>> b)
         where T : IRankFourTensor<T, Array4x4x4x4<V>, V, Index<Lower, IC>, I1, I2, I3>
@@ -227,7 +227,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankTwoTensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
+    public static Tensor<Matrix4x4<V>, V, I1, I2> Contract<T, U, V, IC, I1, I2>(
         IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1> a,
         IRankTwoTensor<U, Matrix4x4<V>, V, Index<Upper, IC>, I2> b)
         where T : IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1>
@@ -256,7 +256,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
         IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1> a,
         IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I2, I3> b)
         where T : IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1>
@@ -285,7 +285,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorContractions]
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> Contract<T, U, V, IC, I1, I2, I3>(
         IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a,
         IRankTwoTensor<U, Matrix4x4<V>, V, Index<Upper, IC>, I3> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2>
@@ -318,7 +318,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
         IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1> a,
         IRankFourTensor<U, Array4x4x4x4<V>, V, Index<Upper, IC>, I2, I3, I4> b)
         where T : IRankTwoTensor<T, Matrix4x4<V>, V, Index<Lower, IC>, I1>
@@ -351,7 +351,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorContractions]
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
         IRankFourTensor<T, Array4x4x4x4<V>, V, Index<Lower, IC>, I1, I2, I3> a,
         IRankTwoTensor<U, Matrix2x2<V>, V, Index<Upper, IC>, I4> b)
         where T : IRankFourTensor<T, Array4x4x4x4<V>, V, Index<Lower, IC>, I1, I2, I3>
@@ -388,7 +388,7 @@ public static partial class DifGeo
     //
 
     [GenerateTensorContractions]
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
         IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a,
         IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2>
@@ -440,7 +440,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorSelfContractions]
-    public static RankOneTensor<Vector4<U>, U, I> Contract<T, U, IC, I>(IRankThreeTensor<T, Array4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I> a)
+    public static Tensor<Vector4<U>, U, I> Contract<T, U, IC, I>(IRankThreeTensor<T, Array4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I> a)
         where T : IRankThreeTensor<T, Array4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I>
         where U : IComplex<U>
         where IC : ISymbol
@@ -458,7 +458,7 @@ public static partial class DifGeo
     }
 
     [GenerateTensorSelfContractions]
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2>
         where U : IComplex<U>
         where IC : ISymbol
@@ -492,7 +492,7 @@ public static partial class DifGeo
     /// <param name="a">The first tensor</param>
     /// <param name="b">The second tensor</param>
     /// <returns>A rank-two tensor</returns>
-    public static RankTwoTensor<Matrix4x4<V>, V, I1, I2> TensorProduct<T, U, V, I1, I2>(IRankOneTensor<T, Vector4<V>, V, I1> a, IRankOneTensor<U, Vector4<V>, V, I2> b)
+    public static Tensor<Matrix4x4<V>, V, I1, I2> TensorProduct<T, U, V, I1, I2>(IRankOneTensor<T, Vector4<V>, V, I1> a, IRankOneTensor<U, Vector4<V>, V, I2> b)
         where T : IRankOneTensor<T, Vector4<V>, V, I1>
         where U : IRankOneTensor<U, Vector4<V>, V, I2>
         where V : IComplex<V>
@@ -520,7 +520,7 @@ public static partial class DifGeo
     /// <param name="a">A rank-one tensor</param>
     /// <param name="b">A rank-two tensor</param>
     /// <returns>A rank-three tensor</returns>
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> TensorProduct<T, U, V, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> TensorProduct<T, U, V, I1, I2, I3>(
         IRankOneTensor<T, Vector4<V>, V, I1> a,
         IRankTwoTensor<U, Matrix4x4<V>, V, I2, I3> b)
         where T : IRankOneTensor<T, Vector4<V>, V, I1>
@@ -554,7 +554,7 @@ public static partial class DifGeo
     /// <param name="a">A rank-two tensor</param>
     /// <param name="b">A rank-one tensor</param>
     /// <returns>A rank-three tensor</returns>
-    public static RankThreeTensor<Array4x4x4<V>, V, I1, I2, I3> TensorProduct<T, U, V, I1, I2, I3>(
+    public static Tensor<Array4x4x4<V>, V, I1, I2, I3> TensorProduct<T, U, V, I1, I2, I3>(
         IRankTwoTensor<T, Matrix4x4<V>, V, I1, I2> a,
         IRankOneTensor<U, Vector4<V>, V, I3> b)
         where T : IRankTwoTensor<T, Matrix4x4<V>, V, I1, I2>

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
@@ -45,8 +45,8 @@ namespace Mathematics.NET.DifferentialGeometry;
 [StructLayout(LayoutKind.Sequential)]
 public struct MetricTensor<T, U, V, W, X>(T matrix)
     : IRankTwoTensor<MetricTensor<T, U, V, W, X>, T, U, Index<V, W>, Index<V, X>>,
-      IAdditionOperation<MetricTensor<T, U, V, W, X>, RankTwoTensor<T, U, Index<V, W>, Index<V, X>>>,
-      ISubtractionOperation<MetricTensor<T, U, V, W, X>, RankTwoTensor<T, U, Index<V, W>, Index<V, X>>>
+      IAdditionOperation<MetricTensor<T, U, V, W, X>, Tensor<T, U, Index<V, W>, Index<V, X>>>,
+      ISubtractionOperation<MetricTensor<T, U, V, W, X>, Tensor<T, U, Index<V, W>, Index<V, X>>>
     where T : ISquareMatrix<T, U>
     where U : IComplex<U>
     where V : IIndexPosition
@@ -89,10 +89,10 @@ public struct MetricTensor<T, U, V, W, X>(T matrix)
     // Operators
     //
 
-    public static RankTwoTensor<T, U, Index<V, W>, Index<V, X>> operator +(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static Tensor<T, U, Index<V, W>, Index<V, X>> operator +(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
         => left._matrix + right._matrix;
 
-    public static RankTwoTensor<T, U, Index<V, W>, Index<V, X>> operator -(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static Tensor<T, U, Index<V, W>, Index<V, X>> operator -(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
         => left._matrix - right._matrix;
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RankOneTensor.cs" company="Mathematics.NET">
+﻿// <copyright file="Tensor`3.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -40,10 +40,10 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="V">An index</typeparam>
 /// <param name="vector">A backing vector</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct RankOneTensor<T, U, V>(T vector)
-    : IRankOneTensor<RankOneTensor<T, U, V>, T, U, V>,
-      IAdditionOperation<RankOneTensor<T, U, V>, RankOneTensor<T, U, V>>,
-      ISubtractionOperation<RankOneTensor<T, U, V>, RankOneTensor<T, U, V>>
+public struct Tensor<T, U, V>(T vector)
+    : IRankOneTensor<Tensor<T, U, V>, T, U, V>,
+      IAdditionOperation<Tensor<T, U, V>, Tensor<T, U, V>>,
+      ISubtractionOperation<Tensor<T, U, V>, Tensor<T, U, V>>
     where T : IVector<T, U>
     where U : IComplex<U>
     where V : IIndex
@@ -78,25 +78,25 @@ public struct RankOneTensor<T, U, V>(T vector)
     // Operators
     //
 
-    public static RankOneTensor<T, U, V> operator +(RankOneTensor<T, U, V> left, RankOneTensor<T, U, V> right)
+    public static Tensor<T, U, V> operator +(Tensor<T, U, V> left, Tensor<T, U, V> right)
         => new(left._vector + right._vector);
 
-    public static RankOneTensor<T, U, V> operator -(RankOneTensor<T, U, V> left, RankOneTensor<T, U, V> right)
+    public static Tensor<T, U, V> operator -(Tensor<T, U, V> left, Tensor<T, U, V> right)
         => new(left._vector - right._vector);
 
     //
     // Equality
     //
 
-    public static bool operator ==(RankOneTensor<T, U, V> left, RankOneTensor<T, U, V> right)
+    public static bool operator ==(Tensor<T, U, V> left, Tensor<T, U, V> right)
         => left._vector == right._vector;
 
-    public static bool operator !=(RankOneTensor<T, U, V> left, RankOneTensor<T, U, V> right)
+    public static bool operator !=(Tensor<T, U, V> left, Tensor<T, U, V> right)
         => left._vector != right._vector;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is RankOneTensor<T, U, V> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V> other && Equals(other);
 
-    public readonly bool Equals(RankOneTensor<T, U, V> value) => _vector.Equals(value._vector);
+    public readonly bool Equals(Tensor<T, U, V> value) => _vector.Equals(value._vector);
 
     public override readonly int GetHashCode() => HashCode.Combine(_vector);
 
@@ -114,13 +114,13 @@ public struct RankOneTensor<T, U, V>(T vector)
     /// <typeparam name="W">A new index</typeparam>
     /// <returns>A tensor with a new index</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankOneTensor<T, U, W> WithIndex<W>()
+    public Tensor<T, U, W> WithIndex<W>()
         where W : IIndex
-        => Unsafe.As<RankOneTensor<T, U, V>, RankOneTensor<T, U, W>>(ref this);
+        => Unsafe.As<Tensor<T, U, V>, Tensor<T, U, W>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator RankOneTensor<T, U, V>(T input) => new(input);
+    public static implicit operator Tensor<T, U, V>(T input) => new(input);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RankTwoTensor.cs" company="Mathematics.NET">
+﻿// <copyright file="Tensor`4.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -34,17 +34,17 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a rank-two tensors</summary>
+/// <summary>Represents a rank-two tensor</summary>
 /// <typeparam name="T">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
 /// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="V">The first index</typeparam>
 /// <typeparam name="W">The second index</typeparam>
 /// <param name="matrix">A backing matrix</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct RankTwoTensor<T, U, V, W>(T matrix)
-    : IRankTwoTensor<RankTwoTensor<T, U, V, W>, T, U, V, W>,
-      IAdditionOperation<RankTwoTensor<T, U, V, W>, RankTwoTensor<T, U, V, W>>,
-      ISubtractionOperation<RankTwoTensor<T, U, V, W>, RankTwoTensor<T, U, V, W>>
+public struct Tensor<T, U, V, W>(T matrix)
+    : IRankTwoTensor<Tensor<T, U, V, W>, T, U, V, W>,
+      IAdditionOperation<Tensor<T, U, V, W>, Tensor<T, U, V, W>>,
+      ISubtractionOperation<Tensor<T, U, V, W>, Tensor<T, U, V, W>>
     where T : ISquareMatrix<T, U>
     where U : IComplex<U>
     where V : IIndex
@@ -84,25 +84,25 @@ public struct RankTwoTensor<T, U, V, W>(T matrix)
     // Operators
     //
 
-    public static RankTwoTensor<T, U, V, W> operator +(RankTwoTensor<T, U, V, W> left, RankTwoTensor<T, U, V, W> right)
+    public static Tensor<T, U, V, W> operator +(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
         => left._matrix + right._matrix;
 
-    public static RankTwoTensor<T, U, V, W> operator -(RankTwoTensor<T, U, V, W> left, RankTwoTensor<T, U, V, W> right)
+    public static Tensor<T, U, V, W> operator -(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
         => left._matrix - right._matrix;
 
     //
     // Equality
     //
 
-    public static bool operator ==(RankTwoTensor<T, U, V, W> left, RankTwoTensor<T, U, V, W> right)
+    public static bool operator ==(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
         => left._matrix == right._matrix;
 
-    public static bool operator !=(RankTwoTensor<T, U, V, W> left, RankTwoTensor<T, U, V, W> right)
+    public static bool operator !=(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
         => left._matrix != right._matrix;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is RankTwoTensor<T, U, V, W> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W> other && Equals(other);
 
-    public readonly bool Equals(RankTwoTensor<T, U, V, W> value) => _matrix.Equals(value._matrix);
+    public readonly bool Equals(Tensor<T, U, V, W> value) => _matrix.Equals(value._matrix);
 
     public override readonly int GetHashCode() => HashCode.Combine(_matrix);
 
@@ -120,21 +120,21 @@ public struct RankTwoTensor<T, U, V, W>(T matrix)
     /// <typeparam name="X">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankTwoTensor<T, U, X, W> WithIndexOne<X>()
+    public Tensor<T, U, X, W> WithIndexOne<X>()
         where X : IIndex
-        => Unsafe.As<RankTwoTensor<T, U, V, W>, RankTwoTensor<T, U, X, W>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W>, Tensor<T, U, X, W>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
     /// <typeparam name="X">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankTwoTensor<T, U, V, X> WithIndexTwo<X>()
+    public Tensor<T, U, V, X> WithIndexTwo<X>()
         where X : IIndex
-        => Unsafe.As<RankTwoTensor<T, U, V, W>, RankTwoTensor<T, U, V, X>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W>, Tensor<T, U, V, X>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator RankTwoTensor<T, U, V, W>(T input) => new(input);
+    public static implicit operator Tensor<T, U, V, W>(T input) => new(input);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RankThreeTensor.cs" company="Mathematics.NET">
+﻿// <copyright file="Tensor`5.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -41,8 +41,8 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="X">The third index</typeparam>
 /// <param name="array">A backing array</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct RankThreeTensor<T, U, V, W, X>(T array)
-    : IRankThreeTensor<RankThreeTensor<T, U, V, W, X>, T, U, V, W, X>
+public struct Tensor<T, U, V, W, X>(T array)
+    : IRankThreeTensor<Tensor<T, U, V, W, X>, T, U, V, W, X>
     where T : ICubicArray<T, U>
     where U : IComplex<U>
     where V : IIndex
@@ -87,15 +87,15 @@ public struct RankThreeTensor<T, U, V, W, X>(T array)
     // Equality
     //
 
-    public static bool operator ==(RankThreeTensor<T, U, V, W, X> left, RankThreeTensor<T, U, V, W, X> right)
+    public static bool operator ==(Tensor<T, U, V, W, X> left, Tensor<T, U, V, W, X> right)
         => left._array == right._array;
 
-    public static bool operator !=(RankThreeTensor<T, U, V, W, X> left, RankThreeTensor<T, U, V, W, X> right)
+    public static bool operator !=(Tensor<T, U, V, W, X> left, Tensor<T, U, V, W, X> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is RankThreeTensor<T, U, V, W, X> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W, X> other && Equals(other);
 
-    public readonly bool Equals(RankThreeTensor<T, U, V, W, X> value) => _array.Equals(value._array);
+    public readonly bool Equals(Tensor<T, U, V, W, X> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -113,29 +113,29 @@ public struct RankThreeTensor<T, U, V, W, X>(T array)
     /// <typeparam name="Y">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankThreeTensor<T, U, Y, W, X> WithIndexOne<Y>()
+    public Tensor<T, U, Y, W, X> WithIndexOne<Y>()
         where Y : IIndex
-        => Unsafe.As<RankThreeTensor<T, U, V, W, X>, RankThreeTensor<T, U, Y, W, X>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, Y, W, X>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
     /// <typeparam name="Y">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankThreeTensor<T, U, V, Y, X> WithIndexTwo<Y>()
+    public Tensor<T, U, V, Y, X> WithIndexTwo<Y>()
         where Y : IIndex
-        => Unsafe.As<RankThreeTensor<T, U, V, W, X>, RankThreeTensor<T, U, V, Y, X>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, V, Y, X>>(ref this);
 
     /// <summary>Create a tensor with a new index in the third position.</summary>
     /// <typeparam name="Y">A new index</typeparam>
     /// <returns>A tensor with a new index in the third position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankThreeTensor<T, U, V, W, Y> WithIndexThree<Y>()
+    public Tensor<T, U, V, W, Y> WithIndexThree<Y>()
         where Y : IIndex
-        => Unsafe.As<RankThreeTensor<T, U, V, W, X>, RankThreeTensor<T, U, V, W, Y>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, V, W, Y>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator RankThreeTensor<T, U, V, W, X>(T value) => new(value);
+    public static implicit operator Tensor<T, U, V, W, X>(T value) => new(value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RankFourTensor.cs" company="Mathematics.NET">
+﻿// <copyright file="Tensor`6.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -42,8 +42,8 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="Y">The fourth index</typeparam>
 /// <param name="array">A backing array</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct RankFourTensor<T, U, V, W, X, Y>(T array)
-    : IRankFourTensor<RankFourTensor<T, U, V, W, X, Y>, T, U, V, W, X, Y>
+public struct Tensor<T, U, V, W, X, Y>(T array)
+    : IRankFourTensor<Tensor<T, U, V, W, X, Y>, T, U, V, W, X, Y>
     where T : IHyperCubic4DArray<T, U>
     where U : IComplex<U>
     where V : IIndex
@@ -93,15 +93,15 @@ public struct RankFourTensor<T, U, V, W, X, Y>(T array)
     // Equality
     //
 
-    public static bool operator ==(RankFourTensor<T, U, V, W, X, Y> left, RankFourTensor<T, U, V, W, X, Y> right)
+    public static bool operator ==(Tensor<T, U, V, W, X, Y> left, Tensor<T, U, V, W, X, Y> right)
     => left._array == right._array;
 
-    public static bool operator !=(RankFourTensor<T, U, V, W, X, Y> left, RankFourTensor<T, U, V, W, X, Y> right)
+    public static bool operator !=(Tensor<T, U, V, W, X, Y> left, Tensor<T, U, V, W, X, Y> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is RankFourTensor<T, U, V, W, X, Y> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W, X, Y> other && Equals(other);
 
-    public readonly bool Equals(RankFourTensor<T, U, V, W, X, Y> value) => _array.Equals(value._array);
+    public readonly bool Equals(Tensor<T, U, V, W, X, Y> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -119,37 +119,37 @@ public struct RankFourTensor<T, U, V, W, X, Y>(T array)
     /// <typeparam name="Z">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankFourTensor<T, U, Z, W, X, Y> WithIndexOne<Z>()
+    public Tensor<T, U, Z, W, X, Y> WithIndexOne<Z>()
         where Z : IIndex
-        => Unsafe.As<RankFourTensor<T, U, V, W, X, Y>, RankFourTensor<T, U, Z, W, X, Y>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, Z, W, X, Y>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
     /// <typeparam name="Z">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankFourTensor<T, U, V, Z, X, Y> WithIndexTwo<Z>()
+    public Tensor<T, U, V, Z, X, Y> WithIndexTwo<Z>()
         where Z : IIndex
-        => Unsafe.As<RankFourTensor<T, U, V, W, X, Y>, RankFourTensor<T, U, V, Z, X, Y>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, Z, X, Y>>(ref this);
 
     /// <summary>Create a tensor with a new index in the third position.</summary>
     /// <typeparam name="Z">A new index</typeparam>
     /// <returns>A tensor with a new index in the third position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankFourTensor<T, U, V, W, Z, Y> WithIndexThree<Z>()
+    public Tensor<T, U, V, W, Z, Y> WithIndexThree<Z>()
         where Z : IIndex
-        => Unsafe.As<RankFourTensor<T, U, V, W, X, Y>, RankFourTensor<T, U, V, W, Z, Y>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, W, Z, Y>>(ref this);
 
     /// <summary>Create a tensor with a new index in the fourth position.</summary>
     /// <typeparam name="Z">A new index</typeparam>
     /// <returns>A tensor with a new index in the fourth position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public RankFourTensor<T, U, V, W, X, Z> WithIndexFour<Z>()
+    public Tensor<T, U, V, W, X, Z> WithIndexFour<Z>()
         where Z : IIndex
-        => Unsafe.As<RankFourTensor<T, U, V, W, X, Y>, RankFourTensor<T, U, V, W, X, Z>>(ref this);
+        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, W, X, Z>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator RankFourTensor<T, U, V, W, X, Y>(T value) => new(value);
+    public static implicit operator Tensor<T, U, V, W, X, Y>(T value) => new(value);
 }

--- a/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/Snapshots/TensorContractionGeneratorTests.SourceGenerator_RankThreeTensors_GeneratesContractions#DifGeo.Contractions.g.verified.cs
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/Snapshots/TensorContractionGeneratorTests.SourceGenerator_RankThreeTensors_GeneratesContractions#DifGeo.Contractions.g.verified.cs
@@ -7,7 +7,7 @@ using Mathematics.NET.Symbols;
 namespace Mathematics.NET.DifferentialGeometry;
 public static partial class DifGeo
 {
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -31,7 +31,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -55,7 +55,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -79,7 +79,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -103,7 +103,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Upper, IC>, I1, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -127,7 +127,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -151,7 +151,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -175,7 +175,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -199,7 +199,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -223,7 +223,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Lower, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -247,7 +247,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, Index<Upper, IC>, I2> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -271,7 +271,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -295,7 +295,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, Index<Lower, IC>, I3, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -319,7 +319,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Upper, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -343,7 +343,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, Index<Lower, IC>, I4> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -367,7 +367,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Lower, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Upper, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();
@@ -391,7 +391,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
+    public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> a, IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> b)
         where T : IRankThreeTensor<T, Array4x4x4<V>, V, I1, I2, Index<Upper, IC>> where U : IRankThreeTensor<U, Array4x4x4<V>, V, I3, I4, Index<Lower, IC>> where V : IComplex<V> where IC : ISymbol where I1 : IIndex where I2 : IIndex where I3 : IIndex where I4 : IIndex
     {
         Array4x4x4x4<V> array = new();

--- a/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/Snapshots/TensorSelfContractionGeneratorTests.SourceGenerator_RankFourTensor_GeneratesSelfContractions#DifGeo.SelfContractions.g.verified.cs
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/Snapshots/TensorSelfContractionGeneratorTests.SourceGenerator_RankFourTensor_GeneratesSelfContractions#DifGeo.SelfContractions.g.verified.cs
@@ -7,7 +7,7 @@ using Mathematics.NET.Symbols;
 namespace Mathematics.NET.DifferentialGeometry;
 public static partial class DifGeo
 {
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, Index<Lower, IC>, I1, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, Index<Lower, IC>, I1, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, Index<Lower, IC>, I1, I2> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -25,7 +25,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, Index<Upper, IC>, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, Index<Upper, IC>, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, Index<Upper, IC>, I2> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -43,7 +43,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, Index<Lower, IC>, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, Index<Lower, IC>, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, Index<Lower, IC>, I2> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -61,7 +61,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, I2, Index<Upper, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, I2, Index<Upper, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, I1, I2, Index<Upper, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -79,7 +79,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, I2, Index<Lower, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, I2, Index<Lower, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Upper, IC>, I1, I2, Index<Lower, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -97,7 +97,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, Index<Upper, IC>, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, Index<Upper, IC>, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, Index<Upper, IC>, I2> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -115,7 +115,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, Index<Lower, IC>, I2> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, Index<Lower, IC>, I2> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, Index<Lower, IC>, I2> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -133,7 +133,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, I2, Index<Upper, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, I2, Index<Upper, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Lower, IC>, I2, Index<Upper, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -151,7 +151,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, I2, Index<Lower, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, I2, Index<Lower, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, Index<Upper, IC>, I2, Index<Lower, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -169,7 +169,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Lower, IC>, Index<Upper, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Lower, IC>, Index<Upper, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Lower, IC>, Index<Upper, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();
@@ -187,7 +187,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Upper, IC>, Index<Lower, IC>> a)
+    public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Upper, IC>, Index<Lower, IC>> a)
         where T : IRankFourTensor<T, Array4x4x4x4<U>, U, I1, I2, Index<Upper, IC>, Index<Lower, IC>> where U : IComplex<U> where IC : ISymbol where I1 : IIndex where I2 : IIndex
     {
         Matrix4x4<U> matrix = new();

--- a/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/TensorContractionGeneratorTests.cs
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/TensorContractionGeneratorTests.cs
@@ -41,7 +41,7 @@ public sealed class TensorContractionGeneratorTests : VerifyBase
             namespace TestNamespace;
 
             [GenerateTensorContractions]
-            public static RankFourTensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
+            public static Tensor<Array4x4x4x4<V>, V, I1, I2, I3, I4> Contract<T, U, V, IC, I1, I2, I3, I4>(
                 IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2> a,
                 IRankThreeTensor<U, Array4x4x4<V>, V, Index<Upper, IC>, I3, I4> b)
                 where T : IRankThreeTensor<T, Array4x4x4<V>, V, Index<Lower, IC>, I1, I2>

--- a/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/TensorSelfContractionGeneratorTests.cs
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/DifferentialGeometry/TensorSelfContractionGeneratorTests.cs
@@ -41,7 +41,7 @@ public sealed class TensorSelfContractionGeneratorTests : VerifyBase
             namespace TestNamespace;
 
             [GenerateTensorSelfContractions]
-            public static RankTwoTensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2> a)
+            public static Tensor<Matrix4x4<U>, U, I1, I2> Contract<T, U, IC, I1, I2>(IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2> a)
                 where T : IRankFourTensor<T, Array4x4x4x4<U>, U, Index<Lower, IC>, Index<Upper, IC>, I1, I2>
                 where U : IComplex<U>
                 where IC : ISymbol


### PR DESCRIPTION
- Rename tensor structs to `Tensor` for simplicity
- Update tests
- Fix documentation comment for rank-two tensors