### PR TITLE
Add test for Christoffel symbols of the first kind

### DIFF
--- a/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
@@ -124,6 +124,8 @@ public struct Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA array)
     // Methods
     //
 
+    public readonly void CopyTo(ref TN[,,] destination) => _array.CopyTo(ref destination);
+
     /// <summary>Create a Christoffel symbol with a new index in the first position.</summary>
     /// <typeparam name="TNI">An index</typeparam>
     /// <returns>A Christoffel symbol with a new index in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
@@ -125,6 +125,8 @@ public struct Tensor<TCA, TN, TI1, TI2, TI3>(TCA array)
     // Methods
     //
 
+    public readonly void CopyTo(ref TN[,,] destination) => _array.CopyTo(ref destination);
+
     /// <summary>Create a tensor with a new index in the first position.</summary>
     /// <typeparam name="TNI">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -131,6 +131,8 @@ public struct Tensor<TH4DA, TN, TI1, TI2, TI3, TI4>(TH4DA array)
     // Methods
     //
 
+    public readonly void CopyTo(ref TN[,,,] destination) => _array.CopyTo(ref destination);
+
     /// <summary>Create a tensor with a new index in the first position.</summary>
     /// <typeparam name="TNI">A new index</typeparam>
     /// <returns>A tensor with a new index in the first position</returns>

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IFourDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IFourDimensionalArrayRepresentable.cs
@@ -55,4 +55,8 @@ public interface IFourDimensionalArrayRepresentable<T, U>
     /// <param name="l">The fourth index</param>
     /// <returns>The element at the specified indices</returns>
     U this[int i, int j, int k, int l] { get; set; }
+
+    /// <summary>Copy the values of this object to a 4D array.</summary>
+    /// <param name="destination">The destination array</param>
+    void CopyTo(ref U[,,,] destination);
 }

--- a/src/Mathematics.NET/LinearAlgebra/Abstractions/IThreeDimensionalArrayRepresentable.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Abstractions/IThreeDimensionalArrayRepresentable.cs
@@ -51,4 +51,8 @@ public interface IThreeDimensionalArrayRepresentable<T, U>
     /// <param name="k">The third index</param>
     /// <returns>The element at the specified indices</returns>
     U this[int i, int j, int k] { get; set; }
+
+    /// <summary>Copy the values of this object to a 3D array.</summary>
+    /// <param name="destination">The destination array</param>
+    void CopyTo(ref U[,,] destination);
 }

--- a/src/Mathematics.NET/LinearAlgebra/Array4x4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Array4x4x4.cs
@@ -148,27 +148,28 @@ public struct Array4x4x4<T> : ICubicArray<Array4x4x4<T>, T>
     // Formatting
     //
 
-    public string ToString(string? format, IFormatProvider? provider) => ToArray3D().ToDisplayString(format, provider);
-
-    //
-    // Helpers
-    //
-
-    private T[,,] ToArray3D()
+    public string ToString(string? format, IFormatProvider? provider)
     {
-        T[,,] result = new T[4, 4, 4];
+        var array = new T[4, 4, 4];
+        CopyTo(ref array);
+        return array.ToDisplayString(format, provider);
+    }
 
+    //
+    // Methods
+    //
+
+    public readonly void CopyTo(ref T[,,] destination)
+    {
         for (int i = 0; i < 4; i++)
         {
             for (int j = 0; j < 4; j++)
             {
                 for (int k = 0; k < 4; k++)
                 {
-                    result[i, j, k] = this[i, j, k];
+                    destination[i, j, k] = this[i, j, k];
                 }
             }
         }
-
-        return result;
     }
 }

--- a/src/Mathematics.NET/LinearAlgebra/Array4x4x4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Array4x4x4x4.cs
@@ -150,16 +150,19 @@ public struct Array4x4x4x4<T> : IHypercubic4DArray<Array4x4x4x4<T>, T>
     // Formatting
     //
 
-    public string ToString(string? format, IFormatProvider? provider) => ToArray4D().ToDisplayString(format, provider);
-
-    //
-    // Helpers
-    //
-
-    private T[,,,] ToArray4D()
+    public string ToString(string? format, IFormatProvider? provider)
     {
-        T[,,,] result = new T[4, 4, 4, 4];
+        var array = new T[4, 4, 4, 4];
+        CopyTo(ref array);
+        return array.ToDisplayString(format, provider);
+    }
 
