### PR TITLE
Add node tracking functionality

### DIFF
--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -70,18 +70,23 @@ namespace Mathematics.NET.AutoDiff;
 public record class GradientTape<T> : ITape<T>
     where T : IComplex<T>, IDifferentiableFunctions<T>
 {
+    private bool _isTracking;
     private List<GradientNode<T>> _nodes;
     private int _variableCount;
 
-    public GradientTape()
+    public GradientTape(bool isTracking = true)
     {
         _nodes = [];
+        _isTracking = isTracking;
     }
 
-    public GradientTape(int n)
+    public GradientTape(int n, bool isTracking = true)
     {
         _nodes = new(n);
+        _isTracking = isTracking;
     }
+
+    public bool IsTracking { get => _isTracking; set => _isTracking = false; }
 
     public int NodeCount => _nodes.Count;
 
@@ -174,95 +179,155 @@ public record class GradientTape<T> : ITape<T>
 
     public Variable<T> Add(Variable<T> x, Variable<T> y)
     {
-        _nodes.Add(new(T.One, T.One, x._index, y._index));
-        return new(_nodes.Count - 1, x.Value + y.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, T.One, x._index, y._index));
+            return new(_nodes.Count - 1, x.Value + y.Value);
+        }
+        return new(_nodes.Count, x.Value + y.Value);
     }
 
     public Variable<T> Add(T c, Variable<T> x)
     {
-        _nodes.Add(new(T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, c + x.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, c + x.Value);
+        }
+        return new(_nodes.Count, c + x.Value);
     }
 
     public Variable<T> Add(Variable<T> x, T c)
     {
-        _nodes.Add(new(T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value + c);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value + c);
+        }
+        return new(_nodes.Count, x.Value + c);
     }
 
     public Variable<T> Divide(Variable<T> x, Variable<T> y)
     {
         var u = T.One / y.Value;
-        _nodes.Add(new(T.One / y.Value, -x.Value * u * u, x._index, y._index));
-        return new(_nodes.Count - 1, x.Value * u);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / y.Value, -x.Value * u * u, x._index, y._index));
+            return new(_nodes.Count - 1, x.Value * u);
+        }
+        return new(_nodes.Count, x.Value * u);
     }
 
     public Variable<T> Divide(T c, Variable<T> x)
     {
         var u = T.One / x.Value;
-        _nodes.Add(new(-c * u * u, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value * u);
+        if (_isTracking)
+        {
+            _nodes.Add(new(-c * u * u, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, c * u);
+        }
+        return new(_nodes.Count, c * u);
     }
 
     public Variable<T> Divide(Variable<T> x, T c)
     {
         var u = T.One / c;
-        _nodes.Add(new(u, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value * u);
+        if (_isTracking)
+        {
+            _nodes.Add(new(u, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value * u);
+        }
+        return new(_nodes.Count, x.Value * u);
     }
 
     public Variable<Real> Modulo(Variable<Real> x, Variable<Real> y)
     {
-        _nodes.Add(new(T.One, x.Value * Real.Floor(x.Value / y.Value), x._index, y._index));
-        return new(_nodes.Count - 1, x.Value % y.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, x.Value * Real.Floor(x.Value / y.Value), x._index, y._index));
+            return new(_nodes.Count - 1, x.Value % y.Value);
+        }
+        return new(_nodes.Count, x.Value % y.Value);
     }
 
     public Variable<Real> Modulo(Real c, Variable<Real> x)
     {
-        _nodes.Add(new(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, c % x.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, c % x.Value);
+        }
+        return new(_nodes.Count, c % x.Value);
     }
 
     public Variable<Real> Modulo(Variable<Real> x, Real c)
     {
-        _nodes.Add(new(T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value % c);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value % c);
+        }
+        return new(_nodes.Count, x.Value % c);
     }
 
     public Variable<T> Multiply(Variable<T> x, Variable<T> y)
     {
-        _nodes.Add(new(y.Value, x.Value, x._index, y._index));
-        return new(_nodes.Count - 1, x.Value * y.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(y.Value, x.Value, x._index, y._index));
+            return new(_nodes.Count - 1, x.Value * y.Value);
+        }
+        return new(_nodes.Count, x.Value * y.Value);
     }
 
     public Variable<T> Multiply(T c, Variable<T> x)
     {
-        _nodes.Add(new(c, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, c * x.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(c, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, c * x.Value);
+        }
+        return new(_nodes.Count, c * x.Value);
     }
 
     public Variable<T> Multiply(Variable<T> x, T c)
     {
-        _nodes.Add(new(c, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value * c);
+        if (_isTracking)
+        {
+            _nodes.Add(new(c, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value * c);
+        }
+        return new(_nodes.Count, x.Value * c);
     }
 
     public Variable<T> Subtract(Variable<T> x, Variable<T> y)
     {
-        _nodes.Add(new(T.One, -T.One, x._index, y._index));
-        return new(_nodes.Count - 1, x.Value - y.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, -T.One, x._index, y._index));
+            return new(_nodes.Count - 1, x.Value - y.Value);
+        }
+        return new(_nodes.Count, x.Value - y.Value);
     }
 
     public Variable<T> Subtract(T c, Variable<T> x)
     {
-        _nodes.Add(new(-T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, c - x.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(-T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, c - x.Value);
+        }
+        return new(_nodes.Count, c - x.Value);
     }
 
     public Variable<T> Subtract(Variable<T> x, T c)
     {
-        _nodes.Add(new(T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, x.Value - c);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value - c);
+        }
+        return new(_nodes.Count, x.Value - c);
     }
 
     //
@@ -271,8 +336,12 @@ public record class GradientTape<T> : ITape<T>
 
     public Variable<T> Negate(Variable<T> x)
     {
-        _nodes.Add(new(-T.One, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, -x.Value);
+        if (_isTracking)
+        {
+            _nodes.Add(new(-T.One, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, -x.Value);
+        }
+        return new(_nodes.Count, -x.Value);
     }
 
     // Exponential functions
@@ -280,88 +349,140 @@ public record class GradientTape<T> : ITape<T>
     public Variable<T> Exp(Variable<T> x)
     {
         var exp = T.Exp(x.Value);
-        _nodes.Add(new(exp, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, exp);
+        if (_isTracking)
+        {
+            _nodes.Add(new(exp, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, exp);
+        }
+        return new(_nodes.Count, exp);
     }
 
     public Variable<T> Exp2(Variable<T> x)
     {
         var exp2 = T.Exp2(x.Value);
-        _nodes.Add(new(Real.Ln2 * exp2, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, exp2);
+        if (_isTracking)
+        {
+            _nodes.Add(new(Real.Ln2 * exp2, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, exp2);
+        }
+        return new(_nodes.Count, exp2);
     }
 
     public Variable<T> Exp10(Variable<T> x)
     {
         var exp10 = T.Exp10(x.Value);
-        _nodes.Add(new(Real.Ln10 * exp10, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, exp10);
+        if (_isTracking)
+        {
+            _nodes.Add(new(Real.Ln10 * exp10, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, exp10);
+        }
+        return new(_nodes.Count, exp10);
     }
 
     // Hyperbolic functions
 
     public Variable<T> Acosh(Variable<T> x)
     {
-        _nodes.Add(new(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Acosh(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Acosh(x.Value));
+        }
+        return new(_nodes.Count, T.Acosh(x.Value));
     }
 
     public Variable<T> Asinh(Variable<T> x)
     {
-        _nodes.Add(new(T.One / T.Sqrt(x.Value * x.Value + T.One), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Asinh(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / T.Sqrt(x.Value * x.Value + T.One), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Asinh(x.Value));
+        }
+        return new(_nodes.Count, T.Asinh(x.Value));
     }
 
     public Variable<T> Atanh(Variable<T> x)
     {
-        _nodes.Add(new(T.One / (T.One - x.Value * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Atanh(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (T.One - x.Value * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Atanh(x.Value));
+        }
+        return new(_nodes.Count, T.Atanh(x.Value));
     }
 
     public Variable<T> Cosh(Variable<T> x)
     {
-        _nodes.Add(new(T.Sinh(x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Cosh(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.Sinh(x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Cosh(x.Value));
+        }
+        return new(_nodes.Count, T.Cosh(x.Value));
     }
 
     public Variable<T> Sinh(Variable<T> x)
     {
-        _nodes.Add(new(T.Cosh(x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Sinh(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.Cosh(x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Sinh(x.Value));
+        }
+        return new(_nodes.Count, T.Sinh(x.Value));
     }
 
     public Variable<T> Tanh(Variable<T> x)
     {
-        var u = T.One / T.Cosh(x.Value);
-        _nodes.Add(new(u * u, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Tanh(x.Value));
+        if (_isTracking)
+        {
+            var u = T.One / T.Cosh(x.Value);
+            _nodes.Add(new(u * u, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Tanh(x.Value));
+        }
+        return new(_nodes.Count, T.Tanh(x.Value));
     }
 
     // Logarithmic functions
 
     public Variable<T> Ln(Variable<T> x)
     {
-        _nodes.Add(new(T.One / x.Value, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Ln(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / x.Value, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Ln(x.Value));
+        }
+        return new(_nodes.Count, T.Ln(x.Value));
     }
 
     public Variable<T> Log(Variable<T> x, Variable<T> b)
     {
-        var lnB = T.Ln(b.Value);
-        _nodes.Add(new(T.One / (x.Value * lnB), -T.Ln(x.Value) / (b.Value * lnB * lnB), x._index, b._index));
-        return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
+        if (_isTracking)
+        {
+            var lnB = T.Ln(b.Value);
+            _nodes.Add(new(T.One / (x.Value * lnB), -T.Ln(x.Value) / (b.Value * lnB * lnB), x._index, b._index));
+            return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
+        }
+        return new(_nodes.Count, T.Log(x.Value, b.Value));
     }
 
     public Variable<T> Log2(Variable<T> x)
     {
-        _nodes.Add(new(T.One / (Real.Ln2 * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Log2(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (Real.Ln2 * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Log2(x.Value));
+        }
+        return new(_nodes.Count, T.Log2(x.Value));
     }
 
     public Variable<T> Log10(Variable<T> x)
     {
-        _nodes.Add(new(T.One / (Real.Ln10 * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Log10(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (Real.Ln10 * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Log10(x.Value));
+        }
+        return new(_nodes.Count, T.Log10(x.Value));
     }
 
     // Power functions
@@ -369,8 +490,12 @@ public record class GradientTape<T> : ITape<T>
     public Variable<T> Pow(Variable<T> x, Variable<T> y)
     {
         var pow = T.Pow(x.Value, y.Value);
-        _nodes.Add(new(y.Value * T.Pow(x.Value, y.Value - T.One), T.Ln(x.Value) * pow, x._index, y._index));
-        return new(_nodes.Count - 1, pow);
+        if (_isTracking)
+        {
+            _nodes.Add(new(y.Value * T.Pow(x.Value, y.Value - T.One), T.Ln(x.Value) * pow, x._index, y._index));
+            return new(_nodes.Count - 1, pow);
+        }
+        return new(_nodes.Count, pow);
     }
 
     // Root functions
@@ -378,68 +503,108 @@ public record class GradientTape<T> : ITape<T>
     public Variable<T> Cbrt(Variable<T> x)
     {
         var cbrt = T.Cbrt(x.Value);
-        _nodes.Add(new(T.One / (3.0 * cbrt * cbrt), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, cbrt);
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (3.0 * cbrt * cbrt), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, cbrt);
+        }
+        return new(_nodes.Count, cbrt);
     }
 
     public Variable<T> Root(Variable<T> x, Variable<T> n)
     {
         var root = T.Root(x.Value, n.Value);
-        _nodes.Add(new(root / (n.Value * x.Value), -T.Ln(x.Value) * root / (n.Value * n.Value), x._index, n._index));
-        return new(_nodes.Count - 1, root);
+        if (_isTracking)
+        {
+            _nodes.Add(new(root / (n.Value * x.Value), -T.Ln(x.Value) * root / (n.Value * n.Value), x._index, n._index));
+            return new(_nodes.Count - 1, root);
+        }
+        return new(_nodes.Count, root);
     }
 
     public Variable<T> Sqrt(Variable<T> x)
     {
         var sqrt = T.Sqrt(x.Value);
-        _nodes.Add(new(0.5 / sqrt, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, sqrt);
+        if (_isTracking)
+        {
+            _nodes.Add(new(0.5 / sqrt, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, sqrt);
+        }
+        return new(_nodes.Count, sqrt);
     }
 
     // Trigonometric functions
 
     public Variable<T> Acos(Variable<T> x)
     {
-        _nodes.Add(new(-T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Acos(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(-T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Acos(x.Value));
+        }
+        return new(_nodes.Count, T.Acos(x.Value));
     }
 
     public Variable<T> Asin(Variable<T> x)
     {
-        _nodes.Add(new(T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Asin(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Asin(x.Value));
+        }
+        return new(_nodes.Count, T.Asin(x.Value));
     }
 
     public Variable<T> Atan(Variable<T> x)
     {
-        _nodes.Add(new(T.One / (T.One + x.Value * x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Atan(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.One / (T.One + x.Value * x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Atan(x.Value));
+        }
+        return new(_nodes.Count, T.Atan(x.Value));
     }
 
     public Variable<Real> Atan2(Variable<Real> y, Variable<Real> x)
     {
-        var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
-        _nodes.Add(new(x.Value * u, -y.Value * u, y._index, x._index));
-        return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
+        if (_isTracking)
+        {
+            var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
+            _nodes.Add(new(x.Value * u, -y.Value * u, y._index, x._index));
+            return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
+        }
+        return new(_nodes.Count, Real.Atan2(y.Value, x.Value));
     }
 
     public Variable<T> Cos(Variable<T> x)
     {
-        _nodes.Add(new(-T.Sin(x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Cos(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(-T.Sin(x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Cos(x.Value));
+        }
+        return new(_nodes.Count, T.Cos(x.Value));
     }
 
     public Variable<T> Sin(Variable<T> x)
     {
-        _nodes.Add(new(T.Cos(x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Sin(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(T.Cos(x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Sin(x.Value));
+        }
+        return new(_nodes.Count, T.Sin(x.Value));
     }
 
     public Variable<T> Tan(Variable<T> x)
     {
-        var sec = T.One / T.Cos(x.Value);
-        _nodes.Add(new(sec * sec, x._index, _nodes.Count));
-        return new(_nodes.Count - 1, T.Tan(x.Value));
+        if (_isTracking)
+        {
+            var sec = T.One / T.Cos(x.Value);
+            _nodes.Add(new(sec * sec, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, T.Tan(x.Value));
+        }
+        return new(_nodes.Count, T.Tan(x.Value));
     }
 
     //
@@ -453,8 +618,12 @@ public record class GradientTape<T> : ITape<T>
     /// <returns>A variable</returns>
     public Variable<T> CustomOperation(Variable<T> x, Func<T, T> f, Func<T, T> df)
     {
-        _nodes.Add(new(df(x.Value), x._index, _nodes.Count));
-        return new(_nodes.Count - 1, f(x.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(df(x.Value), x._index, _nodes.Count));
+            return new(_nodes.Count - 1, f(x.Value));
+        }
+        return new(_nodes.Count, f(x.Value));
     }
 
     /// <summary>Add a node to the gradient tape using a custom binary operation.</summary>
@@ -466,7 +635,11 @@ public record class GradientTape<T> : ITape<T>
     /// <returns>A variable</returns>
     public Variable<T> CustomOperation(Variable<T> x, Variable<T> y, Func<T, T, T> f, Func<T, T, T> dfx, Func<T, T, T> dfy)
     {
-        _nodes.Add(new(dfx(x.Value, y.Value), dfy(x.Value, y.Value), x._index, y._index));
-        return new(_nodes.Count - 1, f(x.Value, y.Value));
+        if (_isTracking)
+        {
+            _nodes.Add(new(dfx(x.Value, y.Value), dfy(x.Value, y.Value), x._index, y._index));
+            return new(_nodes.Count - 1, f(x.Value, y.Value));
+        }
+        return new(_nodes.Count, f(x.Value, y.Value));
     }
 }

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -32,6 +32,9 @@ namespace Mathematics.NET.AutoDiff;
 public interface ITape<T>
     where T : IComplex<T>, IDifferentiableFunctions<T>
 {
+    /// <summary>This property indicates whether or not the tape is currently tracking nodes.</summary>
+    public bool IsTracking { get; set; }
+
     /// <summary>Get the number of nodes on the gradient tape.</summary>
     public int NodeCount { get; }
 

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
@@ -343,7 +343,7 @@ public sealed class GradientTapeOfRealTests
         var x = _tape.CreateVariable(right);
         var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
 
-        var actual = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x.AsDouble() * u, (y, x) => -y.AsDouble() * u).Value;
+        var actual = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x * u, (y, x) => -y * u).Value;
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }

--- a/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/GradientTapeOfRealTests.cs
@@ -55,10 +55,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(0.123, 1.447484051603025)]
+    public void Acos_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Acos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.396315794095838)]
     public void Acosh_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Acosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.6658635291565548)]
+    public void Acosh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Acosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -70,6 +88,15 @@ public sealed class GradientTapeOfRealTests
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Add, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Add, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -88,6 +115,17 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Add(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 1)]
     public void Add_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -96,6 +134,17 @@ public sealed class GradientTapeOfRealTests
         _tape.ReverseAccumulate(out var gradient);
 
         var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Add(x, right).Value;
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -110,6 +159,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(0.123, 0.123312275191872)]
+    public void Asin_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Asin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.6308300845448597)]
     public void Asinh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -119,10 +177,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.035037896192308)]
+    public void Asinh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Asinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.3979465955668749)]
     public void Atan_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Atan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.88817377437768)]
+    public void Atan_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Atan, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -139,10 +215,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.4839493878600246)]
+    public void Atan2_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Atan2, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -1.94969779684149)]
     public void Atanh_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Atanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(0.123, 0.1236259811831301)]
+    public void Atanh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Atanh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -157,6 +251,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.071441269690773)]
+    public void Cbrt_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cbrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.942488801931697)]
     public void Cos_Variable_ReturnsGradient(double input, double expected)
     {
@@ -166,10 +269,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.3342377271245026)]
+    public void Cos_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.564468479304407)]
     public void Cosh_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Cosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.856761056985266)]
+    public void Cosh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -206,10 +327,23 @@ public sealed class GradientTapeOfRealTests
         var y = _tape.CreateVariable(left);
         var x = _tape.CreateVariable(right);
         var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
-        _ = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x.AsDouble() * u, (y, x) => -y.AsDouble() * u);
+        _ = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x * u, (y, x) => -y * u);
         _tape.ReverseAccumulate(out var actual);
 
         Real[] expected = [expectedLeft, expectedRight];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.4839493878600246)]
+    public void CustomOperation_Binary_ReturnsValue(double left, double right, double expected)
+    {
+        var y = _tape.CreateVariable(left);
+        var x = _tape.CreateVariable(right);
+        var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
+
+        var actual = _tape.CustomOperation(y, x, Real.Atan2, (y, x) => x.AsDouble() * u, (y, x) => -y.AsDouble() * u).Value;
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -228,12 +362,32 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.942488801931697)]
+    public void CustomOperation_Unary_ReturnsValue(double input, double expected)
+    {
+        var x = _tape.CreateVariable(input);
+
+        var actual = _tape.CustomOperation(x, Real.Sin, Real.Cos).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.4273504273504274, -0.2246329169406093)]
     public void Divide_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Divide, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Divide, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -252,6 +406,17 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Divide(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.4273504273504274)]
     public void Divide_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -260,6 +425,17 @@ public sealed class GradientTapeOfRealTests
         _tape.ReverseAccumulate(out var gradient);
 
         var actual = gradient[0];
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Divide(x, right).Value;
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -274,10 +450,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 3.421229536289673)]
+    public void Exp_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.625894476644487)]
     public void Exp2_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Exp2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.345669898463758)]
