### PR TITLE
Remove unused project references from dev application

### DIFF
--- a/src/Mathematics.NET.DevApp/Mathematics.NET.DevApp.csproj
+++ b/src/Mathematics.NET.DevApp/Mathematics.NET.DevApp.csproj
@@ -11,8 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Mathematics.NET.Renderer\Mathematics.NET.Renderer.csproj" />
-    <ProjectReference Include="..\Mathematics.NET.Plots\Mathematics.NET.Plots.csproj" />
     <ProjectReference Include="..\Mathematics.NET\Mathematics.NET.csproj" />
     <ProjectReference Include="..\Mathematics.NET.SourceGenerators.Public\Mathematics.NET.SourceGenerators.Public.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/Mathematics.NET.DevApp/Mathematics.NET.DevApp.csproj
+++ b/src/Mathematics.NET.DevApp/Mathematics.NET.DevApp.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Plotly.NET.CSharp" Version="0.11.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use `Microsoft.Extensions.Logging.Console` package in the dev application.