+    //
+    // Methods
+    //
+
+    public readonly void CopyTo(ref T[,,,] destination)
+    {
         for (int i = 0; i < 4; i++)
         {
             for (int j = 0; j < 4; j++)
@@ -168,12 +171,10 @@ public struct Array4x4x4x4<T> : IHypercubic4DArray<Array4x4x4x4<T>, T>
                 {
                     for (int l = 0; l < 4; l++)
                     {
-                        result[i, j, k, l] = this[i, j, k, l];
+                        destination[i, j, k, l] = this[i, j, k, l];
                     }
                 }
             }
         }
-
-        return result;
     }
 }

--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -304,17 +304,17 @@ public static class LinAlgExtensions
     public static string ToDisplayString<T>(this T[,,] array, string? format = null, IFormatProvider? provider = null)
         where T : IComplex<T>
     {
-        var e1Length = array.GetLength(0);
-        var e2Length = array.GetLength(1);
-        var e3Length = array.GetLength(2);
+        var e0Length = array.GetLength(0);
+        var e1Length = array.GetLength(1);
+        var e2Length = array.GetLength(2);
 
         var maxElementLength = 0;
-        var strings = new string[4, 4, 4];
-        for (int i = 0; i < e1Length; i++)
+        var strings = new string[e0Length, e1Length, e2Length];
+        for (int i = 0; i < e0Length; i++)
         {
-            for (int j = 0; j < e2Length; j++)
+            for (int j = 0; j < e1Length; j++)
             {
-                for (int k = 0; k < e3Length; k++)
+                for (int k = 0; k < e2Length; k++)
                 {
                     var s = array[i, j, k].ToString(format, provider);
                     strings[i, j, k] = s;
@@ -330,15 +330,15 @@ public static class LinAlgExtensions
         StringBuilder builder = new();
         var newlineChars = Environment.NewLine.ToCharArray();
         builder.Append('[');
-        for (int i = 0; i < e1Length; i++)
+        for (int i = 0; i < e0Length; i++)
         {
             builder.Append(i != 0 ? " [" : "[");
-            for (int j = 0; j < e2Length; j++)
+            for (int j = 0; j < e1Length; j++)
             {
                 builder.Append(j != 0 ? "  [" : "[");
-                for (int k = 0; k < e3Length; k++)
+                for (int k = 0; k < e2Length; k++)
                 {
-                    string value = k != e3Length - 1 ? $"{strings[i, j, k]}, " : strings[i, j, k];
+                    string value = k != e2Length - 1 ? $"{strings[i, j, k]}, " : strings[i, j, k];
                     builder.Append(value.PadRight(maxElementLength));
                 }
                 builder.CloseGroup(newlineChars);
@@ -358,20 +358,20 @@ public static class LinAlgExtensions
     public static string ToDisplayString<T>(this T[,,,] array, string? format = null, IFormatProvider? provider = null)
         where T : IComplex<T>
     {
-        var e1Length = array.GetLength(0);
-        var e2Length = array.GetLength(1);
-        var e3Length = array.GetLength(2);
-        var e4Length = array.GetLength(3);
+        var e0Length = array.GetLength(0);
+        var e1Length = array.GetLength(1);
+        var e2Length = array.GetLength(2);
+        var e3Length = array.GetLength(3);
 
         var maxElementLength = 0;
-        var strings = new string[4, 4, 4, 4];
-        for (int i = 0; i < e1Length; i++)
+        var strings = new string[e0Length, e1Length, e2Length, e3Length];
+        for (int i = 0; i < e0Length; i++)
         {
-            for (int j = 0; j < e2Length; j++)
+            for (int j = 0; j < e1Length; j++)
             {
-                for (int k = 0; k < e3Length; k++)
+                for (int k = 0; k < e2Length; k++)
                 {
-                    for (int l = 0; l < e4Length; l++)
+                    for (int l = 0; l < e3Length; l++)
                     {
                         var s = array[i, j, k, l].ToString(format, provider);
                         strings[i, j, k, l] = s;
@@ -388,18 +388,18 @@ public static class LinAlgExtensions
         StringBuilder builder = new();
         var newlineChars = Environment.NewLine.ToCharArray();
         builder.Append('[');
-        for (int i = 0; i < e1Length; i++)
+        for (int i = 0; i < e0Length; i++)
         {
             builder.Append(i != 0 ? " [" : "[");
-            for (int j = 0; j < e2Length; j++)
+            for (int j = 0; j < e1Length; j++)
             {
                 builder.Append(j != 0 ? "  [" : "[");
-                for (int k = 0; k < e3Length; k++)
+                for (int k = 0; k < e2Length; k++)
                 {
                     builder.Append(k != 0 ? "   [" : "[");
-                    for (int l = 0; l < e4Length; l++)
+                    for (int l = 0; l < e3Length; l++)
                     {
-                        string value = k != e4Length - 1 ? $"{strings[i, j, k, l]}, " : strings[i, j, k, l];
+                        string value = k != e3Length - 1 ? $"{strings[i, j, k, l]}, " : strings[i, j, k, l];
                         builder.Append(value.PadRight(maxElementLength));
                     }
                     builder.CloseGroup(newlineChars);

--- a/tests/Mathematics.NET.Tests/Assert.cs
+++ b/tests/Mathematics.NET.Tests/Assert.cs
@@ -124,7 +124,7 @@ public sealed class Assert<T>
                 if (!Precision.AreApproximatelyEqual(expected[i, j], actual[i, j], epsilon))
                 {
                     Assert.Fail($$"""
-                        Actual value at row {{i}} and column {{j}} does not fall within the specifed margin of error, {{epsilon}}:
+                        Actual value at row {{i}} and column {{j}} does not fall within the specified margin of error, {{epsilon}}:
 
                         Expected: {{expected[i, j]}}
                         Actual: {{actual[i, j]}}
@@ -157,11 +157,89 @@ public sealed class Assert<T>
                 if (!Precision.AreApproximatelyEqual(expected[i, j], actual[i, j], epsilon))
                 {
                     Assert.Fail($$"""
-                        Actual value at row {{i}} and column {{j}} does not fall within the specifed margin of error, {{epsilon}}:
+                        Actual value at row {{i}} and column {{j}} does not fall within the specified margin of error, {{epsilon}}:
 
                         Expected: {{expected[i, j]}}
                         Actual: {{actual[i, j]}}
                         """);
+                }
+            }
+        }
+    }
+
+    /// <summary>Assert that the elements in two 3D arrays are approximately equal.</summary>
+    /// <param name="expected">A 3D array of expected values</param>
+    /// <param name="actual">A 3D array of actual values</param>
+    /// <param name="epsilon">A margin of error</param>
+    public static void AreApproximatelyEqual(T[,,] expected, T[,,] actual, Real epsilon)
+    {
+        if (expected.GetLength(0) != actual.GetLength(0) || expected.GetLength(1) != actual.GetLength(1) || expected.GetLength(2) != actual.GetLength(2))
+        {
+            Assert.Fail($"Dimensions of the actual array, [{actual.GetLength(0)}, {actual.GetLength(1)}, {actual.GetLength(2)}], does not match the dimensions of the expected matrix, [{expected.GetLength(0)}, {expected.GetLength(1)}, {expected.GetLength(2)}]");
+        }
+
+        for (int i = 0; i < expected.GetLength(0); i++)
+        {
+            for (int j = 0; j < expected.GetLength(1); j++)
+            {
+                for (int k = 0; k < expected.GetLength(2); k++)
+                {
+                    if (T.IsNaN(expected[i, j, k]) && T.IsNaN(actual[i, j, k]) || T.IsInfinity(expected[i, j, k]) && T.IsInfinity(actual[i, j, k]))
+                    {
+                        continue;
+                    }
+
+                    if (!Precision.AreApproximatelyEqual(expected[i, j, k], actual[i, j, k], epsilon))
+                    {
+                        Assert.Fail($$"""
+                            Actual value at location [{{i}}, {{j}}, {{k}}] does not fall within the specified margin of error, {{epsilon}}:
+
+                            Expected: {{expected[i, j, k]}}
+                            Actual: {{actual[i, j, k]}}
+                            """);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>Assert that the elements in two 4D arrays are approximately equal.</summary>
+    /// <param name="expected">A 4D array of expected values</param>
+    /// <param name="actual">A 4D array of actual values</param>
+    /// <param name="epsilon">A margin of error</param>
+    public static void AreApproximatelyEqual(T[,,,] expected, T[,,,] actual, Real epsilon)
+    {
+        if (expected.GetLength(0) != actual.GetLength(0) ||
+            expected.GetLength(1) != actual.GetLength(1) ||
+            expected.GetLength(2) != actual.GetLength(2) ||
+            expected.GetLength(3) != actual.GetLength(3))
+        {
+            Assert.Fail($"Dimensions of the actual array, [{actual.GetLength(0)}, {actual.GetLength(1)}, {actual.GetLength(2)}, {actual.GetLength(3)}], does not match the dimensions of the expected matrix, [{expected.GetLength(0)}, {expected.GetLength(1)}, {expected.GetLength(2)}, {expected.GetLength(3)}]");
+        }
+
+        for (int i = 0; i < expected.GetLength(0); i++)
+        {
+            for (int j = 0; j < expected.GetLength(1); j++)
+            {
+                for (int k = 0; k < expected.GetLength(2); k++)
+                {
+                    for (int l = 0; l < expected.GetLength(3); l++)
+                    {
+                        if (T.IsNaN(expected[i, j, k, l]) && T.IsNaN(actual[i, j, k, l]) || T.IsInfinity(expected[i, j, k, l]) && T.IsInfinity(actual[i, j, k, l]))
+                        {
+                            continue;
+                        }
+
+                        if (!Precision.AreApproximatelyEqual(expected[i, j, k, l], actual[i, j, k, l], epsilon))
+                        {
+                            Assert.Fail($$"""
+                                Actual value at location [{{i}}, {{j}}, {{k}}, {{l}}] does not fall within the specified margin of error, {{epsilon}}:
+
+                                Expected: {{expected[i, j, k, l]}}
+                                Actual: {{actual[i, j, k, l]}}
+                                """);
+                        }
+                    }
                 }
             }
         }

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/ChristoffelSymbolTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/ChristoffelSymbolTests.cs
@@ -1,0 +1,106 @@
+﻿// <copyright file="ChristoffelSymbolTests.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.LinearAlgebra;
+
+namespace Mathematics.NET.Tests.DifferentialGeometry;
+
+[TestClass]
+[TestCategory("DifGeo"), TestCategory("Christoffel")]
+public sealed class ChristoffelSymbolTests
+{
+    private GradientTape<Real> _tape;
+
+    public ChristoffelSymbolTests()
+    {
+        _tape = new();
+    }
+
+    //
+    // Tests
+    //
+
+    [TestMethod]
+    [DynamicData(nameof(GetChristoffelSymbolData), DynamicDataSourceType.Method)]
+    public void Christoffel_FromMetricTensor_ReturnsChristoffelSymbolOfTheFirstKind(object[] input, object[] values)
+    {
+        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, Delta>> metric = new();
+        var position = _tape.CreateAutoDiffTensor<Index<Upper, Delta>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
+
+        var expected = (Real[,,])values[0];
+
+        DifGeo.Christoffel(_tape, metric, position, out Christoffel<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Beta, Gamma> result);
+        var actual = new Real[4, 4, 4];
+        result.CopyTo(ref actual);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    //
+    // Helpers
+    //
+
+    public static IEnumerable<object[]> GetChristoffelSymbolData()
+    {
+        yield return new[]
+        {
+            [1.23, 2.46, 3.14, 7.13],
+            new object[]
+            {
+                new Real[,,]
+                {
+                    {
+                        { 0.1671188635622513, 0,                  0,                 0                  },
+                        { 0,                  -1.260061259991784, 0,                 -6.257873917217628 },
+                        { 0,                  0,                  55.78160057616655, 0                  },
+                        { -2713.241692714989, 0,                  0,                 -440.0387661823283 }
+                    },
+                    {
+                        { 0,                 1.427001521325065, 0,                 6.257873917217628 },
+                        { 0,                 0,                 3.00000760964924,  0                 },
+                        { 0,                 3.00000760964924,  0,                 2184.299356493921 },
+                        { 6.257873917217628, 8.24740564478816,  2185.536093357125, -220.299888       }
+                    },
+                    {
+                        { 0,     0,                 -21.09220506989748, 0                 },
+                        { 0,     -3.00000760964924, 0,                  1.138383108352451 },
+                        { 13.53, 0,                 0,                  0                 },
+                        { 0,     1.138383108352451, 9.89974718827474,   -172.591632       }
+                    },
+                    {
+                        { 5426.483385429979, 0,                  0,                  8091.16088708124  },
+                        { 0,                 -16.49481128957631, -2185.536093357125, 223.1454164552846 },
+                        { 0,                 0.0983537548512989, -19.79949437654947, 177.5415055941374 },
+                        { 440.599776,        220.299888,         172.591632,         76.008096         }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
@@ -1,0 +1,108 @@
+﻿// <copyright file="DifGeoTestHelpers.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023 Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+using Mathematics.NET.Symbols;
+
+namespace Mathematics.NET.Tests.DifferentialGeometry;
+
+public static class DifGeoTestHelpers
+{
+    public sealed class Test4x4MetricTensorFieldNo1<TT, TSM, TN, TPI> : MetricTensorField<TT, TSM, TN, TPI>
+        where TT : ITape<TN>
+        where TSM : ISquareMatrix<TSM, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPI : IIndex
+    {
+        public Test4x4MetricTensorFieldNo1()
+        {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            base[0, 0] = (tape, x) => tape.Sin(x.X0);
+            base[0, 1] = (tape, x) => tape.Multiply(2, tape.Cos(x.X1));
+            base[0, 2] = (tape, x) => tape.Multiply(3, tape.Exp(x.X2));
+            base[0, 3] = (tape, x) => tape.Multiply(4, tape.Ln(x.X3));
+
+            base[1, 0] = (tape, x) => tape.Multiply(5, tape.Sqrt(x.X1));
+            base[1, 1] = (tape, x) => tape.Multiply(6, tape.Tan(x.X2));
+            base[1, 2] = (tape, x) => tape.Multiply(7, tape.Sinh(x.X3));
+            base[1, 3] = (tape, x) => tape.Multiply(8, tape.Cosh(x.X0));
+
+            base[2, 0] = (tape, x) => tape.Multiply(9, tape.Tanh(x.X2));
+            base[2, 1] = (tape, x) => tape.Divide(10, x.X3);
+            base[2, 2] = (tape, x) => tape.Multiply(11, tape.Pow(x.X0, 2));
+            base[2, 3] = (tape, x) => tape.Multiply(12, tape.Multiply(tape.Sin(x.X1), tape.Cos(x.X1)));
+
+            base[3, 0] = (tape, x) => tape.Multiply(13, tape.Multiply(tape.Exp(x.X3), tape.Sin(x.X0)));
+            base[3, 1] = (tape, x) => tape.Multiply(14, tape.Divide(x.X3, x.X1));
+            base[3, 2] = (tape, x) => tape.Multiply(15, tape.Sin(tape.Subtract(x.X3, tape.Multiply(2, x.X2))));
+            base[3, 3] = (tape, x) => tape.Multiply(16, tape.Multiply(x.X0, tape.Multiply(x.X1, tape.Multiply(x.X2, x.X3))));
+        }
+    }
+}
+
+//
+// Symbols
+//
+
+public readonly struct Alpha : ISymbol
+{
+    /// <inheritdoc cref="ISymbol.DisplayString"/>
+    public const string DisplayString = "Alpha";
+
+    static string ISymbol.DisplayString => DisplayString;
+}
+
+public readonly struct Beta : ISymbol
+{
+    /// <inheritdoc cref="ISymbol.DisplayString"/>
+    public const string DisplayString = "Beta";
+
+    static string ISymbol.DisplayString => DisplayString;
+}
+
+public readonly struct Gamma : ISymbol
+{
+    /// <inheritdoc cref="ISymbol.DisplayString"/>
+    public const string DisplayString = "Gamma";
+
+    static string ISymbol.DisplayString => DisplayString;
+}
+
+public readonly struct Delta : ISymbol
+{
+    /// <inheritdoc cref="ISymbol.DisplayString"/>
+    public const string DisplayString = "Delta";
+
+    static string ISymbol.DisplayString => DisplayString;
+}


### PR DESCRIPTION
This request adds a test for Christoffel symbols of the first kind.
- Minor update test helpers
- Add methods that allow types that implement `IThreeDimensionalArrayRepresentable<T, U>` and `IFourDimensionalArrayRepresentable<T, U>` to be copied to arrays.