+    public void Exp2_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp2, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -292,10 +486,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 16.98243652461744)]
+    public void Exp10_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.813008130081301)]
     public void Ln_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Ln, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.2070141693843261)]
+    public void Ln_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Ln, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -312,6 +524,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.2435028442982799)]
+    public void Log_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Log, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.172922797470702)]
     public void Log2_Variable_ReturnsGradient(double input, double expected)
     {
@@ -321,10 +542,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.2986583155645151)]
+    public void Log2_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Log2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.35308494463679)]
     public void Log10_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Log10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.0899051114393979)]
+    public void Log10_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Log10, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -341,6 +580,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Modulo, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0)]
     public void Modulo_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
     {
@@ -351,6 +599,17 @@ public sealed class GradientTapeOfRealTests
         var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Modulo(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -367,6 +626,17 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Modulo(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 2.34, 1.23)]
     public void Multiply_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
@@ -375,6 +645,15 @@ public sealed class GradientTapeOfRealTests
         var actual = ComputeGradient(_tape.Multiply, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-16);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Multiply, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -391,6 +670,17 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Multiply(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 2.34)]
     public void Multiply_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -404,10 +694,30 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Multiply(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -1)]
     public void Negate_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Negate, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -1.23)]
+    public void Negate_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Negate, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -424,12 +734,30 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1.623222151685371)]
+    public void Pow_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Pow, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.3795771135606888, -0.04130373687338086)]
     public void Root_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
         Real[] expected = [expectedLeft, expectedRight];
 
         var actual = ComputeGradient(_tape.Root, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 1.092498848250374)]
