### PR TITLE
Remove a type parameter from 4x4 tensors

### DIFF
--- a/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4.cs
+++ b/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4.cs
@@ -35,14 +35,14 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 namespace Mathematics.NET.Core.Buffers;
 
 /// <summary>Represents a buffer of 4 AutoDiffTensor4 delegates</summary>
-/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
-/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-/// <typeparam name="TIndex">An index</typeparam>
+/// <typeparam name="TT">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TI">An index</typeparam>
 [InlineArray(4)]
-internal struct AutoDiffTensor4Buffer4<TTape, TNumber, TIndex>
-    where TTape : ITape<TNumber>
-    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
-    where TIndex : IIndex
+internal struct AutoDiffTensor4Buffer4<TT, TN, TI>
+    where TT : ITape<TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TI : IIndex
 {
-    private Func<TTape, AutoDiffTensor4<TNumber, TIndex>, Variable<TNumber>> _element0;
+    private Func<TT, AutoDiffTensor4<TN, TI>, Variable<TN>> _element0;
 }

--- a/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4x4.cs
+++ b/src/Mathematics.NET/Core/Buffers/AutoDiffTensor4Buffer4x4.cs
@@ -33,15 +33,15 @@ using Mathematics.NET.DifferentialGeometry.Abstractions;
 
 namespace Mathematics.NET.Core.Buffers;
 
-/// <summary>Represents a buffer of 4 TensorDelegateBuffer4 buffers</summary>
-/// <typeparam name="TTape">A type that implements <see cref="ITape{T}"/></typeparam>
-/// <typeparam name="TNumber">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
-/// <typeparam name="TIndex">An index</typeparam>
+/// <summary>Represents a buffer of 4 AutoDiffTensor4Buffer4 buffers</summary>
+/// <typeparam name="TT">A type that implements <see cref="ITape{T}"/></typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
+/// <typeparam name="TI">An index</typeparam>
 [InlineArray(4)]
-internal struct AutoDiffTensor4Buffer4x4<TTape, TNumber, TIndex>
-    where TTape : ITape<TNumber>
-    where TNumber : IComplex<TNumber>, IDifferentiableFunctions<TNumber>
-    where TIndex : IIndex
+internal struct AutoDiffTensor4Buffer4x4<TT, TN, TI>
+    where TT : ITape<TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TI : IIndex
 {
-    private AutoDiffTensor4Buffer4<TTape, TNumber, TIndex> _element0;
+    private AutoDiffTensor4Buffer4<TT, TN, TI> _element0;
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
@@ -36,15 +36,15 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <summary>Represents a Christoffel symbol</summary>
 /// <typeparam name="TCA">A backing type that implements <see cref="ICubicArray{T, U}"/></typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/></typeparam>
-/// <typeparam name="TI">The first index</typeparam>
+/// <typeparam name="TI1">The first index</typeparam>
 /// <typeparam name="TI2N">The name of the second index</typeparam>
 /// <typeparam name="TI3N">The name of the third index</typeparam>
 /// <param name="array">A backing array</param>
-public struct Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA array)
-    : IRankThreeTensor<Christoffel<TCA, TN, TI, TI2N, TI3N>, TCA, TN, TI, Index<Lower, TI2N>, Index<Lower, TI3N>>
+public struct Christoffel<TCA, TN, TI1, TI2N, TI3N>(TCA array)
+    : IRankThreeTensor<Christoffel<TCA, TN, TI1, TI2N, TI3N>, TCA, TN, TI1, Index<Lower, TI2N>, Index<Lower, TI3N>>
     where TCA : ICubicArray<TCA, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
-    where TI : IIndex
+    where TI1 : IIndex
     where TI2N : ISymbol
     where TI3N : ISymbol
 {
@@ -54,7 +54,7 @@ public struct Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA array)
     // IRankThreeTensor interface
     //
 
