### PR TITLE
Add basic tensor fields

### DIFF
--- a/Mathematics.NET.sln
+++ b/Mathematics.NET.sln
@@ -19,6 +19,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{91DB0FE7-BAA4-4D16-8A39-65332DD53662}"
+	ProjectSection(SolutionItems) = preProject
+		tests\.runsettings = tests\.runsettings
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mathematics.NET.SourceGenerators", "src\Mathematics.NET.SourceGenerators\Mathematics.NET.SourceGenerators.csproj", "{557642D0-685A-4846-AD31-DC764692E853}"
 EndProject
@@ -48,7 +51,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mathematics.NET.SourceGener
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mathematics.NET.Tests.SourceGenerators.Public", "tests\Mathematics.NET.Tests.SourceGenerators.Public\Mathematics.NET.Tests.SourceGenerators.Public.csproj", "{CCB1A777-2317-4866-8A9E-B8E75879B40F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mathematics.NET.Plots", "src\Mathematics.NET.Plots\Mathematics.NET.Plots.csproj", "{15D38514-CA1A-4C96-9DFA-F70CDFCE63B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mathematics.NET.Plots", "src\Mathematics.NET.Plots\Mathematics.NET.Plots.csproj", "{15D38514-CA1A-4C96-9DFA-F70CDFCE63B8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/docs/template/public/main.css
+++ b/docs/template/public/main.css
@@ -48,21 +48,19 @@ code {
     position: relative;
     text-align: center;
   }
-  
+
   #interactive-card > .flare,
   #overlay {
     position: absolute;
-    transition: ease-out;
-    transition-duration: 250ms;
     opacity: 0;
     pointer-events: none;
   }
-  
+
   #interactive-card:hover > #overlay,
   #interactive-card:hover > .flare {
     opacity: 1;
   }
-  
+
 #overlay {
   width: 100%;
   height: 100%;
@@ -118,7 +116,7 @@ footer {
 a {
   text-decoration: none;
 }
-  
+
   a:hover {
     text-decoration: underline;
   }

--- a/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4.cs
+++ b/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="AutoDiffTensor4Buffer4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0051
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+
+namespace Mathematics.NET.Core.Buffers;
+
+/// <summary>Represents a buffer of 4 AutoDiffTensor4 delegates</summary>
+/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+[InlineArray(4)]
+internal struct AutoDiffTensor4Buffer4<TTape, TNumber, TIndex>
+    where TTape : ITape<TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
+{
+    private Func<TTape, AutoDiffTensor4<TNumber, TIndex>, Variable<TNumber>> _element0;
+}

--- a/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4x4.cs
+++ b/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4x4.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="AutoDiffTensor4Buffer4x4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0051
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+
+namespace Mathematics.NET.Core.Buffers;
+
+/// <summary>Represents a buffer of 4 TensorDelegateBuffer4 buffers</summary>
+/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+[InlineArray(4)]
+internal struct AutoDiffTensor4Buffer4x4<TTape, TNumber, TIndex>
+    where TTape : ITape<TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
+{
+    private AutoDiffTensor4Buffer4<TTape, TNumber, TIndex> _element0;
+}

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
@@ -30,21 +30,21 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
 /// <summary>Defines support for rank-four tensors</summary>
-/// <typeparam name="T">The type that implements the interface</typeparam>
-/// <typeparam name="U">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
-/// <typeparam name="V">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="W">An index</typeparam>
-/// <typeparam name="X">An index</typeparam>
-/// <typeparam name="Y">An index</typeparam>
-/// <typeparam name="Z">An index</typeparam>
-public interface IRankFourTensor<T, U, V, W, X, Y, Z> : IFourDimensionalArrayRepresentable<T, V>
-    where T : IRankFourTensor<T, U, V, W, X, Y, Z>
-    where U : IHyperCubic4DArray<U, V>
-    where V : IComplex<V>, IDifferentiableFunctions<V>
-    where W : IIndex
-    where X : IIndex
-    where Y : IIndex
-    where Z : IIndex
+/// <typeparam name="TRankFourTensor">The type that implements the interface</typeparam>
+/// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">An index</typeparam>
+/// <typeparam name="TIndex2">An index</typeparam>
+/// <typeparam name="TIndex3">An index</typeparam>
+/// <typeparam name="TIndex4">An index</typeparam>
+public interface IRankFourTensor<TRankFourTensor, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> : IFourDimensionalArrayRepresentable<TRankFourTensor, TNumber>
+    where TRankFourTensor : IRankFourTensor<TRankFourTensor, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
+    where THyperCubic4DArray : IHyperCubic4DArray<THyperCubic4DArray, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
+    where TIndex3 : IIndex
+    where TIndex4 : IIndex
 {
     /// <summary>The first index</summary>
     IIndex I1 { get; }
@@ -58,7 +58,7 @@ public interface IRankFourTensor<T, U, V, W, X, Y, Z> : IFourDimensionalArrayRep
     /// <summary>The fourth index</summary>
     IIndex I4 { get; }
 
-    /// <summary>Convert a value that implements <see cref="IHyperCubic4DArray{T, U}"/> to one of type <typeparamref name="T"/></summary>
+    /// <summary>Convert a value that implements <see cref="IHyperCubic4DArray{T, U}"/> to one of type <typeparamref name="TRankFourTensor"/></summary>
     /// <param name="value">The value to convert</param>
-    static abstract implicit operator T(U value);
+    static abstract implicit operator TRankFourTensor(THyperCubic4DArray value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
@@ -31,15 +31,15 @@ namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
 /// <summary>Defines support for rank-four tensors and similar mathematical objects</summary>
 /// <typeparam name="TRankFourTensor">The type that implements the interface</typeparam>
-/// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
+/// <typeparam name="THypercubic4DArray">A backing type that implements <see cref="IHypercubic4DArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex1">An index</typeparam>
 /// <typeparam name="TIndex2">An index</typeparam>
 /// <typeparam name="TIndex3">An index</typeparam>
 /// <typeparam name="TIndex4">An index</typeparam>
-public interface IRankFourTensor<TRankFourTensor, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> : IFourDimensionalArrayRepresentable<TRankFourTensor, TNumber>
-    where TRankFourTensor : IRankFourTensor<TRankFourTensor, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
-    where THyperCubic4DArray : IHyperCubic4DArray<THyperCubic4DArray, TNumber>
+public interface IRankFourTensor<TRankFourTensor, THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> : IFourDimensionalArrayRepresentable<TRankFourTensor, TNumber>
+    where TRankFourTensor : IRankFourTensor<TRankFourTensor, THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
+    where THypercubic4DArray : IHypercubic4DArray<THypercubic4DArray, TNumber>
     where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
     where TIndex1 : IIndex
     where TIndex2 : IIndex
@@ -58,7 +58,7 @@ public interface IRankFourTensor<TRankFourTensor, THyperCubic4DArray, TNumber, T
     /// <summary>The fourth index</summary>
     IIndex I4 { get; }
 
-    /// <summary>Convert a value that implements <see cref="IHyperCubic4DArray{T, U}"/> to one of type <typeparamref name="TRankFourTensor"/></summary>
+    /// <summary>Convert a value that implements <see cref="IHypercubic4DArray{T, U}"/> to one of type <typeparamref name="TRankFourTensor"/></summary>
     /// <param name="value">The value to convert</param>
-    static abstract implicit operator TRankFourTensor(THyperCubic4DArray value);
+    static abstract implicit operator TRankFourTensor(THypercubic4DArray value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankFourTensor.cs
@@ -29,7 +29,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
-/// <summary>Defines support for rank-four tensors</summary>
+/// <summary>Defines support for rank-four tensors and similar mathematical objects</summary>
 /// <typeparam name="TRankFourTensor">The type that implements the interface</typeparam>
 /// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
@@ -29,7 +29,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
-/// <summary>Defines support for rank-one tensors</summary>
+/// <summary>Defines support for rank-one tensors and similar mathematical objects</summary>
 /// <typeparam name="TRankOneTensor">The type that implements the interface</typeparam>
 /// <typeparam name="TVector">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
@@ -30,20 +30,20 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
 /// <summary>Defines support for rank-one tensors</summary>
-/// <typeparam name="T">The type that implements the interface</typeparam>
-/// <typeparam name="U">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
-/// <typeparam name="V">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="W">An index</typeparam>
-public interface IRankOneTensor<T, U, V, W> : IOneDimensionalArrayRepresentable<T, V>
-    where T : IRankOneTensor<T, U, V, W>
-    where U : IVector<U, V>
-    where V : IComplex<V>, IDifferentiableFunctions<V>
-    where W : IIndex
+/// <typeparam name="TRankOneTensor">The type that implements the interface</typeparam>
+/// <typeparam name="TVector">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public interface IRankOneTensor<TRankOneTensor, TVector, TNumber, TIndex> : IOneDimensionalArrayRepresentable<TRankOneTensor, TNumber>
+    where TRankOneTensor : IRankOneTensor<TRankOneTensor, TVector, TNumber, TIndex>
+    where TVector : IVector<TVector, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>Get the index associated with this rank one tensor</summary>
     IIndex I1 { get; }
 
-    /// <summary>Convert a value that implements <see cref="IVector{T, U}"/> to one of type <typeparamref name="T"/></summary>
+    /// <summary>Convert a value that implements <see cref="IVector{T, U}"/> to one of type <typeparamref name="TRankOneTensor"/></summary>
     /// <param name="value">The value to convert</param>
-    static abstract implicit operator T(U value);
+    static abstract implicit operator TRankOneTensor(TVector value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankThreeTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankThreeTensor.cs
@@ -29,7 +29,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
-/// <summary>Defines support for rank-three tensors</summary>
+/// <summary>Defines support for rank-three tensors and similar mathematical objects</summary>
 /// <typeparam name="TRankThreeTensor">The type that implements the interface</typeparam>
 /// <typeparam name="TCubicArray">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankThreeTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankThreeTensor.cs
@@ -30,19 +30,19 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
 /// <summary>Defines support for rank-three tensors</summary>
-/// <typeparam name="T">The type that implements the interface</typeparam>
-/// <typeparam name="U">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
-/// <typeparam name="V">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="W">An index</typeparam>
-/// <typeparam name="X">An index</typeparam>
-/// <typeparam name="Y">An index</typeparam>
-public interface IRankThreeTensor<T, U, V, W, X, Y> : IThreeDimensionalArrayRepresentable<T, V>
-    where T : IRankThreeTensor<T, U, V, W, X, Y>
-    where U : ICubicArray<U, V>
-    where V : IComplex<V>, IDifferentiableFunctions<V>
-    where W : IIndex
-    where X : IIndex
-    where Y : IIndex
+/// <typeparam name="TRankThreeTensor">The type that implements the interface</typeparam>
+/// <typeparam name="TCubicArray">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">An index</typeparam>
+/// <typeparam name="TIndex2">An index</typeparam>
+/// <typeparam name="TIndex3">An index</typeparam>
+public interface IRankThreeTensor<TRankThreeTensor, TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> : IThreeDimensionalArrayRepresentable<TRankThreeTensor, TNumber>
+    where TRankThreeTensor : IRankThreeTensor<TRankThreeTensor, TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>
+    where TCubicArray : ICubicArray<TCubicArray, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
+    where TIndex3 : IIndex
 {
     /// <summary>The first index</summary>
     IIndex I1 { get; }
@@ -55,5 +55,5 @@ public interface IRankThreeTensor<T, U, V, W, X, Y> : IThreeDimensionalArrayRepr
 
     /// <summary>Convert a value that implements <see cref="ICubicArray{T, U}"/></summary>
     /// <param name="value">The value to convert</param>
-    static abstract implicit operator T(U value);
+    static abstract implicit operator TRankThreeTensor(TCubicArray value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankTwoTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankTwoTensor.cs
@@ -30,17 +30,17 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
 /// <summary>Defines support for rank-two tensors</summary>
-/// <typeparam name="T">The type that implements the interface</typeparam>
-/// <typeparam name="U">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
-/// <typeparam name="V">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="W">An index</typeparam>
-/// <typeparam name="X">An index</typeparam>
-public interface IRankTwoTensor<T, U, V, W, X> : ITwoDimensionalArrayRepresentable<T, V>
-    where T : IRankTwoTensor<T, U, V, W, X>
-    where U : ISquareMatrix<U, V>
-    where V : IComplex<V>, IDifferentiableFunctions<V>
-    where W : IIndex
-    where X : IIndex
+/// <typeparam name="TRankTwoTensor">The type that implements the interface</typeparam>
+/// <typeparam name="TSquareMatrix">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">An index</typeparam>
+/// <typeparam name="TIndex2">An index</typeparam>
+public interface IRankTwoTensor<TRankTwoTensor, TSquareMatrix, TNumber, TIndex1, TIndex2> : ITwoDimensionalArrayRepresentable<TRankTwoTensor, TNumber>
+    where TRankTwoTensor : IRankTwoTensor<TRankTwoTensor, TSquareMatrix, TNumber, TIndex1, TIndex2>
+    where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
 {
     /// <summary>The first index</summary>
     IIndex I1 { get; }
@@ -48,7 +48,7 @@ public interface IRankTwoTensor<T, U, V, W, X> : ITwoDimensionalArrayRepresentab
     /// <summary>The second index</summary>
     IIndex I2 { get; }
 
-    /// <summary>Convert a value that implements <see cref="IMatrix{T, U}"/> to one of type <typeparamref name="T"/></summary>
+    /// <summary>Convert a value that implements <see cref="IMatrix{T, U}"/> to one of type <typeparamref name="TRankTwoTensor"/></summary>
     /// <param name="value">The value to convert</param>
-    static abstract implicit operator T(U value);
+    static abstract implicit operator TRankTwoTensor(TSquareMatrix value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankTwoTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankTwoTensor.cs
@@ -29,7 +29,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 
-/// <summary>Defines support for rank-two tensors</summary>
+/// <summary>Defines support for rank-two tensors and similar mathematical objects</summary>
 /// <typeparam name="TRankTwoTensor">The type that implements the interface</typeparam>
 /// <typeparam name="TSquareMatrix">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/TensorField.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/TensorField.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="TensorField.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Mathematics.NET.DifferentialGeometry.Abstractions;
+
+/// <summary>A base class for tensor fields and similar mathematical objects</summary>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public abstract class TensorField<TNumber, TIndex>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
+{
+    protected TensorField() { }
+}

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor2`2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor2`2.cs
@@ -33,19 +33,19 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of two variables for use in reverse-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="U">An index</typeparam>
-public record struct AutoDiffTensor2<T, U>
-    where T : IComplex<T>
-    where U : IIndex
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor2<TNumber, TIndex>
+    where TNumber : IComplex<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public Variable<T> X0;
+    public Variable<TNumber> X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public Variable<T> X1;
+    public Variable<TNumber> X1;
 
-    public AutoDiffTensor2(Variable<T> x0, Variable<T> x1)
+    public AutoDiffTensor2(Variable<TNumber> x0, Variable<TNumber> x1)
     {
         X0 = x0;
         X1 = x1;
@@ -58,7 +58,7 @@ public record struct AutoDiffTensor2<T, U>
     /// <summary>Get the element at the specified index</summary>
     /// <param name="index">An index</param>
     /// <returns>The element at the index</returns>
-    public Variable<T> this[int index]
+    public Variable<TNumber> this[int index]
     {
         readonly get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -66,7 +66,7 @@ public record struct AutoDiffTensor2<T, U>
 
     // Get
 
-    internal static Variable<T> GetElement(AutoDiffTensor2<T, U> tensor, int index)
+    internal static Variable<TNumber> GetElement(AutoDiffTensor2<TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 2)
         {
@@ -77,31 +77,31 @@ public record struct AutoDiffTensor2<T, U>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Variable<T> GetElementUnsafe(ref AutoDiffTensor2<T, U> tensor, int index)
+    private static Variable<TNumber> GetElementUnsafe(ref AutoDiffTensor2<TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 2);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<T, U>, Variable<T>>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor2<T, U> WithElement(AutoDiffTensor2<T, U> tensor, int index, Variable<T> value)
+    internal static AutoDiffTensor2<TNumber, TIndex> WithElement(AutoDiffTensor2<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         if ((uint)index >= 2)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor2<T, U> result = tensor;
+        AutoDiffTensor2<TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor2<T, U> tensor, int index, Variable<T> value)
+    private static void SetElementUnsafe(ref AutoDiffTensor2<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         Debug.Assert(index is >= 0 and < 2);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<T, U>, Variable<T>>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor2`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor2`3.cs
@@ -33,21 +33,21 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of two variables for use in forward-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-/// <typeparam name="V">An index</typeparam>
-public record struct AutoDiffTensor2<T, U, V>
-    where T : IDual<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
+/// <typeparam name="TDualNumber">A type that implements <see cref="IDual{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor2<TDualNumber, TNumber, TIndex>
+    where TDualNumber : IDual<TDualNumber, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public T X0;
+    public TDualNumber X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public T X1;
+    public TDualNumber X1;
 
-    public AutoDiffTensor2(T x0, T x1)
+    public AutoDiffTensor2(TDualNumber x0, TDualNumber x1)
     {
         X0 = x0;
         X1 = x1;
@@ -57,7 +57,7 @@ public record struct AutoDiffTensor2<T, U, V>
     // Indexer
     //
 
-    public T this[int index]
+    public TDualNumber this[int index]
     {
         get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -65,7 +65,7 @@ public record struct AutoDiffTensor2<T, U, V>
 
     // Get
 
-    internal static T GetElement(AutoDiffTensor2<T, U, V> tensor, int index)
+    internal static TDualNumber GetElement(AutoDiffTensor2<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 2)
         {
@@ -76,31 +76,31 @@ public record struct AutoDiffTensor2<T, U, V>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static T GetElementUnsafe(ref AutoDiffTensor2<T, U, V> tensor, int index)
+    private static TDualNumber GetElementUnsafe(ref AutoDiffTensor2<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 2);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<T, U, V>, T>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor2<T, U, V> WithElement(AutoDiffTensor2<T, U, V> tensor, int index, T value)
+    internal static AutoDiffTensor2<TDualNumber, TNumber, TIndex> WithElement(AutoDiffTensor2<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         if ((uint)index >= 2)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor2<T, U, V> result = tensor;
+        AutoDiffTensor2<TDualNumber, TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor2<T, U, V> tensor, int index, T value)
+    private static void SetElementUnsafe(ref AutoDiffTensor2<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         Debug.Assert(index is >= 0 and < 2);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<T, U, V>, T>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor2<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor3`2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor3`2.cs
@@ -33,22 +33,22 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of three variables for use in reverse-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="U">An index</typeparam>
-public record struct AutoDiffTensor3<T, U>
-    where T : IComplex<T>
-    where U : IIndex
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor3<TNumber, TIndex>
+    where TNumber : IComplex<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public Variable<T> X0;
+    public Variable<TNumber> X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public Variable<T> X1;
+    public Variable<TNumber> X1;
 
     /// <summary>The second element of the rank-one tensor</summary>
-    public Variable<T> X2;
+    public Variable<TNumber> X2;
 
-    public AutoDiffTensor3(Variable<T> x0, Variable<T> x1, Variable<T> x2)
+    public AutoDiffTensor3(Variable<TNumber> x0, Variable<TNumber> x1, Variable<TNumber> x2)
     {
         X0 = x0;
         X1 = x1;
@@ -62,7 +62,7 @@ public record struct AutoDiffTensor3<T, U>
     /// <summary>Get the element at the specified index</summary>
     /// <param name="index">An index</param>
     /// <returns>The element at the index</returns>
-    public Variable<T> this[int index]
+    public Variable<TNumber> this[int index]
     {
         readonly get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -70,7 +70,7 @@ public record struct AutoDiffTensor3<T, U>
 
     // Get
 
-    internal static Variable<T> GetElement(AutoDiffTensor3<T, U> tensor, int index)
+    internal static Variable<TNumber> GetElement(AutoDiffTensor3<TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 3)
         {
@@ -81,31 +81,31 @@ public record struct AutoDiffTensor3<T, U>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Variable<T> GetElementUnsafe(ref AutoDiffTensor3<T, U> tensor, int index)
+    private static Variable<TNumber> GetElementUnsafe(ref AutoDiffTensor3<TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 3);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<T, U>, Variable<T>>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor3<T, U> WithElement(AutoDiffTensor3<T, U> tensor, int index, Variable<T> value)
+    internal static AutoDiffTensor3<TNumber, TIndex> WithElement(AutoDiffTensor3<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         if ((uint)index >= 3)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor3<T, U> result = tensor;
+        AutoDiffTensor3<TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor3<T, U> tensor, int index, Variable<T> value)
+    private static void SetElementUnsafe(ref AutoDiffTensor3<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         Debug.Assert(index is >= 0 and < 3);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<T, U>, Variable<T>>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor3`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor3`3.cs
@@ -33,24 +33,24 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of three variables for use in forward-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-/// <typeparam name="V">An index</typeparam>
-public record struct AutoDiffTensor3<T, U, V>
-    where T : IDual<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
+/// <typeparam name="TDualNumber">A type that implements <see cref="IDual{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor3<TDualNumber, TNumber, TIndex>
+    where TDualNumber : IDual<TDualNumber, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public T X0;
+    public TDualNumber X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public T X1;
+    public TDualNumber X1;
 
     /// <summary>The second element of the rank-one tensor</summary>
-    public T X2;
+    public TDualNumber X2;
 
-    public AutoDiffTensor3(T x0, T x1, T x2)
+    public AutoDiffTensor3(TDualNumber x0, TDualNumber x1, TDualNumber x2)
     {
         X0 = x0;
         X1 = x1;
@@ -61,7 +61,7 @@ public record struct AutoDiffTensor3<T, U, V>
     // Indexer
     //
 
-    public T this[int index]
+    public TDualNumber this[int index]
     {
         get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -69,7 +69,7 @@ public record struct AutoDiffTensor3<T, U, V>
 
     // Get
 
-    internal static T GetElement(AutoDiffTensor3<T, U, V> tensor, int index)
+    internal static TDualNumber GetElement(AutoDiffTensor3<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 3)
         {
@@ -80,31 +80,31 @@ public record struct AutoDiffTensor3<T, U, V>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static T GetElementUnsafe(ref AutoDiffTensor3<T, U, V> tensor, int index)
+    private static TDualNumber GetElementUnsafe(ref AutoDiffTensor3<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 3);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<T, U, V>, T>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor3<T, U, V> WithElement(AutoDiffTensor3<T, U, V> tensor, int index, T value)
+    internal static AutoDiffTensor3<TDualNumber, TNumber, TIndex> WithElement(AutoDiffTensor3<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         if ((uint)index >= 3)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor3<T, U, V> result = tensor;
+        AutoDiffTensor3<TDualNumber, TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor3<T, U, V> tensor, int index, T value)
+    private static void SetElementUnsafe(ref AutoDiffTensor3<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         Debug.Assert(index is >= 0 and < 3);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<T, U, V>, T>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor3<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor4`2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor4`2.cs
@@ -33,25 +33,25 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of four variables for use in reverse-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="U">An index</typeparam>
-public record struct AutoDiffTensor4<T, U>
-    where T : IComplex<T>
-    where U : IIndex
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor4<TNumber, TIndex>
+    where TNumber : IComplex<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public Variable<T> X0;
+    public Variable<TNumber> X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public Variable<T> X1;
+    public Variable<TNumber> X1;
 
     /// <summary>The second element of the rank-one tensor</summary>
-    public Variable<T> X2;
+    public Variable<TNumber> X2;
 
     /// <summary>The third element of the rank-one tensor</summary>
-    public Variable<T> X3;
+    public Variable<TNumber> X3;
 
-    public AutoDiffTensor4(Variable<T> x0, Variable<T> x1, Variable<T> x2, Variable<T> x3)
+    public AutoDiffTensor4(Variable<TNumber> x0, Variable<TNumber> x1, Variable<TNumber> x2, Variable<TNumber> x3)
     {
         X0 = x0;
         X1 = x1;
@@ -66,7 +66,7 @@ public record struct AutoDiffTensor4<T, U>
     /// <summary>Get the element at the specified index</summary>
     /// <param name="index">An index</param>
     /// <returns>The element at the index</returns>
-    public Variable<T> this[int index]
+    public Variable<TNumber> this[int index]
     {
         readonly get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -74,7 +74,7 @@ public record struct AutoDiffTensor4<T, U>
 
     // Get
 
-    internal static Variable<T> GetElement(AutoDiffTensor4<T, U> tensor, int index)
+    internal static Variable<TNumber> GetElement(AutoDiffTensor4<TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 4)
         {
@@ -85,31 +85,31 @@ public record struct AutoDiffTensor4<T, U>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Variable<T> GetElementUnsafe(ref AutoDiffTensor4<T, U> tensor, int index)
+    private static Variable<TNumber> GetElementUnsafe(ref AutoDiffTensor4<TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 4);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<T, U>, Variable<T>>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor4<T, U> WithElement(AutoDiffTensor4<T, U> tensor, int index, Variable<T> value)
+    internal static AutoDiffTensor4<TNumber, TIndex> WithElement(AutoDiffTensor4<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         if ((uint)index >= 4)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor4<T, U> result = tensor;
+        AutoDiffTensor4<TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor4<T, U> tensor, int index, Variable<T> value)
+    private static void SetElementUnsafe(ref AutoDiffTensor4<TNumber, TIndex> tensor, int index, Variable<TNumber> value)
     {
         Debug.Assert(index is >= 0 and < 4);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<T, U>, Variable<T>>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<TNumber, TIndex>, Variable<TNumber>>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor4`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/AutoDiffTensor4`3.cs
@@ -33,27 +33,27 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor of four variables for use in forward-mode automatic differentiation</summary>
-/// <typeparam name="T">A type that implements <see cref="IDual{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-/// <typeparam name="V">An index</typeparam>
-public record struct AutoDiffTensor4<T, U, V>
-    where T : IDual<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
+/// <typeparam name="TDualNumber">A type that implements <see cref="IDual{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
+public record struct AutoDiffTensor4<TDualNumber, TNumber, TIndex>
+    where TDualNumber : IDual<TDualNumber, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
 {
     /// <summary>The zeroth element of the rank-one tensor</summary>
-    public T X0;
+    public TDualNumber X0;
 
     /// <summary>The first element of the rank-one tensor</summary>
-    public T X1;
+    public TDualNumber X1;
 
     /// <summary>The second element of the rank-one tensor</summary>
-    public T X2;
+    public TDualNumber X2;
 
     /// <summary>The third element of the rank-one tensor</summary>
-    public T X3;
+    public TDualNumber X3;
 
-    public AutoDiffTensor4(T x0, T x1, T x2, T x3)
+    public AutoDiffTensor4(TDualNumber x0, TDualNumber x1, TDualNumber x2, TDualNumber x3)
     {
         X0 = x0;
         X1 = x1;
@@ -65,7 +65,7 @@ public record struct AutoDiffTensor4<T, U, V>
     // Indexer
     //
 
-    public T this[int index]
+    public TDualNumber this[int index]
     {
         get => GetElement(this, index);
         set => this = WithElement(this, index, value);
@@ -73,7 +73,7 @@ public record struct AutoDiffTensor4<T, U, V>
 
     // Get
 
-    internal static T GetElement(AutoDiffTensor4<T, U, V> tensor, int index)
+    internal static TDualNumber GetElement(AutoDiffTensor4<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         if ((uint)index >= 4)
         {
@@ -84,31 +84,31 @@ public record struct AutoDiffTensor4<T, U, V>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static T GetElementUnsafe(ref AutoDiffTensor4<T, U, V> tensor, int index)
+    private static TDualNumber GetElementUnsafe(ref AutoDiffTensor4<TDualNumber, TNumber, TIndex> tensor, int index)
     {
         Debug.Assert(index is >= 0 and < 4);
-        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<T, U, V>, T>(ref tensor), index);
+        return Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index);
     }
 
     // Set
 
-    internal static AutoDiffTensor4<T, U, V> WithElement(AutoDiffTensor4<T, U, V> tensor, int index, T value)
+    internal static AutoDiffTensor4<TDualNumber, TNumber, TIndex> WithElement(AutoDiffTensor4<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         if ((uint)index >= 4)
         {
             throw new IndexOutOfRangeException();
         }
 
-        AutoDiffTensor4<T, U, V> result = tensor;
+        AutoDiffTensor4<TDualNumber, TNumber, TIndex> result = tensor;
         SetElementUnsafe(ref result, index, value);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SetElementUnsafe(ref AutoDiffTensor4<T, U, V> tensor, int index, T value)
+    private static void SetElementUnsafe(ref AutoDiffTensor4<TDualNumber, TNumber, TIndex> tensor, int index, TDualNumber value)
     {
         Debug.Assert(index is >= 0 and < 4);
-        Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<T, U, V>, T>(ref tensor), index) = value;
+        Unsafe.Add(ref Unsafe.As<AutoDiffTensor4<TDualNumber, TNumber, TIndex>, TDualNumber>(ref tensor), index) = value;
     }
 
     //

--- a/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
@@ -34,48 +34,49 @@ using Mathematics.NET.Symbols;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a Christoffel symbol</summary>
-/// <typeparam name="T">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">The first index</typeparam>
-/// <typeparam name="W">The name of the second index</typeparam>
-/// <typeparam name="X">The name of the third index</typeparam>
+/// <typeparam name="TCubicArray">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">The first index</typeparam>
+/// <typeparam name="TIndex2Name">The name of the second index</typeparam>
+/// <typeparam name="TIndex3Name">The name of the third index</typeparam>
 /// <param name="array">A backing array</param>
-public struct Christoffel<T, U, V, W, X>(T array) : IRankThreeTensor<Christoffel<T, U, V, W, X>, T, U, V, Index<Lower, W>, Index<Lower, X>>
-    where T : ICubicArray<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
-    where W : ISymbol
-    where X : ISymbol
+public struct Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>(TCubicArray array)
+    : IRankThreeTensor<Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>, TCubicArray, TNumber, TIndex1, Index<Lower, TIndex2Name>, Index<Lower, TIndex3Name>>
+    where TCubicArray : ICubicArray<TCubicArray, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2Name : ISymbol
+    where TIndex3Name : ISymbol
 {
-    private T _array = array;
+    private TCubicArray _array = array;
 
     //
     // IRankThreeTensor interface
     //
 
-    public readonly IIndex I1 => V.Instance;
+    public readonly IIndex I1 => TIndex1.Instance;
 
-    public readonly IIndex I2 => Index<Lower, W>.Instance;
+    public readonly IIndex I2 => Index<Lower, TIndex2Name>.Instance;
 
-    public readonly IIndex I3 => Index<Lower, X>.Instance;
+    public readonly IIndex I3 => Index<Lower, TIndex3Name>.Instance;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => TCubicArray.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => TCubicArray.E1Components;
 
-    public static int E2Components => T.E2Components;
+    public static int E2Components => TCubicArray.E2Components;
 
-    public static int E3Components => T.E3Components;
+    public static int E3Components => TCubicArray.E3Components;
 
     //
     // Indexer
     //
 
-    public U this[int i, int j, int k]
+    public TNumber this[int i, int j, int k]
     {
         get => _array[i, j, k];
         set => _array[i, j, k] = value;
@@ -85,15 +86,15 @@ public struct Christoffel<T, U, V, W, X>(T array) : IRankThreeTensor<Christoffel
     // Equality
     //
 
-    public static bool operator ==(Christoffel<T, U, V, W, X> left, Christoffel<T, U, V, W, X> right)
+    public static bool operator ==(Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> left, Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> right)
         => left._array == right._array;
 
-    public static bool operator !=(Christoffel<T, U, V, W, X> left, Christoffel<T, U, V, W, X> right)
+    public static bool operator !=(Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> left, Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Christoffel<T, U, V, W, X> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> other && Equals(other);
 
-    public readonly bool Equals(Christoffel<T, U, V, W, X> value) => _array.Equals(value._array);
+    public readonly bool Equals(Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -108,29 +109,29 @@ public struct Christoffel<T, U, V, W, X>(T array) : IRankThreeTensor<Christoffel
     //
 
     /// <summary>Create a Christoffel symbol with a new index in the first position.</summary>
-    /// <typeparam name="Y">An index</typeparam>
+    /// <typeparam name="TNewIndex">An index</typeparam>
     /// <returns>A Christoffel symbol with a new index in the first position</returns>
-    public Christoffel<T, U, Y, W, X> WithIndexOne<Y>()
-        where Y : IIndex
-        => Unsafe.As<Christoffel<T, U, V, W, X>, Christoffel<T, U, Y, W, X>>(ref this);
+    public Christoffel<TCubicArray, TNumber, TNewIndex, TIndex2Name, TIndex3Name> WithIndexOne<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>, Christoffel<TCubicArray, TNumber, TNewIndex, TIndex2Name, TIndex3Name>>(ref this);
 
     /// <summary>Create a Christoffel symbol with a new index in the second position.</summary>
-    /// <typeparam name="Y">A symbol</typeparam>
+    /// <typeparam name="TNewIndexName">A symbol</typeparam>
     /// <returns>A Christoffel symbol with a new index in the second position</returns>
-    public Christoffel<T, U, V, Y, X> WithIndexTwo<Y>()
-        where Y : ISymbol
-        => Unsafe.As<Christoffel<T, U, V, W, X>, Christoffel<T, U, V, Y, X>>(ref this);
+    public Christoffel<TCubicArray, TNumber, TIndex1, TNewIndexName, TIndex3Name> WithIndexTwo<TNewIndexName>()
+        where TNewIndexName : ISymbol
+        => Unsafe.As<Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>, Christoffel<TCubicArray, TNumber, TIndex1, TNewIndexName, TIndex3Name>>(ref this);
 
     /// <summary>Create a Christoffel symbol with a new index in the third position.</summary>
-    /// <typeparam name="Y">A symbol</typeparam>
+    /// <typeparam name="TNewIndexName">A symbol</typeparam>
     /// <returns>A Christoffel symbol with a new index in the third position</returns>
-    public Christoffel<T, U, V, W, Y> WithIndexThree<Y>()
-        where Y : ISymbol
-        => Unsafe.As<Christoffel<T, U, V, W, X>, Christoffel<T, U, V, W, Y>>(ref this);
+    public Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TNewIndexName> WithIndexThree<TNewIndexName>()
+        where TNewIndexName : ISymbol
+        => Unsafe.As<Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>, Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TNewIndexName>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Christoffel<T, U, V, W, X>(T value) => new(value);
+    public static implicit operator Christoffel<TCubicArray, TNumber, TIndex1, TIndex2Name, TIndex3Name>(TCubicArray value) => new(value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -95,12 +95,12 @@ public static partial class DifGeo
         where TIndex3 : ISymbol
         where TPointIndex : ISymbol
     {
-        var value = metric
+        var inverseMetric = metric
             .Compute<TIndex1, InternalIndex1>(tape, position)
             .Inverse();
         Christoffel(tape, metric, position, out Christoffel<Array4x4x4<Real>, Real, Index<Lower, InternalIndex1>, TIndex2, TIndex3> christoffelFirstKind);
 
-        var result = Contract(value, christoffelFirstKind);
+        var result = Contract(inverseMetric, christoffelFirstKind);
 
         christoffel = Unsafe.As<
             Tensor<Array4x4x4<Real>, Real, Index<Upper, TIndex1>, Index<Lower, TIndex2>, Index<Lower, TIndex3>>,

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -43,6 +43,7 @@ public static partial class DifGeo
     //
 
     /// <summary>Compute the Christoffel symbol of the first kind given a metric tensor.</summary>
+    /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <typeparam name="TIndex1">The first index of the Christoffel symbol</typeparam>
     /// <typeparam name="TIndex2">The second index of the Christoffel symbol</typeparam>
     /// <typeparam name="TIndex3">The third index of the Christoffel symbol</typeparam>
@@ -51,11 +52,12 @@ public static partial class DifGeo
     /// <param name="metric">A metric tensor</param>
     /// <param name="point">A point on the manifold</param>
     /// <param name="christoffel">The result</param>
-    public static void Christoffel<TIndex1, TIndex2, TIndex3, TPointIndex>(
-        ITape<Real> tape,
-        MetricTensorField<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, TPointIndex>> metric,
-        AutoDiffTensor4<Real, Index<Upper, TPointIndex>> point,
-        out Christoffel<Array4x4x4<Real>, Real, Index<Lower, TIndex1>, TIndex2, TIndex3> christoffel)
+    public static void Christoffel<TNumber, TIndex1, TIndex2, TIndex3, TPointIndex>(
+        ITape<TNumber> tape,
+        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndex>> metric,
+        AutoDiffTensor4<TNumber, Index<Upper, TPointIndex>> point,
+        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, TIndex1>, TIndex2, TIndex3> christoffel)
+        where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
         where TIndex1 : ISymbol
         where TIndex2 : ISymbol
         where TIndex3 : ISymbol
@@ -77,6 +79,7 @@ public static partial class DifGeo
     }
 
     /// <summary>Compute the Christoffel symbol of the second kind given a metric tensor.</summary>
+    /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
     /// <typeparam name="TIndex1">The first index of the Christoffel symbol</typeparam>
     /// <typeparam name="TIndex2">The second index of the Christoffel symbol</typeparam>
     /// <typeparam name="TIndex3">The third index of the Christoffel symbol</typeparam>
@@ -85,11 +88,12 @@ public static partial class DifGeo
     /// <param name="metric">A metric tensor</param>
     /// <param name="point">A point on the manifold</param>
     /// <param name="christoffel">The result</param>
-    public static void Christoffel<TIndex1, TIndex2, TIndex3, TPointIndex>(
-        ITape<Real> tape,
-        MetricTensorField<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, TPointIndex>> metric,
-        AutoDiffTensor4<Real, Index<Upper, TPointIndex>> position,
-        out Christoffel<Array4x4x4<Real>, Real, Index<Upper, TIndex1>, TIndex2, TIndex3> christoffel)
+    public static void Christoffel<TNumber, TIndex1, TIndex2, TIndex3, TPointIndex>(
+        ITape<TNumber> tape,
+        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndex>> metric,
+        AutoDiffTensor4<TNumber, Index<Upper, TPointIndex>> position,
+        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, TIndex2, TIndex3> christoffel)
+        where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
         where TIndex1 : ISymbol
         where TIndex2 : ISymbol
         where TIndex3 : ISymbol
@@ -98,13 +102,13 @@ public static partial class DifGeo
         var inverseMetric = metric
             .Compute<TIndex1, InternalIndex1>(tape, position)
             .Inverse();
-        Christoffel(tape, metric, position, out Christoffel<Array4x4x4<Real>, Real, Index<Lower, InternalIndex1>, TIndex2, TIndex3> christoffelFirstKind);
+        Christoffel(tape, metric, position, out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, InternalIndex1>, TIndex2, TIndex3> christoffelFirstKind);
 
         var result = Contract(inverseMetric, christoffelFirstKind);
 
         christoffel = Unsafe.As<
-            Tensor<Array4x4x4<Real>, Real, Index<Upper, TIndex1>, Index<Lower, TIndex2>, Index<Lower, TIndex3>>,
-            Christoffel<Array4x4x4<Real>, Real, Index<Upper, TIndex1>, TIndex2, TIndex3>
+            Tensor<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, Index<Lower, TIndex2>, Index<Lower, TIndex3>>,
+            Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, TIndex2, TIndex3>
             >(ref result);
     }
 

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -44,27 +44,27 @@ public static partial class DifGeo
 
     /// <summary>Compute the Christoffel symbol of the first kind given a metric tensor.</summary>
     /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    /// <typeparam name="TIndex1">The first index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TIndex2">The second index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TIndex3">The third index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TPointIndex">The index of the point at which to compute the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex1Name">The first index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex2Name">The second index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex3Name">The third index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TPointIndexName">The index of the point at which to compute the Christoffel symbol</typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="metric">A metric tensor</param>
     /// <param name="point">A point on the manifold</param>
     /// <param name="christoffel">The result</param>
-    public static void Christoffel<TNumber, TIndex1, TIndex2, TIndex3, TPointIndex>(
+    public static void Christoffel<TNumber, TIndex1Name, TIndex2Name, TIndex3Name, TPointIndexName>(
         ITape<TNumber> tape,
-        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndex>> metric,
-        AutoDiffTensor4<TNumber, Index<Upper, TPointIndex>> point,
-        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, TIndex1>, TIndex2, TIndex3> christoffel)
+        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndexName>> metric,
+        AutoDiffTensor4<TNumber, Index<Upper, TPointIndexName>> point,
+        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, TIndex1Name>, TIndex2Name, TIndex3Name> christoffel)
         where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
-        where TIndex1 : ISymbol
-        where TIndex2 : ISymbol
-        where TIndex3 : ISymbol
-        where TPointIndex : ISymbol
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+        where TIndex3Name : ISymbol
+        where TPointIndexName : ISymbol
     {
         christoffel = new();
-        var diff = metric.ElementGradient<TIndex1, TIndex2>(tape, point);
+        var diff = metric.ElementGradient<TIndex1Name, TIndex2Name>(tape, point);
 
         for (int k = 0; k < 4; k++)
         {
@@ -80,35 +80,35 @@ public static partial class DifGeo
 
     /// <summary>Compute the Christoffel symbol of the second kind given a metric tensor.</summary>
     /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-    /// <typeparam name="TIndex1">The first index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TIndex2">The second index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TIndex3">The third index of the Christoffel symbol</typeparam>
-    /// <typeparam name="TPointIndex">The index of the point at which to compute the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex1Name">The first index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex2Name">The second index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TIndex3Name">The third index of the Christoffel symbol</typeparam>
+    /// <typeparam name="TPointIndexName">The index of the point at which to compute the Christoffel symbol</typeparam>
     /// <param name="tape">A gradient or Hessian tape</param>
     /// <param name="metric">A metric tensor</param>
     /// <param name="point">A point on the manifold</param>
     /// <param name="christoffel">The result</param>
-    public static void Christoffel<TNumber, TIndex1, TIndex2, TIndex3, TPointIndex>(
+    public static void Christoffel<TNumber, TIndex1Name, TIndex2Name, TIndex3Name, TPointIndexName>(
         ITape<TNumber> tape,
-        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndex>> metric,
-        AutoDiffTensor4<TNumber, Index<Upper, TPointIndex>> position,
-        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, TIndex2, TIndex3> christoffel)
+        MetricTensorField<ITape<TNumber>, Matrix4x4<TNumber>, TNumber, Index<Upper, TPointIndexName>> metric,
+        AutoDiffTensor4<TNumber, Index<Upper, TPointIndexName>> position,
+        out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1Name>, TIndex2Name, TIndex3Name> christoffel)
         where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
-        where TIndex1 : ISymbol
-        where TIndex2 : ISymbol
-        where TIndex3 : ISymbol
-        where TPointIndex : ISymbol
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+        where TIndex3Name : ISymbol
+        where TPointIndexName : ISymbol
     {
         var inverseMetric = metric
-            .Compute<TIndex1, InternalIndex1>(tape, position)
+            .Compute<TIndex1Name, InternalIndex1>(tape, position)
             .Inverse();
-        Christoffel(tape, metric, position, out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, InternalIndex1>, TIndex2, TIndex3> christoffelFirstKind);
+        Christoffel(tape, metric, position, out Christoffel<Array4x4x4<TNumber>, TNumber, Index<Lower, InternalIndex1>, TIndex2Name, TIndex3Name> christoffelFirstKind);
 
         var result = Contract(inverseMetric, christoffelFirstKind);
 
         christoffel = Unsafe.As<
-            Tensor<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, Index<Lower, TIndex2>, Index<Lower, TIndex3>>,
-            Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1>, TIndex2, TIndex3>
+            Tensor<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1Name>, Index<Lower, TIndex2Name>, Index<Lower, TIndex3Name>>,
+            Christoffel<Array4x4x4<TNumber>, TNumber, Index<Upper, TIndex1Name>, TIndex2Name, TIndex3Name>
             >(ref result);
     }
 

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeoExtensions.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeoExtensions.cs
@@ -25,15 +25,22 @@
 // SOFTWARE.
 // </copyright>
 
+using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
 using Mathematics.NET.LinearAlgebra;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+using Mathematics.NET.Symbols;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>A class containing difgeo extension methods</summary>
 public static class DifGeoExtensions
 {
+    //
+    // AutoDiff
+    //
+
     /// <summary>Create an autodiff, rank-one tensor from a real vector.</summary>
     /// <typeparam name="T">An index</typeparam>
     /// <param name="tape">A type that implements <see cref="ITape{T}"/></param>
@@ -153,4 +160,42 @@ public static class DifGeoExtensions
     public static AutoDiffTensor4<Complex, T> CreateAutoDiffTensor<T>(this ITape<Complex> tape, Complex x0Seed, Complex x1Seed, Complex x2Seed, Complex x3Seed)
         where T : IIndex
         => new(tape.CreateVariable(x0Seed), tape.CreateVariable(x1Seed), tape.CreateVariable(x2Seed), tape.CreateVariable(x3Seed));
+
+    //
+    // Calculus
+    //
+
+    /// <summary>Compute the inverse of a metric tensor with lower indices.</summary>
+    /// <typeparam name="TSquareMatrix">A type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+    /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <typeparam name="TIndex1Name">The first index of the metric tensor</typeparam>
+    /// <typeparam name="TIndex2Name">The second index of the metric tensor</typeparam>
+    /// <param name="metric">The metric tensor</param>
+    /// <returns>A metric tensor with upper indices</returns>
+    public static MetricTensor<TSquareMatrix, TNumber, Upper, TIndex1Name, TIndex2Name> Inverse<TSquareMatrix, TNumber, TIndex1Name, TIndex2Name>(this MetricTensor<TSquareMatrix, TNumber, Lower, TIndex1Name, TIndex2Name> metric)
+        where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+        where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+    {
+        var inverse = Unsafe.As<MetricTensor<TSquareMatrix, TNumber, Lower, TIndex1Name, TIndex2Name>, TSquareMatrix>(ref metric).Inverse();
+        return Unsafe.As<TSquareMatrix, MetricTensor<TSquareMatrix, TNumber, Upper, TIndex1Name, TIndex2Name>>(ref inverse);
+    }
+
+    /// <summary>Compute the inverse of a metric tensor with upper indices.</summary>
+    /// <typeparam name="TSquareMatrix">A type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+    /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+    /// <typeparam name="TIndex1Name">The first index of the metric tensor</typeparam>
+    /// <typeparam name="TIndex2Name">The second index of the metric tensor</typeparam>
+    /// <param name="metric">The metric tensor</param>
+    /// <returns>A metric tensor with lower indices</returns>
+    public static MetricTensor<TSquareMatrix, TNumber, Lower, TIndex1Name, TIndex2Name> Inverse<TSquareMatrix, TNumber, TIndex1Name, TIndex2Name>(this MetricTensor<TSquareMatrix, TNumber, Upper, TIndex1Name, TIndex2Name> metric)
+        where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+        where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+    {
+        var inverse = Unsafe.As<MetricTensor<TSquareMatrix, TNumber, Upper, TIndex1Name, TIndex2Name>, TSquareMatrix>(ref metric).Inverse();
+        return Unsafe.As<TSquareMatrix, MetricTensor<TSquareMatrix, TNumber, Lower, TIndex1Name, TIndex2Name>>(ref inverse);
+    }
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Index.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Index.cs
@@ -31,13 +31,13 @@ using Mathematics.NET.Symbols;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a tensor index</summary>
-/// <typeparam name="T">An index position</typeparam>
-/// <typeparam name="U">A symbol</typeparam>
-public struct Index<T, U> : IIndex
-    where T : IIndexPosition
-    where U : ISymbol
+/// <typeparam name="TIndexPosition">An index position</typeparam>
+/// <typeparam name="TIndexName">A symbol</typeparam>
+public struct Index<TIndexPosition, TIndexName> : IIndex
+    where TIndexPosition : IIndexPosition
+    where TIndexName : ISymbol
 {
-    public static IIndex Instance => new Index<T, U>();
+    public static IIndex Instance => new Index<TIndexPosition, TIndexName>();
 
     //
     // Formatting
@@ -45,5 +45,5 @@ public struct Index<T, U> : IIndex
 
     public override readonly string ToString() => ToString(null, null);
 
-    public readonly string ToString(string? format, IFormatProvider? provider) => $"{T.DisplayString} {U.DisplayString}";
+    public readonly string ToString(string? format, IFormatProvider? provider) => $"{TIndexPosition.DisplayString} {TIndexName.DisplayString}";
 }

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
@@ -36,50 +36,50 @@ using Mathematics.NET.Symbols;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a metric tensor</summary>
-/// <typeparam name="T">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">An index position</typeparam>
-/// <typeparam name="W">The name of the first index</typeparam>
-/// <typeparam name="X">The name of the second index</typeparam>
+/// <typeparam name="TSquareMatrix">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndexPosition">An index position</typeparam>
+/// <typeparam name="TIndex1Name">The name of the first index</typeparam>
+/// <typeparam name="TIndex2Name">The name of the second index</typeparam>
 /// <param name="matrix">A backing matrix</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct MetricTensor<T, U, V, W, X>(T matrix)
-    : IRankTwoTensor<MetricTensor<T, U, V, W, X>, T, U, Index<V, W>, Index<V, X>>,
-      IAdditionOperation<MetricTensor<T, U, V, W, X>, Tensor<T, U, Index<V, W>, Index<V, X>>>,
-      ISubtractionOperation<MetricTensor<T, U, V, W, X>, Tensor<T, U, Index<V, W>, Index<V, X>>>
-    where T : ISquareMatrix<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndexPosition
-    where W : ISymbol
-    where X : ISymbol
+public struct MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>(TSquareMatrix matrix)
+    : IRankTwoTensor<MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>, TSquareMatrix, TNumber, Index<TIndexPosition, TIndex1Name>, Index<TIndexPosition, TIndex2Name>>,
+      IAdditionOperation<MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>, Tensor<TSquareMatrix, TNumber, Index<TIndexPosition, TIndex1Name>, Index<TIndexPosition, TIndex2Name>>>,
+      ISubtractionOperation<MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>, Tensor<TSquareMatrix, TNumber, Index<TIndexPosition, TIndex1Name>, Index<TIndexPosition, TIndex2Name>>>
+    where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndexPosition : IIndexPosition
+    where TIndex1Name : ISymbol
+    where TIndex2Name : ISymbol
 {
-    public static readonly MetricTensor<T, U, V, W, X> Euclidean = T.Identity;
+    public static readonly MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> Euclidean = TSquareMatrix.Identity;
 
-    private T _matrix = matrix;
+    private TSquareMatrix _matrix = matrix;
 
     //
     // IRankTwoTensor interface
     //
 
-    public readonly IIndex I1 => Index<V, W>.Instance;
+    public readonly IIndex I1 => Index<TIndexPosition, TIndex1Name>.Instance;
 
-    public readonly IIndex I2 => Index<V, X>.Instance;
+    public readonly IIndex I2 => Index<TIndexPosition, TIndex2Name>.Instance;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => TSquareMatrix.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => TSquareMatrix.E1Components;
 
-    public static int E2Components => T.E2Components;
+    public static int E2Components => TSquareMatrix.E2Components;
 
     //
     // Indexer
     //
 
-    public U this[int row, int column]
+    public TNumber this[int row, int column]
     {
         get => _matrix[row, column];
         set => _matrix[row, column] = value;
@@ -89,25 +89,25 @@ public struct MetricTensor<T, U, V, W, X>(T matrix)
     // Operators
     //
 
-    public static Tensor<T, U, Index<V, W>, Index<V, X>> operator +(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static Tensor<TSquareMatrix, TNumber, Index<TIndexPosition, TIndex1Name>, Index<TIndexPosition, TIndex2Name>> operator +(MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> left, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> right)
         => left._matrix + right._matrix;
 
-    public static Tensor<T, U, Index<V, W>, Index<V, X>> operator -(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static Tensor<TSquareMatrix, TNumber, Index<TIndexPosition, TIndex1Name>, Index<TIndexPosition, TIndex2Name>> operator -(MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> left, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> right)
         => left._matrix - right._matrix;
 
     //
     // Equality
     //
 
-    public static bool operator ==(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static bool operator ==(MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> left, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> right)
         => left._matrix == right._matrix;
 
-    public static bool operator !=(MetricTensor<T, U, V, W, X> left, MetricTensor<T, U, V, W, X> right)
+    public static bool operator !=(MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> left, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> right)
         => left._matrix == right._matrix;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is MetricTensor<T, U, V, W, X> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> other && Equals(other);
 
-    public readonly bool Equals(MetricTensor<T, U, V, W, X> value) => _matrix.Equals(value._matrix);
+    public readonly bool Equals(MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name> value) => _matrix.Equals(value._matrix);
 
     public override readonly int GetHashCode() => HashCode.Combine(_matrix);
 
@@ -122,22 +122,22 @@ public struct MetricTensor<T, U, V, W, X>(T matrix)
     //
 
     /// <summary>Create a tensor with a new index in the first position.</summary>
-    /// <typeparam name="Y">A symbol</typeparam>
+    /// <typeparam name="TNewIndexName">A symbol</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
-    public MetricTensor<T, U, V, Y, X> WithIndexOne<Y>()
-        where Y : ISymbol
-        => Unsafe.As<MetricTensor<T, U, V, W, X>, MetricTensor<T, U, V, Y, X>>(ref this);
+    public MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TNewIndexName, TIndex2Name> WithIndexOne<TNewIndexName>()
+        where TNewIndexName : ISymbol
+        => Unsafe.As<MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TNewIndexName, TIndex2Name>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
-    /// <typeparam name="Y">A symbol</typeparam>
+    /// <typeparam name="TNewIndexName">A symbol</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
-    public MetricTensor<T, U, V, W, Y> WithIndexTwo<Y>()
-        where Y : ISymbol
-        => Unsafe.As<MetricTensor<T, U, V, W, X>, MetricTensor<T, U, V, W, Y>>(ref this);
+    public MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TNewIndexName> WithIndexTwo<TNewIndexName>()
+        where TNewIndexName : ISymbol
+        => Unsafe.As<MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>, MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TNewIndexName>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator MetricTensor<T, U, V, W, X>(T input) => new(input);
+    public static implicit operator MetricTensor<TSquareMatrix, TNumber, TIndexPosition, TIndex1Name, TIndex2Name>(TSquareMatrix input) => new(input);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensorField.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensorField.cs
@@ -1,0 +1,96 @@
+﻿// <copyright file="MetricTensorField.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+using Mathematics.NET.Symbols;
+
+namespace Mathematics.NET.DifferentialGeometry;
+
+/// <summary>Represents a metric tensor field</summary>
+/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TSquareMatrix">A type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TPointIndex">An index name</typeparam>
+public abstract class MetricTensorField<TTape, TSquareMatrix, TNumber, TPointIndex> : TensorField4x4<TTape, TNumber, Lower, Lower, TPointIndex>
+    where TTape : ITape<TNumber>
+    where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TPointIndex : IIndex
+{
+    public MetricTensorField() { }
+
+    public new MetricTensor<Matrix4x4<TNumber>, TNumber, Lower, TIndex1, TIndex2> Compute<TIndex1, TIndex2>(TTape tape, AutoDiffTensor4<TNumber, TPointIndex> x)
+        where TIndex1 : ISymbol
+        where TIndex2 : ISymbol
+    {
+        tape.IsTracking = false;
+
+        Matrix4x4<TNumber> result = new();
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                if (_buffer[i][j] is Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> function)
+                {
+                    result[i, j] = function(tape, x).Value;
+                }
+            }
+        }
+
+        tape.IsTracking = true;
+        return new MetricTensor<Matrix4x4<TNumber>, TNumber, Lower, TIndex1, TIndex2>(result);
+    }
+
+    /// <inheritdoc cref="TensorField4x4{TTape, TNumber, TIndex1Position, TIndex2Position, TPointIndex}.ElementGradient{TIndex1Name, TIndex2Name}(TTape, AutoDiffTensor4{TNumber, TPointIndex})"/>
+    public new ReadOnlySpan<MetricTensor<Matrix4x4<TNumber>, TNumber, Lower, TIndex1Name, TIndex2Name>> ElementGradient<TIndex1Name, TIndex2Name>(TTape tape, AutoDiffTensor4<TNumber, TPointIndex> point)
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+    {
+        Span<MetricTensor<Matrix4x4<TNumber>, TNumber, Lower, TIndex1Name, TIndex2Name>> result = new MetricTensor<Matrix4x4<TNumber>, TNumber, Lower, TIndex1Name, TIndex2Name>[4];
+
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                if (this[i, j] is Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> function)
+                {
+                    _ = function(tape, point);
+                    tape.ReverseAccumulate(out var gradient);
+
+                    result[0][i, j] = gradient[0];
+                    result[1][i, j] = gradient[1];
+                    result[2][i, j] = gradient[2];
+                    result[3][i, j] = gradient[3];
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/Mathematics.NET/DifferentialGeometry/TensorField4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/TensorField4.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="TensorField4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Core.Buffers;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
+using Mathematics.NET.Symbols;
+
+namespace Mathematics.NET.DifferentialGeometry;
+
+/// <summary>Represents a rank-one tensor field with four elements</summary>
+/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndexPosition">An index position</typeparam>
+/// <typeparam name="TPointIndex">An index</typeparam>
+public class TensorField4<TTape, TNumber, TIndexPosition, TPointIndex> : TensorField<TNumber, TPointIndex>
+    where TTape : ITape<TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndexPosition : IIndexPosition
+    where TPointIndex : IIndex
+{
+    private AutoDiffTensor4Buffer4<TTape, TNumber, TPointIndex> _buffer;
+
+    public TensorField4() { }
+
+    public Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _buffer[index];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _buffer[index] = value;
+    }
+
+    /// <summary>Compute the gradient of all elements of the tensor.</summary>
+    /// <typeparam name="TIndexName">The first index of the result tensor</typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="point">A point on the manifold</param>
+    /// <returns>A read-only span of gradients</returns>
+    public ReadOnlySpan<Tensor<Vector4<TNumber>, TNumber, Index<TIndexPosition, TIndexName>>> ElementGradient<TIndexName>(
+        TTape tape,
+        AutoDiffTensor4<TNumber, TPointIndex> point)
+        where TIndexName : ISymbol
+    {
+        Span<Tensor<Vector4<TNumber>, TNumber, Index<TIndexPosition, TIndexName>>> result = new Tensor<Vector4<TNumber>, TNumber, Index<TIndexPosition, TIndexName>>[4];
+
+        for (int i = 0; i < 4; i++)
+        {
+            if (this[i] is Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                result[0][i] = gradient[0];
+                result[1][i] = gradient[1];
+                result[2][i] = gradient[2];
+                result[3][i] = gradient[3];
+            }
+        }
+        return result;
+    }
+}

--- a/src/Mathematics.NET/DifferentialGeometry/TensorField4x4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/TensorField4x4.cs
@@ -1,0 +1,117 @@
+﻿// <copyright file="TensorField4x4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Core.Buffers;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
+using Mathematics.NET.Symbols;
+
+namespace Mathematics.NET.DifferentialGeometry;
+
+/// <summary>Represents a rank-two tensor field with 16 elements</summary>
+/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TIndex1Position">An index</typeparam>
+/// <typeparam name="TIndex2Position">An index</typeparam>
+/// <typeparam name="TPointIndex">An index</typeparam>
+public class TensorField4x4<TTape, TNumber, TIndex1Position, TIndex2Position, TPointIndex> : TensorField<TNumber, TPointIndex>
+    where TTape : ITape<TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1Position : IIndexPosition
+    where TIndex2Position : IIndexPosition
+    where TPointIndex : IIndex
+{
+    private protected AutoDiffTensor4Buffer4x4<TTape, TNumber, TPointIndex> _buffer;
+
+    public TensorField4x4() { }
+
+    public Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> this[int row, int column]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _buffer[row][column];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _buffer[row][column] = value;
+    }
+
+    public Tensor<Matrix4x4<TNumber>, TNumber, Index<TIndex1Position, TIndex1>, Index<TIndex2Position, TIndex2>> Compute<TIndex1, TIndex2>(TTape tape, AutoDiffTensor4<TNumber, TPointIndex> x)
+        where TIndex1 : ISymbol
+        where TIndex2 : ISymbol
+    {
+        tape.IsTracking = false;
+
+        Matrix4x4<TNumber> result = new();
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                if (_buffer[i][j] is Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> function)
+                {
+                    result[i, j] = function(tape, x).Value;
+                }
+            }
+        }
+
+        tape.IsTracking = true;
+        return new Tensor<Matrix4x4<TNumber>, TNumber, Index<TIndex1Position, TIndex1>, Index<TIndex2Position, TIndex2>>(result);
+    }
+
+    /// <summary>Compute the gradient of all elements of the tensor.</summary>
+    /// <typeparam name="TIndex1Name">The first index of the result tensor</typeparam>
+    /// <typeparam name="TIndex2Name">The second index of the result tensor</typeparam>
+    /// <param name="tape">A gradient or Hessian tape</param>
+    /// <param name="point">A point on the manifold</param>
+    /// <returns>A read-only span of gradients</returns>
+    public ReadOnlySpan<Tensor<Matrix4x4<TNumber>, TNumber, Index<TIndex1Position, TIndex1Name>, Index<TIndex2Position, TIndex2Name>>> ElementGradient<TIndex1Name, TIndex2Name>(
+        TTape tape,
+        AutoDiffTensor4<TNumber, TPointIndex> point)
+        where TIndex1Name : ISymbol
+        where TIndex2Name : ISymbol
+    {
+        Span<Tensor<Matrix4x4<TNumber>, TNumber, Index<TIndex1Position, TIndex1Name>, Index<TIndex2Position, TIndex2Name>>> result = new Tensor<Matrix4x4<TNumber>, TNumber, Index<TIndex1Position, TIndex1Name>, Index<TIndex2Position, TIndex2Name>>[4];
+
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                if (this[i, j] is Func<TTape, AutoDiffTensor4<TNumber, TPointIndex>, Variable<TNumber>> function)
+                {
+                    _ = function(tape, point);
+                    tape.ReverseAccumulate(out var gradient);
+
+                    result[0][i, j] = gradient[0];
+                    result[1][i, j] = gradient[1];
+                    result[2][i, j] = gradient[2];
+                    result[3][i, j] = gradient[3];
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
@@ -34,7 +34,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a rank-one tensor</summary>
+/// <summary>Represents a rank-one tensor or a similar mathematical object</summary>
 /// <typeparam name="TVector">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex">An index</typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
@@ -35,40 +35,40 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-one tensor</summary>
-/// <typeparam name="T">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">An index</typeparam>
+/// <typeparam name="TVector">A backing type that implements <see cref="IVector{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex">An index</typeparam>
 /// <param name="vector">A backing vector</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<T, U, V>(T vector)
-    : IRankOneTensor<Tensor<T, U, V>, T, U, V>,
-      IAdditionOperation<Tensor<T, U, V>, Tensor<T, U, V>>,
-      ISubtractionOperation<Tensor<T, U, V>, Tensor<T, U, V>>
-    where T : IVector<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
+public struct Tensor<TVector, TNumber, TIndex>(TVector vector)
+    : IRankOneTensor<Tensor<TVector, TNumber, TIndex>, TVector, TNumber, TIndex>,
+      IAdditionOperation<Tensor<TVector, TNumber, TIndex>, Tensor<TVector, TNumber, TIndex>>,
+      ISubtractionOperation<Tensor<TVector, TNumber, TIndex>, Tensor<TVector, TNumber, TIndex>>
+    where TVector : IVector<TVector, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex : IIndex
 {
-    private T _vector = vector;
+    private TVector _vector = vector;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => TVector.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => TVector.E1Components;
 
     //
     // IRankOneTensor interface
     //
 
-    public readonly IIndex I1 => V.Instance;
+    public readonly IIndex I1 => TIndex.Instance;
 
     //
     // Indexer
     //
 
-    public U this[int index]
+    public TNumber this[int index]
     {
         get => _vector[index];
         set => _vector[index] = value;
@@ -78,25 +78,25 @@ public struct Tensor<T, U, V>(T vector)
     // Operators
     //
 
-    public static Tensor<T, U, V> operator +(Tensor<T, U, V> left, Tensor<T, U, V> right)
+    public static Tensor<TVector, TNumber, TIndex> operator +(Tensor<TVector, TNumber, TIndex> left, Tensor<TVector, TNumber, TIndex> right)
         => new(left._vector + right._vector);
 
-    public static Tensor<T, U, V> operator -(Tensor<T, U, V> left, Tensor<T, U, V> right)
+    public static Tensor<TVector, TNumber, TIndex> operator -(Tensor<TVector, TNumber, TIndex> left, Tensor<TVector, TNumber, TIndex> right)
         => new(left._vector - right._vector);
 
     //
     // Equality
     //
 
-    public static bool operator ==(Tensor<T, U, V> left, Tensor<T, U, V> right)
+    public static bool operator ==(Tensor<TVector, TNumber, TIndex> left, Tensor<TVector, TNumber, TIndex> right)
         => left._vector == right._vector;
 
-    public static bool operator !=(Tensor<T, U, V> left, Tensor<T, U, V> right)
+    public static bool operator !=(Tensor<TVector, TNumber, TIndex> left, Tensor<TVector, TNumber, TIndex> right)
         => left._vector != right._vector;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<TVector, TNumber, TIndex> other && Equals(other);
 
-    public readonly bool Equals(Tensor<T, U, V> value) => _vector.Equals(value._vector);
+    public readonly bool Equals(Tensor<TVector, TNumber, TIndex> value) => _vector.Equals(value._vector);
 
     public override readonly int GetHashCode() => HashCode.Combine(_vector);
 
@@ -111,16 +111,16 @@ public struct Tensor<T, U, V>(T vector)
     //
 
     /// <summary>Create a tensor with a new index.</summary>
-    /// <typeparam name="W">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, W> WithIndex<W>()
-        where W : IIndex
-        => Unsafe.As<Tensor<T, U, V>, Tensor<T, U, W>>(ref this);
+    public Tensor<TVector, TNumber, TNewIndex> WithIndex<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TVector, TNumber, TIndex>, Tensor<TVector, TNumber, TNewIndex>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Tensor<T, U, V>(T input) => new(input);
+    public static implicit operator Tensor<TVector, TNumber, TIndex>(TVector input) => new(input);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
@@ -34,7 +34,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a rank-two tensor</summary>
+/// <summary>Represents a rank-two tensor or a similar mathematical object</summary>
 /// <typeparam name="TSquareMatrix">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex1">The first index</typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
@@ -35,46 +35,46 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-two tensor</summary>
-/// <typeparam name="T">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">The first index</typeparam>
-/// <typeparam name="W">The second index</typeparam>
+/// <typeparam name="TSquareMatrix">A backing type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">The first index</typeparam>
+/// <typeparam name="TIndex2">The second index</typeparam>
 /// <param name="matrix">A backing matrix</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<T, U, V, W>(T matrix)
-    : IRankTwoTensor<Tensor<T, U, V, W>, T, U, V, W>,
-      IAdditionOperation<Tensor<T, U, V, W>, Tensor<T, U, V, W>>,
-      ISubtractionOperation<Tensor<T, U, V, W>, Tensor<T, U, V, W>>
-    where T : ISquareMatrix<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
-    where W : IIndex
+public struct Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>(TSquareMatrix matrix)
+    : IRankTwoTensor<Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>, TSquareMatrix, TNumber, TIndex1, TIndex2>,
+      IAdditionOperation<Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>>,
+      ISubtractionOperation<Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>>
+    where TSquareMatrix : ISquareMatrix<TSquareMatrix, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
 {
-    private T _matrix = matrix;
+    private TSquareMatrix _matrix = matrix;
 
     //
     // IRankTwoTensor interface
     //
 
-    public readonly IIndex I1 => V.Instance;
+    public readonly IIndex I1 => TIndex1.Instance;
 
-    public readonly IIndex I2 => W.Instance;
+    public readonly IIndex I2 => TIndex2.Instance;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => TSquareMatrix.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => TSquareMatrix.E1Components;
 
-    public static int E2Components => T.E2Components;
+    public static int E2Components => TSquareMatrix.E2Components;
 
     //
     // Indexer
     //
 
-    public U this[int row, int column]
+    public TNumber this[int row, int column]
     {
         get => _matrix[row, column];
         set => _matrix[row, column] = value;
@@ -84,25 +84,25 @@ public struct Tensor<T, U, V, W>(T matrix)
     // Operators
     //
 
-    public static Tensor<T, U, V, W> operator +(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
+    public static Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> operator +(Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> left, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> right)
         => left._matrix + right._matrix;
 
-    public static Tensor<T, U, V, W> operator -(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
+    public static Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> operator -(Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> left, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> right)
         => left._matrix - right._matrix;
 
     //
     // Equality
     //
 
-    public static bool operator ==(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
+    public static bool operator ==(Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> left, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> right)
         => left._matrix == right._matrix;
 
-    public static bool operator !=(Tensor<T, U, V, W> left, Tensor<T, U, V, W> right)
+    public static bool operator !=(Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> left, Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> right)
         => left._matrix != right._matrix;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> other && Equals(other);
 
-    public readonly bool Equals(Tensor<T, U, V, W> value) => _matrix.Equals(value._matrix);
+    public readonly bool Equals(Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2> value) => _matrix.Equals(value._matrix);
 
     public override readonly int GetHashCode() => HashCode.Combine(_matrix);
 
@@ -117,24 +117,24 @@ public struct Tensor<T, U, V, W>(T matrix)
     //
 
     /// <summary>Create a tensor with a new index in the first position.</summary>
-    /// <typeparam name="X">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, X, W> WithIndexOne<X>()
-        where X : IIndex
-        => Unsafe.As<Tensor<T, U, V, W>, Tensor<T, U, X, W>>(ref this);
+    public Tensor<TSquareMatrix, TNumber, TNewIndex, TIndex2> WithIndexOne<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>, Tensor<TSquareMatrix, TNumber, TNewIndex, TIndex2>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
-    /// <typeparam name="X">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, X> WithIndexTwo<X>()
-        where X : IIndex
-        => Unsafe.As<Tensor<T, U, V, W>, Tensor<T, U, V, X>>(ref this);
+    public Tensor<TSquareMatrix, TNumber, TIndex1, TNewIndex> WithIndexTwo<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>, Tensor<TSquareMatrix, TNumber, TIndex1, TNewIndex>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Tensor<T, U, V, W>(T input) => new(input);
+    public static implicit operator Tensor<TSquareMatrix, TNumber, TIndex1, TIndex2>(TSquareMatrix input) => new(input);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
@@ -34,50 +34,50 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-three tensor</summary>
-/// <typeparam name="T">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">The first index</typeparam>
-/// <typeparam name="W">The second index</typeparam>
-/// <typeparam name="X">The third index</typeparam>
+/// <typeparam name="TCubicArray">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">The first index</typeparam>
+/// <typeparam name="TIndex2">The second index</typeparam>
+/// <typeparam name="TIndex3">The third index</typeparam>
 /// <param name="array">A backing array</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<T, U, V, W, X>(T array)
-    : IRankThreeTensor<Tensor<T, U, V, W, X>, T, U, V, W, X>
-    where T : ICubicArray<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
-    where W : IIndex
-    where X : IIndex
+public struct Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>(TCubicArray array)
+    : IRankThreeTensor<Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>, TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>
+    where TCubicArray : ICubicArray<TCubicArray, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
+    where TIndex3 : IIndex
 {
-    private T _array = array;
+    private TCubicArray _array = array;
 
     //
     // IRankThreeTensor interface
     //
 
-    public readonly IIndex I1 => V.Instance;
+    public readonly IIndex I1 => TIndex1.Instance;
 
-    public readonly IIndex I2 => W.Instance;
+    public readonly IIndex I2 => TIndex2.Instance;
 
-    public readonly IIndex I3 => X.Instance;
+    public readonly IIndex I3 => TIndex3.Instance;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => TCubicArray.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => TCubicArray.E1Components;
 
-    public static int E2Components => T.E2Components;
+    public static int E2Components => TCubicArray.E2Components;
 
-    public static int E3Components => T.E3Components;
+    public static int E3Components => TCubicArray.E3Components;
 
     //
     // Indexer
     //
 
-    public U this[int i, int j, int k]
+    public TNumber this[int i, int j, int k]
     {
         get => _array[i, j, k];
         set => _array[i, j, k] = value;
@@ -87,15 +87,15 @@ public struct Tensor<T, U, V, W, X>(T array)
     // Equality
     //
 
-    public static bool operator ==(Tensor<T, U, V, W, X> left, Tensor<T, U, V, W, X> right)
+    public static bool operator ==(Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> left, Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> right)
         => left._array == right._array;
 
-    public static bool operator !=(Tensor<T, U, V, W, X> left, Tensor<T, U, V, W, X> right)
+    public static bool operator !=(Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> left, Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W, X> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> other && Equals(other);
 
-    public readonly bool Equals(Tensor<T, U, V, W, X> value) => _array.Equals(value._array);
+    public readonly bool Equals(Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -110,32 +110,32 @@ public struct Tensor<T, U, V, W, X>(T array)
     //
 
     /// <summary>Create a tensor with a new index in the first position.</summary>
-    /// <typeparam name="Y">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, Y, W, X> WithIndexOne<Y>()
-        where Y : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, Y, W, X>>(ref this);
+    public Tensor<TCubicArray, TNumber, TNewIndex, TIndex2, TIndex3> WithIndexOne<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>, Tensor<TCubicArray, TNumber, TNewIndex, TIndex2, TIndex3>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
-    /// <typeparam name="Y">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, Y, X> WithIndexTwo<Y>()
-        where Y : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, V, Y, X>>(ref this);
+    public Tensor<TCubicArray, TNumber, TIndex1, TNewIndex, TIndex3> WithIndexTwo<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>, Tensor<TCubicArray, TNumber, TIndex1, TNewIndex, TIndex3>>(ref this);
 
     /// <summary>Create a tensor with a new index in the third position.</summary>
-    /// <typeparam name="Y">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the third position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, W, Y> WithIndexThree<Y>()
-        where Y : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X>, Tensor<T, U, V, W, Y>>(ref this);
+    public Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TNewIndex> WithIndexThree<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>, Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TNewIndex>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Tensor<T, U, V, W, X>(T value) => new(value);
+    public static implicit operator Tensor<TCubicArray, TNumber, TIndex1, TIndex2, TIndex3>(TCubicArray value) => new(value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
@@ -33,7 +33,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a rank-three tensor</summary>
+/// <summary>Represents a rank-three tensor or a similar mathematical object</summary>
 /// <typeparam name="TCubicArray">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex1">The first index</typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -33,7 +33,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a rank-four tensor</summary>
+/// <summary>Represents a rank-four tensor or a similar mathematical object</summary>
 /// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex1">The first index</typeparam>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -34,7 +34,7 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-four tensor or a similar mathematical object</summary>
-/// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
+/// <typeparam name="THypercubic4DArray">A backing type that implements <see cref="IHypercubic4DArray{T, U}"/></typeparam>
 /// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
 /// <typeparam name="TIndex1">The first index</typeparam>
 /// <typeparam name="TIndex2">The second index</typeparam>
@@ -42,16 +42,16 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="TIndex4">The fourth index</typeparam>
 /// <param name="array">A backing array</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THyperCubic4DArray array)
-    : IRankFourTensor<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
-    where THyperCubic4DArray : IHyperCubic4DArray<THyperCubic4DArray, TNumber>
+public struct Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THypercubic4DArray array)
+    : IRankFourTensor<Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
+    where THypercubic4DArray : IHypercubic4DArray<THypercubic4DArray, TNumber>
     where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
     where TIndex1 : IIndex
     where TIndex2 : IIndex
     where TIndex3 : IIndex
     where TIndex4 : IIndex
 {
-    private THyperCubic4DArray _array = array;
+    private THypercubic4DArray _array = array;
 
     //
     // IRankFourTensor interface
@@ -69,15 +69,15 @@ public struct Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIn
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => THyperCubic4DArray.Components;
+    public static int Components => THypercubic4DArray.Components;
 
-    public static int E1Components => THyperCubic4DArray.E1Components;
+    public static int E1Components => THypercubic4DArray.E1Components;
 
-    public static int E2Components => THyperCubic4DArray.E2Components;
+    public static int E2Components => THypercubic4DArray.E2Components;
 
-    public static int E3Components => THyperCubic4DArray.E3Components;
+    public static int E3Components => THypercubic4DArray.E3Components;
 
-    public static int E4Components => THyperCubic4DArray.E4Components;
+    public static int E4Components => THypercubic4DArray.E4Components;
 
     //
     // Indexer
@@ -93,15 +93,15 @@ public struct Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIn
     // Equality
     //
 
-    public static bool operator ==(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
+    public static bool operator ==(Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
     => left._array == right._array;
 
-    public static bool operator !=(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
+    public static bool operator !=(Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> other && Equals(other);
 
-    public readonly bool Equals(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> value) => _array.Equals(value._array);
+    public readonly bool Equals(Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -119,37 +119,37 @@ public struct Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIn
     /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<THyperCubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4> WithIndexOne<TNewIndex>()
+    public Tensor<THypercubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4> WithIndexOne<TNewIndex>()
         where TNewIndex : IIndex
-        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4>>(ref this);
+        => Unsafe.As<Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THypercubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
     /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4> WithIndexTwo<TNewIndex>()
+    public Tensor<THypercubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4> WithIndexTwo<TNewIndex>()
         where TNewIndex : IIndex
-        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4>>(ref this);
+        => Unsafe.As<Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THypercubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the third position.</summary>
     /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the third position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4> WithIndexThree<TNewIndex>()
+    public Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4> WithIndexThree<TNewIndex>()
         where TNewIndex : IIndex
-        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4>>(ref this);
+        => Unsafe.As<Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the fourth position.</summary>
     /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the fourth position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex> WithIndexFour<TNewIndex>()
+    public Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex> WithIndexFour<TNewIndex>()
         where TNewIndex : IIndex
-        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex>>(ref this);
+        => Unsafe.As<Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THyperCubic4DArray value) => new(value);
+    public static implicit operator Tensor<THypercubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THypercubic4DArray value) => new(value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -34,56 +34,56 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a rank-four tensor</summary>
-/// <typeparam name="T">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
-/// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="V">The first index</typeparam>
-/// <typeparam name="W">The second index</typeparam>
-/// <typeparam name="X">The third index</typeparam>
-/// <typeparam name="Y">The fourth index</typeparam>
+/// <typeparam name="THyperCubic4DArray">A backing type that implements <see cref="IHyperCubic4DArray{T, U}"/></typeparam>
+/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/></typeparam>
+/// <typeparam name="TIndex1">The first index</typeparam>
+/// <typeparam name="TIndex2">The second index</typeparam>
+/// <typeparam name="TIndex3">The third index</typeparam>
+/// <typeparam name="TIndex4">The fourth index</typeparam>
 /// <param name="array">A backing array</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<T, U, V, W, X, Y>(T array)
-    : IRankFourTensor<Tensor<T, U, V, W, X, Y>, T, U, V, W, X, Y>
-    where T : IHyperCubic4DArray<T, U>
-    where U : IComplex<U>, IDifferentiableFunctions<U>
-    where V : IIndex
-    where W : IIndex
-    where X : IIndex
-    where Y : IIndex
+public struct Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THyperCubic4DArray array)
+    : IRankFourTensor<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>
+    where THyperCubic4DArray : IHyperCubic4DArray<THyperCubic4DArray, TNumber>
+    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
+    where TIndex1 : IIndex
+    where TIndex2 : IIndex
+    where TIndex3 : IIndex
+    where TIndex4 : IIndex
 {
-    private T _array = array;
+    private THyperCubic4DArray _array = array;
 
     //
     // IRankFourTensor interface
     //
 
-    public readonly IIndex I1 => V.Instance;
+    public readonly IIndex I1 => TIndex1.Instance;
 
-    public readonly IIndex I2 => W.Instance;
+    public readonly IIndex I2 => TIndex2.Instance;
 
-    public readonly IIndex I3 => X.Instance;
+    public readonly IIndex I3 => TIndex3.Instance;
 
-    public readonly IIndex I4 => Y.Instance;
+    public readonly IIndex I4 => TIndex4.Instance;
 
     //
     // IArrayRepresentable & relevant interfaces
     //
 
-    public static int Components => T.Components;
+    public static int Components => THyperCubic4DArray.Components;
 
-    public static int E1Components => T.E1Components;
+    public static int E1Components => THyperCubic4DArray.E1Components;
 
-    public static int E2Components => T.E2Components;
+    public static int E2Components => THyperCubic4DArray.E2Components;
 
-    public static int E3Components => T.E3Components;
+    public static int E3Components => THyperCubic4DArray.E3Components;
 
-    public static int E4Components => T.E4Components;
+    public static int E4Components => THyperCubic4DArray.E4Components;
 
     //
     // Indexer
     //
 
-    public U this[int i, int j, int k, int l]
+    public TNumber this[int i, int j, int k, int l]
     {
         get => _array[i, j, k, l];
         set => _array[i, j, k, l] = value;
@@ -93,15 +93,15 @@ public struct Tensor<T, U, V, W, X, Y>(T array)
     // Equality
     //
 
-    public static bool operator ==(Tensor<T, U, V, W, X, Y> left, Tensor<T, U, V, W, X, Y> right)
+    public static bool operator ==(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
     => left._array == right._array;
 
-    public static bool operator !=(Tensor<T, U, V, W, X, Y> left, Tensor<T, U, V, W, X, Y> right)
+    public static bool operator !=(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> left, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<T, U, V, W, X, Y> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> other && Equals(other);
 
-    public readonly bool Equals(Tensor<T, U, V, W, X, Y> value) => _array.Equals(value._array);
+    public readonly bool Equals(Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -116,40 +116,40 @@ public struct Tensor<T, U, V, W, X, Y>(T array)
     //
 
     /// <summary>Create a tensor with a new index in the first position.</summary>
-    /// <typeparam name="Z">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, Z, W, X, Y> WithIndexOne<Z>()
-        where Z : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, Z, W, X, Y>>(ref this);
+    public Tensor<THyperCubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4> WithIndexOne<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TNewIndex, TIndex2, TIndex3, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the second position.</summary>
-    /// <typeparam name="Z">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the second position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, Z, X, Y> WithIndexTwo<Z>()
-        where Z : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, Z, X, Y>>(ref this);
+    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4> WithIndexTwo<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TNewIndex, TIndex3, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the third position.</summary>
-    /// <typeparam name="Z">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the third position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, W, Z, Y> WithIndexThree<Z>()
-        where Z : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, W, Z, Y>>(ref this);
+    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4> WithIndexThree<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TNewIndex, TIndex4>>(ref this);
 
     /// <summary>Create a tensor with a new index in the fourth position.</summary>
-    /// <typeparam name="Z">A new index</typeparam>
+    /// <typeparam name="TNewIndex">A new index</typeparam>
     /// <returns>A tensor with a new index in the fourth position</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Tensor<T, U, V, W, X, Z> WithIndexFour<Z>()
-        where Z : IIndex
-        => Unsafe.As<Tensor<T, U, V, W, X, Y>, Tensor<T, U, V, W, X, Z>>(ref this);
+    public Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex> WithIndexFour<TNewIndex>()
+        where TNewIndex : IIndex
+        => Unsafe.As<Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>, Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TNewIndex>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Tensor<T, U, V, W, X, Y>(T value) => new(value);
+    public static implicit operator Tensor<THyperCubic4DArray, TNumber, TIndex1, TIndex2, TIndex3, TIndex4>(THyperCubic4DArray value) => new(value);
 }

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IHypercubic4DArray.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IHypercubic4DArray.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IHyperCubic4DArray.cs" company="Mathematics.NET">
+﻿// <copyright file="IHypercubic4DArray.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -30,6 +30,6 @@ namespace Mathematics.NET.LinearAlgebra.Abstractions;
 /// <summary>Defines support for 4D hypercubic arrays</summary>
 /// <typeparam name="T">The type that implements the interface</typeparam>
 /// <typeparam name="U">A type that implements <see cref="IComplex{T}"/></typeparam>
-public interface IHyperCubic4DArray<T, U> : IArray4D<T, U>
-    where T : IHyperCubic4DArray<T, U>
+public interface IHypercubic4DArray<T, U> : IArray4D<T, U>
+    where T : IHypercubic4DArray<T, U>
     where U : IComplex<U>;

--- a/src/Mathematics.NET/LinearAlgebra/Array4x4x4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Array4x4x4x4.cs
@@ -35,7 +35,7 @@ namespace Mathematics.NET.LinearAlgebra;
 /// <summary>Represents a 4x4x4x4 array</summary>
 /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/></typeparam>
 [StructLayout(LayoutKind.Sequential)]
-public struct Array4x4x4x4<T> : IHyperCubic4DArray<Array4x4x4x4<T>, T>
+public struct Array4x4x4x4<T> : IHypercubic4DArray<Array4x4x4x4<T>, T>
     where T : IComplex<T>
 {
     public const int Components = 256;

--- a/src/Mathematics.NET/Symbols/InternalIndex1.cs
+++ b/src/Mathematics.NET/Symbols/InternalIndex1.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="InternalIndex1.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Mathematics.NET.Symbols;
+
+internal readonly struct InternalIndex1 : ISymbol
+{
+    /// <inheritdoc cref="ISymbol.DisplayString"/>
+    public const string DisplayString = "InternalIndex1";
+
+    static string ISymbol.DisplayString => DisplayString;
+}

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="23.5.2" />
+    <PackageReference Include="Verify.MSTest" Version="23.6.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="23.5.2" />
+    <PackageReference Include="Verify.MSTest" Version="23.6.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This update adds rank-one and rank-two tensor fields as well as all objects necessary for them to function. This is a work-in-progress, and things may be drastically changed in the future.

- Update dependencies
- Update type parameter names
- Update documentation comments
- Remove transitions from the CSS file for the documentation site
- Other minor changes