### PR TITLE
Add a Runge-Kutta solver for rank-one tensors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <Platforms>AnyCPU</Platforms>
     
     <!-- Package information -->
-    <Version>0.2.0-alpha.7</Version>
+    <Version>0.2.0-alpha.8</Version>
     <Authors>Hamlet Tanyavong</Authors>
     <Copyright>Copyright (c) 2023-present Hamlet Tanyavong</Copyright>
     <PackageProjectUrl>https://mathematics.hamlettanyavong.com</PackageProjectUrl>

--- a/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Abstractions/IRankOneTensor.cs
@@ -25,6 +25,7 @@
 // SOFTWARE.
 // </copyright>
 
+using Mathematics.NET.Core.Operations;
 using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.DifferentialGeometry.Abstractions;
@@ -34,7 +35,10 @@ namespace Mathematics.NET.DifferentialGeometry.Abstractions;
 /// <typeparam name="TV">A backing type that implements <see cref="IVector{T, U}"/>.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/>.</typeparam>
 /// <typeparam name="TI">An index.</typeparam>
-public interface IRankOneTensor<TR1T, TV, TN, TI> : IOneDimensionalArrayRepresentable<TR1T, TN>
+public interface IRankOneTensor<TR1T, TV, TN, TI>
+    : IOneDimensionalArrayRepresentable<TR1T, TN>,
+      IAdditionOperation<TR1T, TR1T>,
+      ISubtractionOperation<TR1T, TR1T>
     where TR1T : IRankOneTensor<TR1T, TV, TN, TI>
     where TV : IVector<TV, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>