+    public void Root_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Root, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -444,6 +772,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.942488801931697)]
+    public void Sin_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.856761056985266)]
     public void Sinh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -453,10 +790,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.564468479304407)]
+    public void Sinh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.4508348173337161)]
     public void Sqrt_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Sqrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.109053650640942)]
+    public void Sqrt_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sqrt, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -473,6 +828,15 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Subtract, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, -1)]
     public void Subtract_ConstantAndVariable_ReturnsGradient(double left, double right, double expected)
     {
@@ -483,6 +847,17 @@ public sealed class GradientTapeOfRealTests
         var actual = gradient[0];
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Subtract(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -499,6 +874,17 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Subtract(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 8.95136077522624)]
     public void Tan_Variable_ReturnsGradient(double input, double expected)
     {
@@ -508,10 +894,28 @@ public sealed class GradientTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.819815734268152)]
+    public void Tan_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Tan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.2900600799721436)]
     public void Tanh_Variable_ReturnsGradient(double input, double expected)
     {
         var actual = ComputeGradient(_tape.Tanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.84257932565893)]
+    public void Tanh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Tanh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -535,5 +939,18 @@ public sealed class GradientTapeOfRealTests
         _ = function(x, y);
         _tape.ReverseAccumulate(out var gradient);
         return gradient.ToArray();
