### PR TITLE
Make changes to gradient and Hessian tapes regarding performance

### DIFF
--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -58,6 +58,8 @@
 //
 //     ╳────╳ '*', '+', '%', etc. and constant ──── Result
 
+#pragma warning disable IDE0032
+
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -68,14 +70,17 @@ namespace Mathematics.NET.AutoDiff;
 public record class GradientTape<T> : ITape<T>
     where T : IComplex<T>, IDifferentiableFunctions<T>
 {
-    // TODO: Measure performance with Stack<Node<T>> instead of List<Node<T>>
-    // TODO: Consider using array pools or something similar
     private List<GradientNode<T>> _nodes;
     private int _variableCount;
 
     public GradientTape()
     {
         _nodes = [];
+    }
+
+    public GradientTape(int n)
+    {
+        _nodes = new(n);
     }
 
     public int NodeCount => _nodes.Count;
@@ -134,11 +139,9 @@ public record class GradientTape<T> : ITape<T>
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient)
         => ReverseAccumulate(out gradient, T.One);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed)
     {
         if (_variableCount == 0)

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -25,6 +25,8 @@
 // SOFTWARE.
 // </copyright>
 
+#pragma warning disable IDE0032
+
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -38,9 +40,17 @@ public record class HessianTape<T> : ITape<T>
     private List<HessianNode<T>> _nodes;
     private int _variableCount;
 
+    /// <summary>Create an instance of a Hessian tape.</summary>
     public HessianTape()
     {
         _nodes = [];
+    }
+
+    /// <summary>Create an instance of a Hessian tape that will hold an expected number of nodes.</summary>
+    /// <param name="n">An integer</param>
+    public HessianTape(int n)
+    {
+        _nodes = new(n);
     }
 
     public int NodeCount => _nodes.Count;
@@ -101,14 +111,12 @@ public record class HessianTape<T> : ITape<T>
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient)
         => ReverseAccumulate(out gradient, T.One);
 
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting Hessian.</summary>
     /// <param name="hessian">The Hessian</param>
     /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan2D<T> hessian)
         => ReverseAccumulate(out hessian, T.One);
 
@@ -116,11 +124,9 @@ public record class HessianTape<T> : ITape<T>
     /// <param name="gradient">The gradient</param>
     /// <param name="hessian">The Hessian</param>
     /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian)
         => ReverseAccumulate(out gradient, out hessian, T.One);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed)
     {
         if (_variableCount == 0)
@@ -151,7 +157,6 @@ public record class HessianTape<T> : ITape<T>
     /// <param name="hessian">The Hessian</param>
     /// <param name="seed">A seed value</param>
     /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan2D<T> hessian, T seed)
     {
         if (_variableCount == 0)
@@ -194,7 +199,6 @@ public record class HessianTape<T> : ITape<T>
     /// <param name="hessian">The Hessian</param>
     /// <param name="seed">A seed value</param>
     /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian, T seed)
     {
         if (_variableCount == 0)

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -174,7 +174,10 @@ public record class HessianTape<T> : ITape<T>
             var gradientElement = gradientSpan[i];
 
             EdgePush(hessianSpan, in node, i);
-            Accumulate(hessianSpan, in node, gradientElement);
+            if (gradientElement != T.Zero)
+            {
+                Accumulate(hessianSpan, in node, gradientElement);
+            }
 
             gradientSpan[node.PX] += gradientElement * node.DX;
             gradientSpan[node.PY] += gradientElement * node.DY;
@@ -185,7 +188,6 @@ public record class HessianTape<T> : ITape<T>
 
     // The following method uses the edge-pushing algorithm outlined by Gower and Mello: https://arxiv.org/pdf/2007.15040.pdf.
     // TODO: use newer variations/versions of this algorithm since they are more performant
-    // TODO: consider creating an overload that computes only the diagonal components of Hessians
 
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting gradient and Hessian.</summary>
     /// <param name="gradient">The gradient</param>
@@ -215,7 +217,10 @@ public record class HessianTape<T> : ITape<T>
             var gradientElement = gradientSpan[i];
 
             EdgePush(hessianSpan, in node, i);
-            Accumulate(hessianSpan, in node, gradientElement);
+            if (gradientElement != T.Zero)
+            {
+                Accumulate(hessianSpan, in node, gradientElement);
+            }
 
             gradientSpan[node.PX] += gradientElement * node.DX;
             gradientSpan[node.PY] += gradientElement * node.DY;


### PR DESCRIPTION
- `ReverseAccumulate` will no longer call `Accumulate` when `gradientElement` is zero.
- This update also removes method implementation attributes from `ReverseAccumulate` methods; benchmarks should be made to see if these are necessary.
- Disable code style warnings
- Remove TODOs