-    public readonly IIndex I1 => TI.Instance;
+    public readonly IIndex I1 => TI1.Instance;
 
     public readonly IIndex I2 => Index<Lower, TI2N>.Instance;
 
@@ -86,31 +86,31 @@ public struct Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA array)
     // Operators
     //
 
-    public static Christoffel<TCA, TN, TI, TI2N, TI3N> operator -(Christoffel<TCA, TN, TI, TI2N, TI3N> christoffel)
+    public static Christoffel<TCA, TN, TI1, TI2N, TI3N> operator -(Christoffel<TCA, TN, TI1, TI2N, TI3N> christoffel)
         => new(-christoffel._array);
 
-    public static Christoffel<TCA, TN, TI, TI2N, TI3N> operator +(Christoffel<TCA, TN, TI, TI2N, TI3N> christoffel)
+    public static Christoffel<TCA, TN, TI1, TI2N, TI3N> operator +(Christoffel<TCA, TN, TI1, TI2N, TI3N> christoffel)
         => christoffel;
 
-    public static Christoffel<TCA, TN, TI, TI2N, TI3N> operator *(TN c, Christoffel<TCA, TN, TI, TI2N, TI3N> christoffel)
+    public static Christoffel<TCA, TN, TI1, TI2N, TI3N> operator *(TN c, Christoffel<TCA, TN, TI1, TI2N, TI3N> christoffel)
         => new(c * christoffel._array);
 
-    public static Christoffel<TCA, TN, TI, TI2N, TI3N> operator *(Christoffel<TCA, TN, TI, TI2N, TI3N> christoffel, TN c)
+    public static Christoffel<TCA, TN, TI1, TI2N, TI3N> operator *(Christoffel<TCA, TN, TI1, TI2N, TI3N> christoffel, TN c)
         => new(christoffel._array * c);
 
     //
     // Equality
     //
 
-    public static bool operator ==(Christoffel<TCA, TN, TI, TI2N, TI3N> left, Christoffel<TCA, TN, TI, TI2N, TI3N> right)
+    public static bool operator ==(Christoffel<TCA, TN, TI1, TI2N, TI3N> left, Christoffel<TCA, TN, TI1, TI2N, TI3N> right)
         => left._array == right._array;
 
-    public static bool operator !=(Christoffel<TCA, TN, TI, TI2N, TI3N> left, Christoffel<TCA, TN, TI, TI2N, TI3N> right)
+    public static bool operator !=(Christoffel<TCA, TN, TI1, TI2N, TI3N> left, Christoffel<TCA, TN, TI1, TI2N, TI3N> right)
         => left._array != right._array;
 
-    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Christoffel<TCA, TN, TI, TI2N, TI3N> other && Equals(other);
+    public override readonly bool Equals([NotNullWhen(true)] object? obj) => obj is Christoffel<TCA, TN, TI1, TI2N, TI3N> other && Equals(other);
 
-    public readonly bool Equals(Christoffel<TCA, TN, TI, TI2N, TI3N> value) => _array.Equals(value._array);
+    public readonly bool Equals(Christoffel<TCA, TN, TI1, TI2N, TI3N> value) => _array.Equals(value._array);
 
     public override readonly int GetHashCode() => HashCode.Combine(_array);
 
@@ -127,35 +127,35 @@ public struct Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA array)
     public readonly void CopyTo(ref TN[,,] destination) => _array.CopyTo(ref destination);
 
     /// <summary>Reinterpret a reference to this Christoffel symbol as one with a new index in the first position.</summary>
-    /// <typeparam name="TNI">A new index</typeparam>
+    /// <typeparam name="TNI1">A new index</typeparam>
     /// <returns>A reference to this Christoffel symbol with a new index in the first position</returns>
     [UnscopedRef]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref Christoffel<TCA, TN, TNI, TI2N, TI3N> WithIndex1<TNI>()