+    }
+
+    private Real ComputeValue(Func<Variable<Real>, Variable<Real>> function, Real input)
+    {
+        var x = _tape.CreateVariable(input);
+        return function(x).Value;
+    }
+
+    private Real ComputeValue(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
+    {
+        var x = _tape.CreateVariable(left);
+        var y = _tape.CreateVariable(right);
+        return function(x, y).Value;
     }
 }

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -461,10 +461,10 @@ public sealed class HessianTapeOfRealTests
             y,
             x,
             Real.Atan2,
-            (y, x) => x.AsDouble() * u,
+            (y, x) => x * u,
             (y, x) => Real.Zero, // Not of interest
             (y, x) => Real.Zero, // Not of interest
-            (y, x) => -y.AsDouble() * u,
+            (y, x) => -y * u,
             (y, x) => Real.Zero); // Not of interest
 
         Real[] expected = [expectedLeft, expectedRight];
@@ -491,10 +491,10 @@ public sealed class HessianTapeOfRealTests
             y,
             x,
             Real.Atan2,
-            (y, x) => x.AsDouble() * a,
+            (y, x) => x * a,
             (y, x) => dfyy,
             (y, x) => (u - v) * b,
-            (y, x) => -y.AsDouble() * a,
+            (y, x) => -y * a,
             (y, x) => -dfyy);
 
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
@@ -523,10 +523,10 @@ public sealed class HessianTapeOfRealTests
             y,
             x,
             Real.Atan2,
