### PR TITLE
Use ILogger for gradient and Hessian tapes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Package information -->
     <Version>0.2.0-alpha.6</Version>
     <Authors>Hamlet Tanyavong</Authors>
-    <Copyright>Copyright (c) 2023–present Hamlet Tanyavong</Copyright>
+    <Copyright>Copyright (c) 2023-present Hamlet Tanyavong</Copyright>
     <PackageProjectUrl>https://mathematics.hamlettanyavong.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HamletTanyavong/Mathematics.NET</RepositoryUrl>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>

--- a/docs/guide/autodiff/first-order-reverse-mode.md
+++ b/docs/guide/autodiff/first-order-reverse-mode.md
@@ -44,15 +44,20 @@ var result = tape.Divide(
     tape.Exp(
         tape.Multiply(-Real.One, x)));
 ```
-which will give us the value of the function at our specified point. At this moment, the derivative has not been calculated, but we are, however, able to examine the nodes which have been added to our tape. We can use the method `PrintNodes` to examine our nodes.
+which will give us the value of the function at our specified point. At this moment, the derivative has not been calculated, but we are, however, able to examine the nodes which have been added to our tape. We can use the method `LogNodes` to do so, provided we have set up a logger.
 ```csharp
-tape.PrintNodes(CancellationToken.None);
+using Microsoft.Extensions.Logging;
+
+using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+var logger = loggerFactory.CreateLogger<GradientTape<Real>>();
+
+tape.LogNodes(logger, CancellationToken.None);
 ```
-Here, we pass in a cancellation token in case the gradient tape is too large and we do not want to print all of the nodes onto the console. We can also set a limit on how many nodes are printed to the console (by default, this value is 100).
+Here, we pass in a cancellation token in case the gradient tape is too large and we do not want to log all of the nodes onto the console. We can also set a limit on how many nodes are logged to the console (by default, this value is 100).
 ```csharp
-tape.PrintNodes(CancellationToken.None, 25);
+tape.LogNodes(logger, CancellationToken.None, 25);
 ```
-Using this on our gradient tape will give us the following output:
+Using this on our gradient tape will give us the following output, which has been summarized:
 ```
 Root Node 0:
     Weights: [0, 0]
@@ -120,7 +125,7 @@ var result = tape.Divide(
         tape.Multiply(-Real.One, x)));
 
 // Optional: examine the nodes on the gradient tape
-tape.PrintNodes();
+tape.LogNodes(logger, CancellationToken.None);
 
 tape.ReverseAccumulate(out var gradient);
 
@@ -153,7 +158,7 @@ var result = tape.Divide(
         tape.Add(x.X1, x.X2),
         tape.Sin(x.X3)));
 ```
-If we want to examine the nodes, we can use the `PrintNodes` method that we have already encountered.
+If we want to examine the nodes, we can use the `LogNodes` method that we have already encountered.
 ```
 Root Node 0:
     Weights: [0, 0]
@@ -207,7 +212,7 @@ As before, we can use `ReverseAccumulate` to get our gradients
 ```csharp
 tape.ReverseAccumulate(out var gradient);
 ```
-and print them to the console with
+and log them to the console with
 ```csharp
 using Mathematics.NET.LinearAlgebra;
 
@@ -215,7 +220,7 @@ using Mathematics.NET.LinearAlgebra;
 
 Console.WriteLine(gradient.ToDisplayString());
 ```
-This will print the following to the console:
+This will log the following to the console:
 ```
 [-0.8243135949243512,  -0.13023459678281554, 0.2382974299363868    ]
 ```
@@ -304,7 +309,7 @@ var result = tape.Cos(
         tape.Sqrt(w)));
 
 // Optional: examine the nodes on the gradient tape
-tape.PrintNodes(CancellationToken.None);
+tape.LogNodes(logger, CancellationToken.None);
 Console.WriteLine();
 
 tape.ReverseAccumulate(out var gradient);

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -25,6 +25,8 @@
 // SOFTWARE.
 // </copyright>
 
+using Microsoft.Extensions.Logging;
+
 namespace Mathematics.NET.AutoDiff;
 
 /// <summary>Defines support for tapes used in reverse-mode automatic differentiation</summary>
@@ -46,10 +48,11 @@ public interface ITape<T>
     /// <returns>A variable</returns>
     public Variable<T> CreateVariable(T seed);
 
-    /// <summary>Print the nodes of the gradient tape to the console.</summary>
+    /// <summary>Log nodes tracked by the tape.</summary>
+    /// <param name="logger">A logger</param>
     /// <param name="cancellationToken">A cancellation token</param>
-    /// <param name="limit">The total number of nodes to print</param>
-    public void PrintNodes(CancellationToken cancellationToken, int limit = 100);
+    /// <param name="limit">The total number of nodes to log</param>
+    public void LogNodes(ILogger<ITape<T>> logger, CancellationToken cancellationToken, int limit = 100);
 
     /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
     /// <param name="gradient">The gradient</param>

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <ProjectReference Include="..\Mathematics.NET.SourceGenerators\Mathematics.NET.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
+++ b/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
@@ -27,6 +27,7 @@
 
 using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
+using Microsoft.Extensions.Logging;
 
 namespace Mathematics.NET.Benchmarks.Implementations.AutoDiff;
 
@@ -64,7 +65,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     }
 
     // There is no need to benchmark this.
-    public void PrintNodes(CancellationToken cancellationToken, int limit = 100)
+    public void LogNodes(ILogger<ITape<T>> logger, CancellationToken cancellationToken, int limit = 100)
         => throw new NotImplementedException();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]


### PR DESCRIPTION
- Use ILogger for logging nodes on a gradient or Hessian tape.
- Use a  hyphen instead of an en dash in `Directory.Build.props`.