-        where TNI : IIndex
-        => ref Unsafe.As<Christoffel<TCA, TN, TI, TI2N, TI3N>, Christoffel<TCA, TN, TNI, TI2N, TI3N>>(ref this);
+    public ref Christoffel<TCA, TN, TNI1, TI2N, TI3N> WithIndex1<TNI1>()
+        where TNI1 : IIndex
+        => ref Unsafe.As<Christoffel<TCA, TN, TI1, TI2N, TI3N>, Christoffel<TCA, TN, TNI1, TI2N, TI3N>>(ref this);
 
     /// <summary>Reinterpret a reference to this Christoffel symbol as one with a new index name in the second position.</summary>
     /// <typeparam name="TNIN">A new index name</typeparam>
     /// <returns>A reference to this Christoffel symbol with a new index name in the second position</returns>
     [UnscopedRef]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref Christoffel<TCA, TN, TI, TNIN, TI3N> WithIndex2Name<TNIN>()
+    public ref Christoffel<TCA, TN, TI1, TNIN, TI3N> WithIndex2Name<TNIN>()
         where TNIN : ISymbol
-        => ref Unsafe.As<Christoffel<TCA, TN, TI, TI2N, TI3N>, Christoffel<TCA, TN, TI, TNIN, TI3N>>(ref this);
+        => ref Unsafe.As<Christoffel<TCA, TN, TI1, TI2N, TI3N>, Christoffel<TCA, TN, TI1, TNIN, TI3N>>(ref this);
 
     /// <summary>Reinterpret a reference to this Christoffel symbol as one with a new index name in the third position.</summary>
     /// <typeparam name="TNIN">A new index name</typeparam>
     /// <returns>A reference to this Christoffel symbol with a new index name in the third position</returns>
     [UnscopedRef]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref Christoffel<TCA, TN, TI, TI2N, TNIN> WithIndex3Name<TNIN>()
+    public ref Christoffel<TCA, TN, TI1, TI2N, TNIN> WithIndex3Name<TNIN>()
         where TNIN : ISymbol
-        => ref Unsafe.As<Christoffel<TCA, TN, TI, TI2N, TI3N>, Christoffel<TCA, TN, TI, TI2N, TNIN>>(ref this);
+        => ref Unsafe.As<Christoffel<TCA, TN, TI1, TI2N, TI3N>, Christoffel<TCA, TN, TI1, TI2N, TNIN>>(ref this);
 
     //
     // Implicit operators
     //
 
-    public static implicit operator Christoffel<TCA, TN, TI, TI2N, TI3N>(TCA value) => new(value);
+    public static implicit operator Christoffel<TCA, TN, TI1, TI2N, TI3N>(TCA value) => new(value);
 }

--- a/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Christoffel.cs
@@ -126,6 +126,19 @@ public struct Christoffel<TCA, TN, TI1, TI2N, TI3N>(TCA array)
 
     public readonly void CopyTo(ref TN[,,] destination) => _array.CopyTo(ref destination);
 
+    /// <summary>Reinterpret a reference to this Christoffel symbol as one with a new first index, second index name, and third index name.</summary>
+    /// <typeparam name="TNI1">A new first index</typeparam>
+    /// <typeparam name="TNI2N">A new second index name</typeparam>
+    /// <typeparam name="TNI3N">A new third index name</typeparam>
+    /// <returns>A reference to this Christoffel symbol with a new first index, second index name, and third index name</returns>
+    [UnscopedRef]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref Christoffel<TCA, TN, TNI1, TNI2N, TNI3N> WithIndices<TNI1, TNI2N, TNI3N>()
+        where TNI1 : IIndex
+        where TNI2N : ISymbol
+        where TNI3N : ISymbol
+        => ref Unsafe.As<Christoffel<TCA, TN, TI1, TI2N, TI3N>, Christoffel<TCA, TN, TNI1, TNI2N, TNI3N>>(ref this);
+
     /// <summary>Reinterpret a reference to this Christoffel symbol as one with a new index in the first position.</summary>
     /// <typeparam name="TNI1">A new index</typeparam>
     /// <returns>A reference to this Christoffel symbol with a new index in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -58,7 +58,7 @@ public static partial class DifGeo
     /// <param name="derivative">A rank-three tensor</param>
     public static void Derivative<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Upper, TI2N>, Index<Upper, TI3N>> derivative)
         where TT : ITape<TN>