-            (y, x) => x.AsDouble() * a,
+            (y, x) => x * a,
             (y, x) => dfyy,
             (y, x) => (u - v) * b,
-            (y, x) => -y.AsDouble() * a,
+            (y, x) => -y * a,
             (y, x) => -dfyy).Value;
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -64,6 +64,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(0.123, 1.447484051603025)]
+    public void Acos_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Acos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.396315794095838)]
     public void Acosh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -77,6 +86,15 @@ public sealed class HessianTapeOfRealTests
     public void Acosh_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Acosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.6658635291565548)]
+    public void Acosh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Acosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -99,6 +117,15 @@ public sealed class HessianTapeOfRealTests
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Add, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Add, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -130,6 +157,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Add(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 1)]
     public void Add_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -156,6 +194,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 3.57)]
+    public void Add_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Add(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
     [DataRow(0.123, 1.007651429146436)]
     public void Asin_Variable_ReturnsGradient(double input, double expected)
     {
@@ -169,6 +218,15 @@ public sealed class HessianTapeOfRealTests
     public void Asin_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Asin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(0.123, 0.123312275191872)]
+    public void Asin_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Asin, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -192,6 +250,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.035037896192308)]
+    public void Asinh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Asinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.3979465955668749)]
     public void Atan_Variable_ReturnsGradient(double input, double expected)
     {
@@ -205,6 +272,15 @@ public sealed class HessianTapeOfRealTests
     public void Atan_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Atan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.88817377437768)]
