### PR TITLE
Mark OpenCL-related files as Content in Build Action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 ### C and OpenCL Files ###
-[*.{c,cl}]
+[*.{h,c,cl}]
 
 # Indentation and spacing
 indent_size = 4

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_mat_mul.cl
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_mat_mul.cl
@@ -1,3 +1,5 @@
+#include "GPU\OpenCL\Kernels\complex.h"
+
 __kernel void comp_mat_mul(__global const complex* matA,
                            __global const complex* matB,
                            const int k,

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_mat_mul.cl
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_mat_mul.cl
@@ -1,6 +1,6 @@
 __kernel void comp_mat_mul(__global const complex* matA,
                            __global const complex* matB,
-                           int const k,
+                           const int k,
                            __global complex* result)
 {
     int row = get_global_id(0);
@@ -10,9 +10,7 @@ __kernel void comp_mat_mul(__global const complex* matA,
     int aIndex = row * k;
     int bIndex = col;
 
-    complex sum;
-    sum.re = 0;
-    sum.im = 0;
+    complex sum = { .re = 0, .im = 0 };
 
     for (int i = 0; i < k; i++)
     {

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_vec_mul_scalar.cl
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/comp_vec_mul_scalar.cl
@@ -1,3 +1,5 @@
+#include "GPU\OpenCL\Kernels\complex.h"
+
 __kernel void comp_vec_mul_scalar(__global const complex* vector,
                                   const complex scalar,
                                   __global complex* result)

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.c
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.c
@@ -1,16 +1,30 @@
+#define Re(z) z.re
+#define Im(z) z.im
+
 typedef struct __attribute__((packed)) {
     double re;
     double im;
 } complex;
 
-inline complex comp_add(const complex z, const complex w) {
-    complex result;
-    result.re = z.re + w.re;
-    result.im = z.im + w.im;
+// Basic operations.
+
+complex comp_add(complex z, complex w) {
+    complex result = {
+        .re = z.re + w.re,
+        .im = z.im + w.im
+    };
     return result;
 }
 
-inline complex comp_div(const complex z, const complex w) {
+complex comp_conjugate(complex z) {
+    complex result = {
+        .re = z.re,
+        .im = -z.im
+    };
+    return result;
+}
+
+complex comp_div(complex z, complex w) {
     double a = z.re;
     double b = z.im;
     double c = w.re;
@@ -29,16 +43,47 @@ inline complex comp_div(const complex z, const complex w) {
     return result;
 }
 
-inline complex comp_mul(const complex z, const complex w) {
-    complex result;
-    result.re = z.re * w.re - z.im * w.im;
-    result.im = z.re * w.im + w.re * z.im;
+complex comp_from_polar(double magnitude, double phase) {
+    complex result = {
+        .re = magnitude * cos(phase),
+        .im = magnitude * sin(phase)
+    };
     return result;
 }
 
-inline complex comp_sub(const complex z, const complex w) {
-    complex result;
-    result.re = z.re - w.re;
-    result.im = z.im - w.im;
+double comp_magnitude(complex z) {
+    return hypot(z.re, z.im);
+}
+
+complex comp_mul(complex z, complex w) {
+    complex result = {
+        .re = z.re * w.re - z.im * w.im,
+        .im = z.re * w.im + w.re * z.im
+    };
+    return result;
+}
+
+double comp_phase(complex z) {
+    return atan2(z.im, z.re);
+}
+
+complex comp_reciprocate(complex z) {
+    if (z.re == 0 && z.im == 0) {
+        COMP_INFINITY;
+    }
+
+    double u = z.re * z.re + z.im * z.im;
+    complex result = {
+        .re = z.re / u,
+        .im = -z.im / u
+    };
+    return result;
+}
+
+complex comp_sub(complex z, complex w) {
+    complex result = {
+        .re = z.re - w.re,
+        .im = z.im - w.im
+    };
     return result;
 }

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.c
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.c
@@ -1,10 +1,4 @@
-#define Re(z) z.re
-#define Im(z) z.im
-
-typedef struct __attribute__((packed)) {
-    double re;
-    double im;
-} complex;
+#include "GPU\OpenCL\Kernels\complex.h"
 
 // Basic operations.
 

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.h
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/complex.h
@@ -1,0 +1,26 @@
+#ifndef COMPLEX_H
+#define COMPLEX_H
+
+#define COMP_IM = ((complex){ .re = 0, .im = 1 });
+#define COMP_INFINITY ((complex){ .re = INFINITY, .im = INFINITY });
+#define COMP_NAN ((complex){ .re = NAN, .im = NAN });
+
+#define Re(z) z.re
+#define Im(z) z.im
+
+typedef struct __attribute__((packed)) {
+    double re;
+    double im;
+} complex;
+
+complex comp_add(complex z, complex w);
+complex comp_conjugate(complex z);
+complex comp_div(complex z, complex w);
+complex comp_from_polar(double magnitude, double phase);
+double comp_magnitude(complex z);
+complex comp_mul(complex z, complex w);
+double comp_phase(complex z);
+complex comp_reciprocate(complex z);
+complex comp_sub(complex z, complex w);
+
+#endif

--- a/src/Mathematics.NET/GPU/OpenCL/Kernels/mat_mul.cl
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernels/mat_mul.cl
@@ -1,6 +1,6 @@
 ﻿__kernel void mat_mul(__global const double* matA,
                       __global const double* matB,
-                      int const k,
+                      const int k,
                       __global double* result)
 {
     int row = get_global_id(0);

--- a/src/Mathematics.NET/GPU/OpenCL/OpenCLService.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/OpenCLService.cs
@@ -55,7 +55,8 @@ public sealed class OpenCLService : IComputeService
     private Context _context;
     private Program _program;
 
-    public unsafe OpenCLService(ILogger<OpenCLService> logger, string vendor, Func<Device, bool> filter, bool useFirst = false)
+    // TODO: Use params ReadOnlySpan<string> when it becomes available.
+    public unsafe OpenCLService(ILogger<OpenCLService> logger, string vendor, Func<Device, bool> filter, bool useFirst = false, params string[] options)
     {
         _logger = logger;
 
@@ -109,7 +110,7 @@ public sealed class OpenCLService : IComputeService
 #endif
 
             // OpenCL program.
-            _program = new Program(_logger, _cl, _context, _devices.Span);
+            _program = new Program(_logger, _cl, _context, _devices.Span, options);
         }
         catch (Exception e)
         {

--- a/src/Mathematics.NET/GPU/OpenCL/Program.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/Program.cs
@@ -27,7 +27,6 @@
 
 #pragma warning disable IDE0058
 
-using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Silk.NET.OpenCL;
@@ -45,24 +44,34 @@ public sealed class Program : IOpenCLObject
         _cl = cl;
         _logger = logger;
 
-        var assembly = Assembly.GetExecutingAssembly();
-        var resourceNames = assembly.GetManifestResourceNames().Where(x => x.EndsWith(".cl") || x.EndsWith(".c")).ToArray();
+        var files = Directory
+            .EnumerateFiles(@"GPU\OpenCL\Kernels")
+            .Where(x => x.EndsWith(".c") || x.EndsWith(".cl"))
+            .ToArray();
 
-        var kernels = new string[resourceNames.Length];
-        var kernelLengths = new nuint[resourceNames.Length];
+        var code = new string[files.Length];
+        var codeLengths = new nuint[files.Length];
+        List<string> kernels = [];
 
-        for (int i = 0; i < resourceNames.Length; i++)
+        for (int i = 0; i < files.Length; i++)
         {
-            using var stream = assembly.GetManifestResourceStream(resourceNames[i])!;
-            using var reader = new StreamReader(stream);
-            var kernel = reader.ReadToEnd();
-            kernels[i] = kernel;
-            kernelLengths[i] = (nuint)kernel.Length;
+            var text = File.ReadAllText(files[i]);
+            code[i] = text;
+            codeLengths[i] = (nuint)text.Length;
+
+            // Make sure all kernels are in the Mathematics.NET.GPU.OpenCL.Kernels folder.
+            //
+            // GPU\OpenCL\Kernels\{name}.cl
+            //                    ^    ^
+            // Index:             19   ^3
+
+            if (files[i].EndsWith(".cl"))
+                kernels.Add(files[i][19..^3]);
         }
 
-        fixed (nuint* pKernelLengths = kernelLengths)
+        fixed (nuint* pCodeLengths = codeLengths)
         {
-            Handle = _cl.CreateProgramWithSource(context.Handle, (uint)kernels.Length, kernels, pKernelLengths, out var error);
+            Handle = _cl.CreateProgramWithSource(context.Handle, (uint)code.Length, code, pCodeLengths, out var error);
 #if DEBUG
             if (error != (int)ErrorCodes.Success)
                 _logger.LogDebug("Unable to create the program from source.");
@@ -81,16 +90,9 @@ public sealed class Program : IOpenCLObject
             }
         }
 
-        foreach (var resource in resourceNames)
+        foreach (var kernel in kernels)
         {
-            // Make sure all kernels are in the Mathematics.NET.GPU.OpenCL.Kernels folder.
-            //
-            // Mathematics.NET.GPU.OpenCL.Kernels.{name}.cl
-            //                                    ^    ^
-            // Index:                             35   ^3
-
-            if (resource.EndsWith(".cl"))
-                CreateKernel(resource[35..^3]);
+            CreateKernel(kernel);
         }
     }
 

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <None Remove="GPU\OpenCL\Kernels\complex.c" />
+    <None Remove="GPU\OpenCL\Kernels\complex.h" />
     <None Remove="GPU\OpenCL\Kernels\comp_mat_mul.cl" />
     <None Remove="GPU\OpenCL\Kernels\comp_vec_mul_scalar.cl" />
     <None Remove="GPU\OpenCL\Kernels\mat_mul.cl" />
@@ -25,11 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="GPU\OpenCL\Kernels\complex.c" />
-    <EmbeddedResource Include="GPU\OpenCL\Kernels\comp_mat_mul.cl" />
-    <EmbeddedResource Include="GPU\OpenCL\Kernels\comp_vec_mul_scalar.cl" />
-    <EmbeddedResource Include="GPU\OpenCL\Kernels\mat_mul.cl" />
-    <EmbeddedResource Include="GPU\OpenCL\Kernels\vec_mul_scalar.cl" />
+    <Content Include="GPU\OpenCL\Kernels\complex.c" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
+    <Content Include="GPU\OpenCL\Kernels\complex.h" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
+    <Content Include="GPU\OpenCL\Kernels\comp_mat_mul.cl" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
+    <Content Include="GPU\OpenCL\Kernels\comp_vec_mul_scalar.cl" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
+    <Content Include="GPU\OpenCL\Kernels\mat_mul.cl" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
+    <Content Include="GPU\OpenCL\Kernels\vec_mul_scalar.cl" CopyToOutputDirectory="Always" PackageCopyToOutput="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This means that OpenCL files will no longer be embedded but instead will be included with the nuget package. This also allows us to use header files and allows for better OpenCL code. Some basic functions were also added to complex numbers.