@@ -80,7 +80,7 @@ public static partial class DifGeo
     /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI1N, TI2N, TI3N}(TT, MetricTensorField4x4{TT, Matrix4x4{TN}, TN, Index{Upper, TPIN}}, AutoDiffTensor4{TN, Index{Upper, TPIN}}, out Tensor{Array4x4x4{TN}, TN, Index{Lower, TI1N}, Index{Upper, TI2N}, Index{Upper, TI3N}})"/>
     public static void Derivative<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Lower, TPIN>> metric,
+        MetricTensorField4x4<TT, TN, Index<Lower, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Lower, TPIN>> point,
         out Tensor<Array4x4x4<TN>, TN, Index<Upper, TI1N>, Index<Upper, TI2N>, Index<Upper, TI3N>> derivative)
         where TT : ITape<TN>
@@ -308,7 +308,7 @@ public static partial class DifGeo
     /// <param name="christoffel">The result</param>
     public static void Christoffel<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Christoffel<Array4x4x4<TN>, TN, Index<Lower, TI1N>, TI2N, TI3N> christoffel)
         where TT : ITape<TN>
@@ -346,7 +346,7 @@ public static partial class DifGeo
     /// <param name="christoffel">The result</param>
     public static void Christoffel<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Christoffel<Array4x4x4<TN>, TN, Index<Upper, TI1N>, TI2N, TI3N> christoffel)
         where TT : ITape<TN>
@@ -382,7 +382,7 @@ public static partial class DifGeo
     /// <param name="derivative">The result</param>
     public static void DerivativeOfChristoffel<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Lower, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> derivative)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>
@@ -423,7 +423,7 @@ public static partial class DifGeo
     /// <param name="derivative">The result</param>
     public static void DerivativeOfChristoffel<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Upper, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> derivative)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>
@@ -474,7 +474,7 @@ public static partial class DifGeo
     /// <param name="riemann">The result</param>
     public static void Riemann<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Upper, TI1N>, Index<Lower, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> riemann)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -71,9 +71,7 @@ public static partial class DifGeo
         var metricValueLeft = metric.Compute<TI2N, InternalIndex1>(tape, point);
         ref var metricValueLeftRef = ref metricValueLeft;
         var inverseMetricLeft = metricValueLeftRef.Inverse();
-        ref var inverseMetricRight = ref inverseMetricLeft
-            .WithIndex1Name<InternalIndex2>()
-            .WithIndex2Name<TI3N>();
+        ref var inverseMetricRight = ref inverseMetricLeft.WithIndices<InternalIndex2, TI3N>();
         Derivative(tape, metric, point, out Tensor<Array4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Lower, InternalIndex1>, Index<Lower, InternalIndex2>> derivativeOfMetric);
 
         derivative = -Contract(Contract(derivativeOfMetric, inverseMetricLeft), inverseMetricRight);
@@ -95,9 +93,7 @@ public static partial class DifGeo
         var metricValueLeft = metric.Compute<TI2N, InternalIndex1>(tape, point);
         ref var metricValueLeftRef = ref metricValueLeft;
         var inverseMetricLeft = metricValueLeftRef.Inverse();
-        ref var inverseMetricRight = ref inverseMetricLeft
-            .WithIndex1Name<InternalIndex2>()
-            .WithIndex2Name<TI3N>();
+        ref var inverseMetricRight = ref inverseMetricLeft.WithIndices<InternalIndex2, TI3N>();
         Derivative(tape, metric, point, out Tensor<Array4x4x4<TN>, TN, Index<Upper, TI1N>, Index<Lower, InternalIndex1>, Index<Lower, InternalIndex2>> derivativeOfMetric);
 
         derivative = -Contract(Contract(derivativeOfMetric, inverseMetricLeft), inverseMetricRight);