+    public void Atan_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Atan, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -232,6 +308,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.4839493878600246)]
+    public void Atan2_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Atan2, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -1.94969779684149)]
     public void Atanh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -245,6 +330,15 @@ public sealed class HessianTapeOfRealTests
     public void Atanh_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Atanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(0.123, 0.1236259811831301)]
+    public void Atanh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Atanh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -268,6 +362,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.071441269690773)]
+    public void Cbrt_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cbrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -0.942488801931697)]
     public void Cos_Variable_ReturnsGradient(double input, double expected)
     {
@@ -286,6 +389,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.3342377271245026)]
+    public void Cos_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cos, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.564468479304407)]
     public void Cosh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -299,6 +411,15 @@ public sealed class HessianTapeOfRealTests
     public void Cosh_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Cosh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.856761056985266)]
+    public void Cosh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Cosh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -386,6 +507,32 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.4839493878600246)]
+    public void CustomOperation_Binary_ReturnsValue(double left, double right, double expected)
+    {
+        var y = _tape.CreateVariable(left);
+        var x = _tape.CreateVariable(right);
+
+        var u = y.Value * y.Value;
+        var v = x.Value * x.Value;
+        var a = Real.One / (u + v);
+        var b = a * a;
+        var dfyy = -2.0 * x.Value * b * y.Value;
+
+        var actual = _tape.CustomOperation(
+            y,
+            x,
+            Real.Atan2,
+            (y, x) => x.AsDouble() * a,
+            (y, x) => dfyy,
+            (y, x) => (u - v) * b,
+            (y, x) => -y.AsDouble() * a,
+            (y, x) => -dfyy).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.3342377271245026)]
     public void CustomOperation_Unary_ReturnsGradient(double input, double expected)
     {
@@ -416,6 +563,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.942488801931697)]
+    public void CustomOperation_Unary_ReturnsValue(double input, double expected)
+    {
+        var x = _tape.CreateVariable(input);
+
+        var actual = _tape.CustomOperation(x, Real.Sin, Real.Cos, x => -Real.Sin(x)).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.4273504273504274, -0.2246329169406093)]
     public void Divide_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
