### PR TITLE
Minor fixes for LinAlg methods

### DIFF
--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -180,7 +180,7 @@ public static class LinAlg
 
                 for (int k = 0; k < height; k++)
                 {
-                    Q[k, i] = Q[k, i] - proj * Q[k, j];
+                    Q[k, i] -= proj * Q[k, j];
                 }
             }
 

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -172,7 +172,7 @@ public static class LinAlg
         Q = new T[height, width];
         R = new T[height, width];
 
-        for (int i = 0; i < width; i++)
+        for (int i = 0; i < Math.Min(height, width); i++)
         {
             var column = Q.GetColumn(i);
             matrix.GetColumn(i).CopyTo(column);

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -141,7 +141,7 @@ public static class LinAlg
 
         var partialSum = Real.Zero;
         var scale = Real.One / (max * max);
-        foreach (ref var component in components)
+        foreach (var component in components)
         {
             partialSum += scale * component;
         }

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -125,7 +125,7 @@ public static class LinAlg
             Debug.Assert(components[i] >= Real.Zero, "Components must be greater than zero.");
         }
 
-        Real max = components[0];
+        var max = components[0];
         for (int i = 1; i < vector.Length; i++)
         {
             if (components[i] > max)

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -25,6 +25,7 @@
 // SOFTWARE.
 // </copyright>
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using CommunityToolkit.HighPerformance.Enumerables;
 using CommunityToolkit.HighPerformance.Helpers;
@@ -121,6 +122,7 @@ public static class LinAlg
         for (int i = 0; i < vector.Length; i++)
         {
             components[i] = (vector[i] * T.Conjugate(vector[i])).Re;
+            Debug.Assert(components[i] >= Real.Zero, "Components must be greater than zero.");
         }
 
         Real max = components[0];

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -162,7 +162,7 @@ public static class LinAlg
     /// <param name="matrix">An input matrix</param>
     /// <param name="Q">The resulting orthogonal matrix</param>
     /// <param name="R">The resulting upper triangular matrix</param>
-    /// <exception cref="DivideByZeroException">One of the columns is not linearly independent from the others</exception>
+    /// <exception cref="DivideByZeroException">One of the columns is not linearly independent from one or more of the others</exception>
     public static void QRGramSchmidt<T>(Span2D<T> matrix, out Span2D<T> Q, out Span2D<T> R)
         where T : IComplex<T>
     {
@@ -202,8 +202,7 @@ public static class LinAlg
             }
             else
             {
-                // TODO: Consider not throwing an exception
-                throw new DivideByZeroException(string.Format("Column {0} is not linearly independent from the others", i));
+                throw new DivideByZeroException(string.Format("Column {0} is not linearly independent from one or more of the others", i));
             }
         }
     }

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -191,6 +191,7 @@ public static class LinAlg
                 }
             }
 
+            // TODO: Check to see if using this RefEnumerable<T>, named column, in Norm() is permitted.
             var norm = Norm(column);
             if (norm != Real.Zero)
             {

--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -134,6 +134,11 @@ public static class LinAlg
             }
         }
 
+        if (max == Real.Zero)
+        {
+            return Real.Zero;
+        }
+
         var partialSum = Real.Zero;
         var scale = Real.One / (max * max);
         foreach (ref var component in components)


### PR DESCRIPTION
- Fix division by zero in `Norm` method.
- The `QRGramSchmidt` method will no longer continue computation if a set of orthonormal vectors is found. It will instead return the current values with the remaining values being zeroes.
- Minor fixes