@@ -490,7 +486,7 @@ public static partial class DifGeo
     {
         DerivativeOfChristoffel(tape, metric, point, out Tensor<Array4x4x4x4<TN>, TN, Index<Lower, TI3N>, Index<Upper, TI1N>, Index<Lower, TI2N>, Index<Lower, TI4N>> derivativeOfChristoffel);
         Christoffel(tape, metric, point, out Christoffel<Array4x4x4<TN>, TN, Index<Upper, TI1N>, InternalIndex1, TI3N> christoffel);
-        var contractedChristoffels = Contract(christoffel, christoffel.WithIndex1<Index<Upper, InternalIndex1>>().WithIndex2Name<TI2N>().WithIndex3Name<TI4N>());
+        var contractedChristoffels = Contract(christoffel, christoffel.WithIndices<Index<Upper, InternalIndex1>, TI2N, TI4N>());
 
         riemann = new();
         for (int r = 0; r < 4; r++)

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -58,7 +58,7 @@ public static partial class DifGeo
     /// <param name="derivative">A rank-three tensor</param>
     public static void Derivative<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Upper, TI2N>, Index<Upper, TI3N>> derivative)
         where TT : ITape<TN>
@@ -77,10 +77,10 @@ public static partial class DifGeo
         derivative = -Contract(Contract(derivativeOfMetric, inverseMetricLeft), inverseMetricRight);
     }
 
-    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI1N, TI2N, TI3N}(TT, MetricTensorField{TT, Matrix4x4{TN}, TN, Index{Upper, TPIN}}, AutoDiffTensor4{TN, Index{Upper, TPIN}}, out Tensor{Array4x4x4{TN}, TN, Index{Lower, TI1N}, Index{Upper, TI2N}, Index{Upper, TI3N}})"/>
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI1N, TI2N, TI3N}(TT, MetricTensorField4x4{TT, Matrix4x4{TN}, TN, Index{Upper, TPIN}}, AutoDiffTensor4{TN, Index{Upper, TPIN}}, out Tensor{Array4x4x4{TN}, TN, Index{Lower, TI1N}, Index{Upper, TI2N}, Index{Upper, TI3N}})"/>
     public static void Derivative<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField<TT, Matrix4x4<TN>, TN, Index<Lower, TPIN>> metric,
+        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Lower, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Lower, TPIN>> point,
         out Tensor<Array4x4x4<TN>, TN, Index<Upper, TI1N>, Index<Upper, TI2N>, Index<Upper, TI3N>> derivative)
         where TT : ITape<TN>
@@ -308,7 +308,7 @@ public static partial class DifGeo
     /// <param name="christoffel">The result</param>
     public static void Christoffel<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Christoffel<Array4x4x4<TN>, TN, Index<Lower, TI1N>, TI2N, TI3N> christoffel)
         where TT : ITape<TN>
@@ -346,7 +346,7 @@ public static partial class DifGeo
     /// <param name="christoffel">The result</param>
     public static void Christoffel<TT, TN, TPIN, TI1N, TI2N, TI3N>(
         TT tape,
-        MetricTensorField<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<TT, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Christoffel<Array4x4x4<TN>, TN, Index<Upper, TI1N>, TI2N, TI3N> christoffel)
         where TT : ITape<TN>
@@ -382,7 +382,7 @@ public static partial class DifGeo
     /// <param name="derivative">The result</param>
     public static void DerivativeOfChristoffel<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Lower, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> derivative)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>
@@ -423,7 +423,7 @@ public static partial class DifGeo
     /// <param name="derivative">The result</param>
     public static void DerivativeOfChristoffel<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Lower, TI1N>, Index<Upper, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> derivative)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>
