### PR TITLE
Add a 16px margin to the logo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@
     <div class="flare" id="circle-one"></div>
     <div class="flare" id="circle-two"></div>
     <div class="flare" id="circle-three"></div>
-    <img src="https://raw.githubusercontent.com/HamletTanyavong/Mathematics.NET/gh-pages/images/logo/mathematics.net.svg" width="128" height="128" alt="Mathematics.NET Logo">
+    <img src="https://raw.githubusercontent.com/HamletTanyavong/Mathematics.NET/gh-pages/images/logo/mathematics.net.svg" width="128" height="128" style="margin: 16px" alt="Mathematics.NET Logo">
     <h1>Mathematics.NET</h1>
     <p>Mathematics.NET is a C# class library that provides tools for solving mathematical problems.</p>
 </div>


### PR DESCRIPTION
- Add a 16px margin to the logo so that it appears nice on the documentation site.