@@ -433,6 +591,15 @@ public sealed class HessianTapeOfRealTests
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Divide, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Divide, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -464,6 +631,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Divide(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.4273504273504274)]
     public void Divide_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -490,6 +668,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.5256410256410256)]
+    public void Divide_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Divide(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 3.421229536289673)]
     public void Exp_Variable_ReturnsGradient(double input, double expected)
     {
@@ -503,6 +692,15 @@ public sealed class HessianTapeOfRealTests
     public void Exp_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Exp, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 3.421229536289673)]
+    public void Exp_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -526,6 +724,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.345669898463758)]
+    public void Exp2_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 39.10350518430174)]
     public void Exp10_Variable_ReturnsGradient(double input, double expected)
     {
@@ -544,6 +751,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 16.98243652461744)]
+    public void Exp10_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Exp10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.813008130081301)]
     public void Ln_Variable_ReturnsGradient(double input, double expected)
     {
@@ -557,6 +773,15 @@ public sealed class HessianTapeOfRealTests
     public void Ln_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Ln, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.2070141693843261)]
+    public void Ln_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Ln, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -584,6 +809,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 0.2435028442982799)]
+    public void Log_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Log, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.172922797470702)]
     public void Log2_Variable_ReturnsGradient(double input, double expected)
     {
@@ -602,6 +836,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.2986583155645151)]
+    public void Log2_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Log2, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.35308494463679)]
     public void Log10_Variable_ReturnsGradient(double input, double expected)
     {
@@ -615,6 +858,15 @@ public sealed class HessianTapeOfRealTests
     public void Log10_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Log10, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.0899051114393979)]
+    public void Log10_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Log10, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -639,6 +891,15 @@ public sealed class HessianTapeOfRealTests
         var actual = ComputeHessian(_tape.Modulo, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Modulo, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -668,6 +929,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Modulo(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 1)]
     public void Modulo_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -694,6 +966,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(3.14, 2.34, 0.8)]
+    public void Modulo_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Modulo(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 2.34, 1.23)]
     public void Multiply_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