@@ -474,7 +474,7 @@ public static partial class DifGeo
     /// <param name="riemann">The result</param>
     public static void Riemann<TN, TPIN, TI1N, TI2N, TI3N, TI4N>(
         HessianTape<TN> tape,
-        MetricTensorField<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
+        MetricTensorField4x4<HessianTape<TN>, Matrix4x4<TN>, TN, Index<Upper, TPIN>> metric,
         AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
         out Tensor<Array4x4x4x4<TN>, TN, Index<Upper, TI1N>, Index<Lower, TI2N>, Index<Lower, TI3N>, Index<Lower, TI4N>> riemann)
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensor.cs
@@ -133,6 +133,17 @@ public struct MetricTensor<TSM, TN, TIP, TI1N, TI2N>(TSM matrix)
     // Methods
     //
 
+    /// <summary>Reinterpret a reference to this metric tensor as one with new index names.</summary>
+    /// <typeparam name="TNI1N">The name of the first index</typeparam>
+    /// <typeparam name="TNI2N">The name of the second index</typeparam>
+    /// <returns>A reference to this tensor with new index names</returns>
+    [UnscopedRef]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref MetricTensor<TSM, TN, TIP, TNI1N, TNI2N> WithIndices<TNI1N, TNI2N>()
+        where TNI1N : ISymbol
+        where TNI2N : ISymbol
+        => ref Unsafe.As<MetricTensor<TSM, TN, TIP, TI1N, TI2N>, MetricTensor<TSM, TN, TIP, TNI1N, TNI2N>>(ref this);
+
     /// <summary>Reinterpret a reference to this metric tensor as one with a new index name in the first position.</summary>
     /// <typeparam name="TNIN">A new index name</typeparam>
     /// <returns>A reference to this tensor with a new index name in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
@@ -28,19 +28,16 @@
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
 using Mathematics.NET.LinearAlgebra;
-using Mathematics.NET.LinearAlgebra.Abstractions;
 using Mathematics.NET.Symbols;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
 /// <summary>Represents a metric tensor field</summary>
 /// <typeparam name="TT">A type that implements <see cref="ITape{T}"/></typeparam>
-/// <typeparam name="TSM">A type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
 /// <typeparam name="TPI">An index name</typeparam>
-public abstract class MetricTensorField4x4<TT, TSM, TN, TPI> : TensorField4x4<TT, TN, Lower, Lower, TPI>
+public abstract class MetricTensorField4x4<TT, TN, TPI> : TensorField4x4<TT, TN, Lower, Lower, TPI>
     where TT : ITape<TN>