--- a/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/Tensor`3.cs
@@ -40,10 +40,7 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="TI">An index.</typeparam>
 /// <param name="vector">A backing vector.</param>
 [StructLayout(LayoutKind.Sequential)]
-public struct Tensor<TV, TN, TI>(TV vector)
-    : IRankOneTensor<Tensor<TV, TN, TI>, TV, TN, TI>,
-      IAdditionOperation<Tensor<TV, TN, TI>, Tensor<TV, TN, TI>>,
-      ISubtractionOperation<Tensor<TV, TN, TI>, Tensor<TV, TN, TI>>
+public struct Tensor<TV, TN, TI>(TV vector) : IRankOneTensor<Tensor<TV, TN, TI>, TV, TN, TI>
     where TV : IVector<TV, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
     where TI : IIndex

--- a/src/Mathematics.NET/Solvers/RungeKutta4`1.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`1.cs
@@ -36,7 +36,7 @@ namespace Mathematics.NET.Solvers;
 public sealed class RungeKutta4<T>(Func<T, T, T> function)
     where T : IComplex<T>, IDifferentiableFunctions<T>
 {
-    private readonly struct RK4StepAction(Func<T, T, T> function, T time, T dt) : IRefAction<T>
+    private readonly struct RK4IntegrateAction(Func<T, T, T> function, T time, T dt) : IRefAction<T>
     {
         private readonly Func<T, T, T> _function = function;
         private readonly T _time = time;
@@ -79,7 +79,7 @@ public sealed class RungeKutta4<T>(Func<T, T, T> function)
     /// <param name="dt">The time step.</param>
     public void IntegrateParallel(SystemState<T> state, T dt)
     {
-        ParallelHelper.ForEach(state.System, new RK4StepAction(_function, state.Time, dt));
+        ParallelHelper.ForEach(state.System, new RK4IntegrateAction(_function, state.Time, dt));
         state.Time += dt;
     }
 }

--- a/src/Mathematics.NET/Solvers/RungeKutta4`1.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`1.cs
@@ -48,7 +48,7 @@ public sealed class RungeKutta4<T>(Func<T, T, T> function)
             var k1 = _function(_time, value);
             var k2 = _function(_time + 0.5 * _dt, value + 0.5 * k1 * _dt);
             var k3 = _function(_time + 0.5 * _dt, value + 0.5 * k2 * _dt);
-            var k4 = _function(_time + _dt, value + _dt * k3);
+            var k4 = _function(_time + _dt, value + k3 * _dt);
             value += _dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
         }
     }
@@ -68,7 +68,7 @@ public sealed class RungeKutta4<T>(Func<T, T, T> function)
             var k1 = _function(time, value);
             var k2 = _function(time + 0.5 * dt, value + 0.5 * k1 * dt);
             var k3 = _function(time + 0.5 * dt, value + 0.5 * k2 * dt);
-            var k4 = _function(time + dt, value + dt * k3);
+            var k4 = _function(time + dt, value + k3 * dt);
             value += dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
         }
         state.Time += dt;

--- a/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
@@ -51,7 +51,7 @@ public sealed class RungeKutta4<TV, TN>(Func<TN, TV, TV> function)
             var k1 = _function(_time, value);
             var k2 = _function(_time + 0.5 * _dt, value + 0.5 * k1 * _dt);
             var k3 = _function(_time + 0.5 * _dt, value + 0.5 * k2 * _dt);
-            var k4 = _function(_time + _dt, value + _dt * k3);
+            var k4 = _function(_time + _dt, value + k3 * _dt);
             value += _dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
         }
     }
@@ -69,7 +69,7 @@ public sealed class RungeKutta4<TV, TN>(Func<TN, TV, TV> function)
             var k1 = _function(time, value);
             var k2 = _function(time + 0.5 * dt, value + 0.5 * k1 * dt);
             var k3 = _function(time + 0.5 * dt, value + 0.5 * k2 * dt);
-            var k4 = _function(time + dt, value + dt * k3);
+            var k4 = _function(time + dt, value + k3 * dt);
             value += dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
         }
         state.Time += dt;

--- a/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
@@ -59,7 +59,7 @@ public sealed class RungeKutta4<TV, TN>(Func<TN, TV, TV> function)
     private readonly Func<TN, TV, TV> _function = function;
 
     /// <inheritdoc cref="RungeKutta4{T}.Integrate(SystemState{T}, T)"/>
-    public void Integrate(ref SystemState<TV, TN> state, TN dt)
+    public void Integrate(SystemState<TV, TN> state, TN dt)
     {
         var system = state.System.Span;
         var time = state.Time;

--- a/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`2.cs
@@ -39,7 +39,7 @@ public sealed class RungeKutta4<TV, TN>(Func<TN, TV, TV> function)
     where TV : IVector<TV, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
 {
-    private readonly struct RK4StepAction(Func<TN, TV, TV> function, TN time, TN dt) : IRefAction<TV>
+    private readonly struct RK4IntegrateAction(Func<TN, TV, TV> function, TN time, TN dt) : IRefAction<TV>
     {
         private readonly Func<TN, TV, TV> _function = function;
         private readonly TN _time = time;
@@ -78,7 +78,7 @@ public sealed class RungeKutta4<TV, TN>(Func<TN, TV, TV> function)
     /// <inheritdoc cref="RungeKutta4{T}.IntegrateParallel(SystemState{T}, T)"/>
     public void IntegrateParallel(SystemState<TV, TN> state, TN dt)
     {
-        ParallelHelper.ForEach(state.System, new RK4StepAction(_function, state.Time, dt));
+        ParallelHelper.ForEach(state.System, new RK4IntegrateAction(_function, state.Time, dt));
         state.Time += dt;
     }
 }

--- a/src/Mathematics.NET/Solvers/RungeKutta4`4.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`4.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="RungeKutta4`4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using CommunityToolkit.HighPerformance.Helpers;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.Solvers;
+
+/// <summary>Represents a fourth-order Runge-Kutta solver.</summary>
+/// <typeparam name="TR1T">A rank-one tensor.</typeparam>
+/// <typeparam name="TV">The backing type of the tensor.</typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TI">The index of the tensor.</typeparam>
+/// <param name="function">A function to use for the integration step.</param>
+public sealed class RungeKutta4<TR1T, TV, TN, TI>(Func<TN, TR1T, TR1T> function)
+    where TR1T : IRankOneTensor<TR1T, TV, TN, TI>
+    where TV : IVector<TV, TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TI : IIndex
+{
+    private readonly struct RK4IntegrateAction(Func<TN, TR1T, TR1T> function, TN time, TN dt) : IRefAction<TR1T>
+    {
+        private readonly Func<TN, TR1T, TR1T> _function = function;
+        private readonly TN _time = time;
+        private readonly TN _dt = dt;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Invoke(ref TR1T value)
+        {
+            var k1 = _function(_time, value);
+            var k2 = _function(_time + 0.5 * _dt, value + 0.5 * k1 * _dt);
+            var k3 = _function(_time + 0.5 * _dt, value + 0.5 * k2 * _dt);
+            var k4 = _function(_time + _dt, value + k3 * _dt);
+            value += _dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
+        }
+    }
+
+    private readonly Func<TN, TR1T, TR1T> _function = function;
+
+    /// <inheritdoc cref="RungeKutta4{T}.Integrate(SystemState{T}, T)"/>
+    public void Integrate(SystemState<TR1T, TV, TN, TI> state, TN dt)
+    {
+        var system = state.System.Span;
+        var time = state.Time;
+        for (int i = 0; i < system.Length; i++)
+        {
+            ref var value = ref system[i];
+            var k1 = _function(time, value);
+            var k2 = _function(time + 0.5 * dt, value + 0.5 * k1 * dt);
+            var k3 = _function(time + 0.5 * dt, value + 0.5 * k2 * dt);
+            var k4 = _function(time + dt, value + k3 * dt);
+            value += dt / 6.0 * (k1 + 2 * (k2 + k3) + k4);
+        }
+        state.Time += dt;
+    }
+
+    /// <inheritdoc cref="RungeKutta4{T}.IntegrateParallel(SystemState{T}, T)"/>
+    public void IntegrateParallel(SystemState<TR1T, TV, TN, TI> state, TN dt)
+    {
+        ParallelHelper.ForEach(state.System, new RK4IntegrateAction(_function, state.Time, dt));
+        state.Time += dt;
+    }
+}

--- a/src/Mathematics.NET/Solvers/SystemState`4.cs
+++ b/src/Mathematics.NET/Solvers/SystemState`4.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="SystemState`4.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra.Abstractions;
+
+namespace Mathematics.NET.Solvers;
+
+/// <summary>Represents the state of a system.</summary>
+/// <typeparam name="TR1T">A rank-one tensor.</typeparam>
+/// <typeparam name="TV">The backing type of the tensor.</typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TI">The index of the tensor.</typeparam>
+/// <param name="system">The system.</param>
+/// <param name="time">The time.</param>
+public sealed class SystemState<TR1T, TV, TN, TI>(Memory<TR1T> system, TN time)
+    where TR1T : IRankOneTensor<TR1T, TV, TN, TI>
+    where TV : IVector<TV, TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TI : IIndex
+{
+    /// <inheritdoc cref="SystemState{T}.System"/>
+    public Memory<TR1T> System = system;
+
+    /// <inheritdoc cref="SystemState{T}.Time"/>
+    public TN Time = time;
+}

--- a/tests/.runsettings
+++ b/tests/.runsettings
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Set this as the solution-wide runsettings file. -->
 <RunSettings>
   <RunConfiguration>
     <ResultsDirectory>.\TestResults</ResultsDirectory>

--- a/tests/Mathematics.NET.Benchmarks/Mathematics.NET.Benchmarks.csproj
+++ b/tests/Mathematics.NET.Benchmarks/Mathematics.NET.Benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="25.3.2" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
+    <PackageReference Include="Verify.MSTest" Version="26.1.6" />
+    <PackageReference Include="Verify.SourceGenerators" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="25.3.2" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
+    <PackageReference Include="Verify.MSTest" Version="26.1.6" />
+    <PackageReference Include="Verify.SourceGenerators" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
+++ b/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Update to version `v0.2.0-alpha.8`.
- Add a Runge-Kutta solver for rank-one tensors.
- Remove the `ref` keyword from the `Integrate` method in the Runge-Kutta solver for vectors.
- Update dependencies.
- Other minor changes.