@@ -713,6 +996,15 @@ public sealed class HessianTapeOfRealTests
         var actual = ComputeHessian(_tape.Multiply, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Multiply, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -742,6 +1034,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Multiply(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 2.34)]
     public void Multiply_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -768,6 +1071,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 2.8782)]
+    public void Multiply_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Multiply(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, -1)]
     public void Negate_Variable_ReturnsGradient(double input, double expected)
     {
@@ -783,6 +1097,15 @@ public sealed class HessianTapeOfRealTests
         var x = _tape.CreateVariable(input);
 
         var actual = ComputeHessian(_tape.Negate, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, -1.23)]
+    public void Negate_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Negate, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
     }
@@ -810,6 +1133,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, 1.623222151685371)]
+    public void Pow_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Pow, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 0.3795771135606888, -0.04130373687338086)]
     public void Root_TwoVariables_ReturnsGradient(double left, double right, double expectedLeft, double expectedRight)
     {
@@ -827,6 +1159,15 @@ public sealed class HessianTapeOfRealTests
         Real[,] expected = new Real[2, 2] { { expectedXX, expectedXY }, { expectedXY, expectedYY } };
 
         var actual = ComputeHessian(_tape.Root, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 1.092498848250374)]
+    public void Root_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Root, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -850,6 +1191,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 0.942488801931697)]
+    public void Sin_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sin, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 1.856761056985266)]
     public void Sinh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -868,6 +1218,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 1.564468479304407)]
+    public void Sinh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sinh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.4508348173337161)]
     public void Sqrt_Variable_ReturnsGradient(double input, double expected)
     {
@@ -881,6 +1240,15 @@ public sealed class HessianTapeOfRealTests
     public void Sqrt_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Sqrt, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 1.109053650640942)]
+    public void Sqrt_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Sqrt, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -905,6 +1273,15 @@ public sealed class HessianTapeOfRealTests
         var actual = ComputeHessian(_tape.Subtract, left, right);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, Real.Zero);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_TwoVariables_ReturnsValue(double left, double right, double expected)
+    {
+        var actual = ComputeValue(_tape.Subtract, left, right);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -934,6 +1311,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_ConstantAndVariable_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(right);
+
+        var actual = _tape.Subtract(left, x).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 2.34, 1)]
     public void Subtract_VariableAndConstant_ReturnsGradient(double left, double right, double expected)
     {
@@ -960,6 +1348,17 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.34, -1.11)]
+    public void Subtract_VariableAndConstant_ReturnsValue(double left, double right, double expected)
+    {
+        var x = _tape.CreateVariable(left);
+
+        var actual = _tape.Subtract(x, right).Value;
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 8.95136077522624)]
     public void Tan_Variable_ReturnsGradient(double input, double expected)
     {
@@ -978,6 +1377,15 @@ public sealed class HessianTapeOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23, 2.819815734268152)]
+    public void Tan_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Tan, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.2900600799721436)]
     public void Tanh_Variable_ReturnsGradient(double input, double expected)
     {
@@ -991,6 +1399,15 @@ public sealed class HessianTapeOfRealTests
     public void Tanh_Variable_ReturnsHessian(double input, double expected)
     {
         var actual = ComputeHessian(_tape.Tanh, input);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DataRow(1.23, 0.84257932565893)]
+    public void Tanh_Variable_ReturnsValue(double input, double expected)
+    {
+        var actual = ComputeValue(_tape.Tanh, input);
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -1031,5 +1448,18 @@ public sealed class HessianTapeOfRealTests
         _ = function(x, y);
         _tape.ReverseAccumulate(out ReadOnlySpan2D<Real> hessian);
         return hessian.ToArray();
+    }
+
+    private Real ComputeValue(Func<Variable<Real>, Variable<Real>> function, Real input)
+    {
+        var x = _tape.CreateVariable(input);
+        return function(x).Value;
+    }
+
+    private Real ComputeValue(Func<Variable<Real>, Variable<Real>, Variable<Real>> function, Real left, Real right)
+    {
+        var x = _tape.CreateVariable(left);
+        var y = _tape.CreateVariable(right);
+        return function(x, y).Value;
     }
 }


### PR DESCRIPTION
This update add the option of tracking or not tracking nodes on gradient and Hessian tapes. Nodes are tracked by default.
- Add more tests for gradient and Hessian tapes
- Minor updates