-    where TSM : ISquareMatrix<TSM, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
     where TPI : IIndex
 {

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricTensorField.cs" company="Mathematics.NET">
+﻿// <copyright file="MetricTensorField4x4.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -38,13 +38,13 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="TSM">A type that implements <see cref="ISquareMatrix{T, U}"/></typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/></typeparam>
 /// <typeparam name="TPI">An index name</typeparam>
-public abstract class MetricTensorField<TT, TSM, TN, TPI> : TensorField4x4<TT, TN, Lower, Lower, TPI>
+public abstract class MetricTensorField4x4<TT, TSM, TN, TPI> : TensorField4x4<TT, TN, Lower, Lower, TPI>
     where TT : ITape<TN>
     where TSM : ISquareMatrix<TSM, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
     where TPI : IIndex
 {
-    public MetricTensorField() { }
+    public MetricTensorField4x4() { }
 
     public new MetricTensor<Matrix4x4<TN>, TN, Lower, TI1, TI2> Compute<TI1, TI2>(TT tape, AutoDiffTensor4<TN, TPI> point)
         where TI1 : ISymbol

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`4.cs
@@ -128,6 +128,17 @@ public struct Tensor<TSM, TN, TI1, TI2>(TSM matrix)
     // Methods
     //
 
+    /// <summary>Reinterpret a reference to this tensor as one with new indices.</summary>
+    /// <typeparam name="TNI1">A new first index</typeparam>
+    /// <typeparam name="TNI2">A new second index</typeparam>
+    /// <returns>A reference to this tensor with new indices</returns>
+    [UnscopedRef]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref Tensor<TSM, TN, TNI1, TNI2> WithIndices<TNI1, TNI2>()
+        where TNI1 : IIndex
+        where TNI2 : IIndex
+        => ref Unsafe.As<Tensor<TSM, TN, TI1, TI2>, Tensor<TSM, TN, TNI1, TNI2>>(ref this);
+
     /// <summary>Reinterpret a reference to this tensor as one with a new index in the first position.</summary>
     /// <typeparam name="TNI">A new index</typeparam>
     /// <returns>A reference to this tensor with a new index in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`5.cs
@@ -127,6 +127,19 @@ public struct Tensor<TCA, TN, TI1, TI2, TI3>(TCA array)
 
     public readonly void CopyTo(ref TN[,,] destination) => _array.CopyTo(ref destination);
 
+    /// <summary>Reinterpret a reference to this tensor as one with new indices.</summary>
+    /// <typeparam name="TNI1">A new first index</typeparam>
+    /// <typeparam name="TNI2">A new second index</typeparam>
+    /// <typeparam name="TNI3">A new third index</typeparam>
+    /// <returns>A reference to this tensor with new indices</returns>
+    [UnscopedRef]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref Tensor<TCA, TN, TNI1, TNI2, TNI3> WithIndices<TNI1, TNI2, TNI3>()
+        where TNI1 : IIndex
+        where TNI2 : IIndex
+        where TNI3 : IIndex
+        => ref Unsafe.As<Tensor<TCA, TN, TI1, TI2, TI3>, Tensor<TCA, TN, TNI1, TNI2, TNI3>>(ref this);
+
     /// <summary>Reinterpret a reference to this tensor as one with a new index in the first position.</summary>
     /// <typeparam name="TNI">A new index</typeparam>
     /// <returns>A reference to this tensor with a new index in the first position</returns>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`6.cs
@@ -133,6 +133,21 @@ public struct Tensor<TH4DA, TN, TI1, TI2, TI3, TI4>(TH4DA array)
 
     public readonly void CopyTo(ref TN[,,,] destination) => _array.CopyTo(ref destination);
 
+    /// <summary>Reinterpret a reference to this tensor as one with new indices.</summary>
+    /// <typeparam name="TNI1">A new first index</typeparam>
+    /// <typeparam name="TNI2">A new second index</typeparam>
+    /// <typeparam name="TNI3">A new third index</typeparam>
+    /// <typeparam name="TNI4">A new fourth index</typeparam>
+    /// <returns>A reference to this tensor with new indices</returns>
+    [UnscopedRef]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref Tensor<TH4DA, TN, TNI1, TNI2, TNI3, TNI4> WithIndices<TNI1, TNI2, TNI3, TNI4>()
+        where TNI1 : IIndex
+        where TNI2 : IIndex
+        where TNI3 : IIndex
+        where TNI4 : IIndex
+        => ref Unsafe.As<Tensor<TH4DA, TN, TI1, TI2, TI3, TI4>, Tensor<TH4DA, TN, TNI1, TNI2, TNI3, TNI4>>(ref this);
+
     /// <summary>Reinterpret a reference to this tensor as one with a new index in the first position.</summary>
     /// <typeparam name="TNI">A new index</typeparam>
     /// <returns>A reference to this tensor with a new index in the first position</returns>

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/ChristoffelSymbolTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/ChristoffelSymbolTests.cs
@@ -50,7 +50,7 @@ public sealed class ChristoffelSymbolTests
     [DynamicData(nameof(GetChristoffelSymbolOfFirstKindData), DynamicDataSourceType.Method)]
     public void Christoffel_FromMetricTensor_ReturnsChristoffelSymbolOfTheFirstKind(object[] input, object[] values)
     {
-        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, Delta>> metric = new();
+        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Real, Index<Upper, Delta>> metric = new();
         var point = _tape.CreateAutoDiffTensor<Index<Upper, Delta>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
 
         var expected = (Real[,,])values[0];
@@ -66,7 +66,7 @@ public sealed class ChristoffelSymbolTests
     [DynamicData(nameof(GetChristoffelSymbolOfSecondKindData), DynamicDataSourceType.Method)]
     public void Christoffel_FromMetricTensor_ReturnsChristoffelSymbolOfTheSecondKind(object[] input, object[] values)
     {
-        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, Delta>> metric = new();
+        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Real, Index<Upper, Delta>> metric = new();
         var point = _tape.CreateAutoDiffTensor<Index<Upper, Delta>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
 
         var expected = (Real[,,])values[0];

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
@@ -28,16 +28,14 @@
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.DifferentialGeometry;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
-using Mathematics.NET.LinearAlgebra.Abstractions;
 using Mathematics.NET.Symbols;
 
 namespace Mathematics.NET.Tests.DifferentialGeometry;
 
 public static class DifGeoTestHelpers
 {
-    public sealed class Test4x4MetricTensorFieldNo1<TT, TSM, TN, TPI> : MetricTensorField4x4<TT, TSM, TN, TPI>
+    public sealed class Test4x4MetricTensorFieldNo1<TT, TN, TPI> : MetricTensorField4x4<TT, TN, TPI>
         where TT : ITape<TN>
-        where TSM : ISquareMatrix<TSM, TN>
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>
         where TPI : IIndex
     {

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
@@ -35,7 +35,7 @@ namespace Mathematics.NET.Tests.DifferentialGeometry;
 
 public static class DifGeoTestHelpers
 {
-    public sealed class Test4x4MetricTensorFieldNo1<TT, TSM, TN, TPI> : MetricTensorField<TT, TSM, TN, TPI>
+    public sealed class Test4x4MetricTensorFieldNo1<TT, TSM, TN, TPI> : MetricTensorField4x4<TT, TSM, TN, TPI>
         where TT : ITape<TN>
         where TSM : ISquareMatrix<TSM, TN>
         where TN : IComplex<TN>, IDifferentiableFunctions<TN>

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTests.cs
@@ -48,7 +48,7 @@ public sealed class DifGeoTests
     [DynamicData(nameof(GetMetricTensorDerivativeData), DynamicDataSourceType.Method)]
     public void Derivative_InverseMetric_ReturnsRankThreeTensor(object[] input, object[] values)
     {
-        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Matrix4x4<Real>, Real, Index<Upper, Delta>> metric = new();
+        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<ITape<Real>, Real, Index<Upper, Delta>> metric = new();
         var point = _gradientTape.CreateAutoDiffTensor<Index<Upper, Delta>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
 
         var expected = (Real[,,])values[0];
@@ -64,7 +64,7 @@ public sealed class DifGeoTests
     [DynamicData(nameof(GetSecondDerivativeData), DynamicDataSourceType.Method)]
     public void SecondDerivative_RankTwoTensor_ReturnsRankFourTensor(object[] input, object[] values)
     {
-        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<HessianTape<Real>, Matrix4x4<Real>, Real, Index<Upper, Epsilon>> metric = new();
+        DifGeoTestHelpers.Test4x4MetricTensorFieldNo1<HessianTape<Real>, Real, Index<Upper, Epsilon>> metric = new();
         var point = _hessianTape.CreateAutoDiffTensor<Index<Upper, Epsilon>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
 
         var expected = (Real[,,,])values[0];


### PR DESCRIPTION
- Rename `MetricTensorField` to `MetricTensorField4x4`
- Remove the requirement to that `Matrix4x4<T>` had to be specified when making 4x4 tensor fields
- Update tests
- Other minor changes