### PR TITLE
Update core numeric types

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,9 +6,9 @@ authors:
   given-names: Hamlet
   orcid: 'https://orcid.org/0009-0002-0327-881X'
 type: software
-version: 0.2.0-alpha.11
+version: 0.2.0-alpha.12
 license: MIT
-date-released: 2024-9-5
+date-released: 2024-9-16
 repository-code: 'https://github.com/HamletTanyavong/Mathematics.NET'
 url: 'https://mathematics.hamlettanyavong.com'
 keywords:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <Platforms>AnyCPU</Platforms>
     
     <!-- Package information -->
-    <Version>0.2.0-alpha.11</Version>
+    <Version>0.2.0-alpha.12</Version>
     <Authors>Hamlet Tanyavong</Authors>
     <Copyright>Copyright (c) 2023-present Hamlet Tanyavong</Copyright>
     <PackageProjectUrl>https://mathematics.hamlettanyavong.com</PackageProjectUrl>

--- a/docs/guide/fundamentals/numeric-types.md
+++ b/docs/guide/fundamentals/numeric-types.md
@@ -20,7 +20,13 @@ This represents the number $ z = 3+i4 $. We can also specify only one number to 
 ```csharp
 Complex z = 3;
 ```
-which represents $ z = 3 $.
+which represents $ z = 3 $. To display only the real component of a complex number, use the format `RE`:
+```csharp
+Complex z = new(1, 2);
+Console.WriteLine("{0:RE}", z);
+Console.WriteLine(z.ToString("RE", null));
+```
+To display only the imaginary component of a complex number, use the format `IM` instead.
 
 ### Real Numbers
 
@@ -39,12 +45,12 @@ Rational numbers are the only Mathematics.NET type in this category.
 
 ### Rational Numbers
 
-Rational numbers require a type parameter that implements <xref href="System.Numerics.IBinaryInteger`1" />. The type specified here is used to represent the numerator and denominator of the rational number.
+Rational numbers require a type parameter constrained by both <xref href="System.Numerics.IBinaryInteger`1" /> and <xref href="System.Numerics.ISignedNumber`1" />. The type specified here is used to represent the numerator and denominator of the rational number.
 
 With this information, we can create the following rational numbers:
 ```csharp
 Rational<int> a = 2;
-Rational<byte> b = new(2, 3);
+Rational<sbyte> b = new(2, 3);
 Rational<BigInteger> c = new(3, 4);
 ```
 which represent $ a = 2 $, $ b = 2/3 $, and $ c = 3/4 $.
@@ -52,11 +58,18 @@ which represent $ a = 2 $, $ b = 2/3 $, and $ c = 3/4 $.
 > [!CAUTION]
 > The floating-point representation of rational numbers may not be accurate in all cases.
 
-We can also convert a double into a rational number with an explicit cast
+We can also convert a double into a rational number with two different methods that do slightly different things:
 ```csharp
-Console.WriteLine((Rational<int>)3.14);
+Console.WriteLine(Rational<int>.FromDouble(3.14));
 ```
-> [!NOTE]
-> The conversion conversion is not guaranteed to create the "best" fraction; for instance, the value $ 0.3333333333333333 $ will not produce $ 1/3 $ but instead produce $ 8333333333333331 / 25000000000000000 $.
+which returns an exact rational representation of the number, `(157, 50)`, and
+```csharp
+var success = Rational<int>.TryConvertFromDouble(0.667, 0.01, 4, out var result);
+Console.WriteLine(result);
+```
+which attempts to find the closest rational representation of the value within a certain threshold and with a maximum denominator size. The result here is `(2 / 3)`. To display only the numerator or denominator of a rational number, use the formats `N` and `D`, respectively.
 
-Be aware that there are performance penalties with converting rationals to and from real numbers. An overflow exception will also be thrown if a value being converted cannot be represented by the target type.
+> [!NOTE]
+> The conversion conversion is not guaranteed to create the "best" fraction; for instance, the value $ 0.3333333333333333 $ will not always produce $ 1/3 $ but instead produce $ 8333333333333331 / 25000000000000000 $.
+
+Be aware that there are performance penalties with converting rationals to and from real numbers. An <xref href="System.OverflowException" /> will also be thrown if a value being converted cannot be represented by the target type.

--- a/src/Mathematics.NET/Core/Complex.cs
+++ b/src/Mathematics.NET/Core/Complex.cs
@@ -263,10 +263,12 @@ public readonly struct Complex(Real real, Real imaginary)
 
     public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Complex result)
     {
+#pragma warning disable EPS06
         s = s.Trim();
         int openParenthesis = s.IndexOf('(');
         int split = s.IndexOf(',');
         int closeParenthesis = s.IndexOf(')');
+#pragma warning restore EPS06
 
         // There a minimum of 5 characters for "(0,0)".
         if (s.Length < 5 || openParenthesis == -1 || split == -1 || closeParenthesis == -1 || openParenthesis > split || openParenthesis > closeParenthesis || split > closeParenthesis)

--- a/src/Mathematics.NET/Core/Extensions.cs
+++ b/src/Mathematics.NET/Core/Extensions.cs
@@ -62,6 +62,6 @@ public static class Extensions
 
     /// <inheritdoc cref="IRational{T, U}.Reduce(T)" />
     public static Rational<T> Reduce<T>(this Rational<T> value)
-        where T : IBinaryInteger<T>
+        where T : IBinaryInteger<T>, ISignedNumber<T>
         => Rational<T>.Reduce(value);
 }

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -417,10 +417,12 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
     public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Rational<T> result)
     {
+#pragma warning disable EPS06
         s = s.Trim();
         int openParenthesis = s.IndexOf('(');
         int split = s.IndexOf('/');
         int closeParenthesis = s.IndexOf(')');
+#pragma warning restore EPS06
 
         // There a minimum of 5 characters for "(0/0)".
         if (s.Length < 5 || openParenthesis == -1 || split == -1 || closeParenthesis == -1 || openParenthesis > split || openParenthesis > closeParenthesis || split > closeParenthesis)

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -636,36 +636,40 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
         }
     }
 
-    /// <summary>Try to convert a <see cref="Real"/> into a <see cref="Rational{T}"/> of <see cref="long"/> to within a certain <paramref name="tolerance"/> and with a max denominator of <paramref name="maxDenominator"/>.</summary>
+    /// <summary>Try to convert a <see cref="double"/> into a rational of <see cref="double"/> to within a certain <paramref name="tolerance"/> and with a <paramref name="max"/> denominator size.</summary>
     /// <param name="value">The value to convert.</param>
     /// <param name="tolerance">A tolerance.</param>
-    /// <param name="maxDenominator">The max denominator.</param>
+    /// <param name="max">The max denominator size.</param>
     /// <param name="result">The result of the conversion if successful; otherwise <see cref="NaN"/>.</param>
     /// <returns><see langword="true"/> if the conversion was successful; otherwise <see langword="false"/>.</returns>
-    public static bool TryConvertFromReal(Real value, Real tolerance, long maxDenominator, out Rational<long> result)
+    /// <exception cref="OverflowException">Thrown when <paramref name="value"/> cannot be represented as a rational of <typeparamref name="T"/>.</exception>
+    public static bool TryConvertFromDouble(double value, double tolerance, T max, out Rational<T> result)
     {
-        if (tolerance < Precision.DblEpsilonVariant || Real.IsNaN(value) || Real.IsInfinity(value))
+        if (double.IsNaN(value) || double.IsInfinity(value))
         {
-            result = Rational<long>.NaN;
+            result = NaN;
             return false;
         }
+        if (tolerance < Precision.DblEpsilonVariant)
+            tolerance = Precision.DblEpsilonVariant;
 
-        var num = 0L;
-        var den = 1L;
+        T num = T.Zero;
+        T den = T.One;
 
-        var quotient = (long)Real.Floor(value);
-        var fractional = value - quotient;
+        var floor = Math.Floor(value);
+        T quotient = T.CreateChecked(floor);
+        var remainder = value - floor;
 
-        while (Real.Abs((Real)num / den - fractional) > tolerance)
+        while (Math.Abs(double.CreateChecked(num) / double.CreateChecked(den) - remainder) > tolerance)
         {
-            if (den > maxDenominator)
+            if (den > max)
             {
-                result = Rational<long>.NaN;
+                result = NaN;
                 return false;
             }
             if (num == den)
             {
-                num = 0L;
+                num = T.Zero;
                 den++;
             }
             num++;

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -516,11 +516,18 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
     public static Rational<T> Floor(Rational<T> x) => T.DivRem(x._numerator, x._denominator).Quotient;
 
-    // TODO: Find a better implementation
+    /// <summary>Create an instance of type rational of <typeparamref name="T"/> from one of type <see cref="double"/>.</summary>
+    /// <param name="x">A value of type <see cref="double"/>.</param>
+    /// <returns>An instance of type rational of <typeparamref name="T"/> created from <paramref name="x"/>.</returns>
+    /// <exception cref="OverflowException">Thrown when <paramref name="x"/> cannot be represented as a rational of <typeparamref name="T"/>.</exception>
     public static Rational<T> FromDouble(double x)
     {
-        if (double.IsNaN(x) || double.IsInfinity(x))
+        if (double.IsNaN(x))
             return NaN;
+        if (double.IsPositiveInfinity(x))
+            return PositiveInfinity;
+        if (double.IsNegativeInfinity(x))
+            return NegativeInfinity;
 
         checked
         {
@@ -533,7 +540,7 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
             T num = T.CreateChecked(x);
             T den = T.CreateChecked(Math.Pow(10.0, n));
-            var gcd = GCD(num, den);
+            T gcd = GCD(num, den);
 
             return new(num / gcd, den / gcd);
         }

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -181,21 +181,15 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
     //
 
     public static bool operator ==(Rational<T> left, Rational<T> right)
-    {
-        return left._numerator == right._numerator && left._denominator == right._denominator;
-    }
+        => left._numerator == right._numerator && left._denominator == right._denominator;
 
     public static bool operator !=(Rational<T> left, Rational<T> right)
-    {
-        return left._numerator != right._numerator || left._denominator != right._denominator;
-    }
+        => left._numerator != right._numerator || left._denominator != right._denominator;
 
     public override bool Equals([NotNullWhen(true)] object? obj) => obj is Rational<T> other && Equals(other);
 
     public bool Equals(Rational<T> value)
-    {
-        return _numerator.Equals(value._numerator) && _denominator.Equals(value._denominator);
-    }
+        => _numerator.Equals(value._numerator) && _denominator.Equals(value._denominator);
 
     public override int GetHashCode() => HashCode.Combine(_numerator, _denominator);
 
@@ -203,25 +197,13 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
     // Comparison
     //
 
-    public static bool operator <(Rational<T> x, Rational<T> y)
-    {
-        return x._numerator * y._denominator < y._numerator * x._denominator;
-    }
+    public static bool operator <(Rational<T> x, Rational<T> y) => x._numerator * y._denominator < y._numerator * x._denominator;
 
-    public static bool operator >(Rational<T> x, Rational<T> y)
-    {
-        return x._numerator * y._denominator > y._numerator * x._denominator;
-    }
+    public static bool operator >(Rational<T> x, Rational<T> y) => x._numerator * y._denominator > y._numerator * x._denominator;
 
-    public static bool operator <=(Rational<T> x, Rational<T> y)
-    {
-        return x._numerator * y._denominator <= y._numerator * x._denominator;
-    }
+    public static bool operator <=(Rational<T> x, Rational<T> y) => x._numerator * y._denominator <= y._numerator * x._denominator;
 
-    public static bool operator >=(Rational<T> x, Rational<T> y)
-    {
-        return x._numerator * y._denominator >= y._numerator * x._denominator;
-    }
+    public static bool operator >=(Rational<T> x, Rational<T> y) => x._numerator * y._denominator >= y._numerator * x._denominator;
 
     public int CompareTo(object? obj)
     {

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -212,8 +212,7 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
             return 1;
         if (obj is Rational<T> other)
             return CompareTo(other);
-
-        throw new ArgumentException("Argument is not a rational number");
+        throw new ArgumentException("The argument is not a rational number.");
     }
 
     public int CompareTo(Rational<T> value)

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -37,10 +37,11 @@ namespace Mathematics.NET.Core;
 /// <typeparam name="T">A type that implements <see cref="IBinaryInteger{TSelf}"/>.</typeparam>
 [Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly struct Rational<T> : IRational<Rational<T>, T>
-    where T : IBinaryInteger<T>
+    where T : IBinaryInteger<T>, ISignedNumber<T>
 {
     public static readonly Rational<T> Zero = T.Zero;
     public static readonly Rational<T> One = T.One;
+    public static readonly Rational<T> NegativeOne = T.NegativeOne;
 
     public static readonly Rational<T> MaxValue = T.CreateSaturating(double.MaxValue);
     public static readonly Rational<T> MinValue = T.CreateSaturating(double.MinValue);

--- a/src/Mathematics.NET/Core/Rational.cs
+++ b/src/Mathematics.NET/Core/Rational.cs
@@ -557,7 +557,6 @@ public readonly struct Rational<T> : IRational<Rational<T>, T>
 
     public static Rational<T> Lerp(Rational<T> start, Rational<T> end, Rational<T> weight) => (One - weight) * start + weight * end;
 
-    // TODO: Find a better implementation for Max and Min
     public static Rational<T> Max(Rational<T> x, Rational<T> y)
     {
         var u = x.Reduce();

--- a/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix3x3.cs
@@ -206,7 +206,9 @@ public struct Matrix3x3<T> : ISquareMatrix<Matrix3x3<T>, T>
     //
 
     public string ToString(string? format, IFormatProvider? provider)
+#pragma warning disable EPS06
         => this.AsSpan2D().ToDisplayString();
+#pragma warning restore EPS06
 
     //
     // Methods

--- a/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix4x4.cs
@@ -231,7 +231,9 @@ public struct Matrix4x4<T> : ISquareMatrix<Matrix4x4<T>, T>
     //
 
     public string ToString(string? format, IFormatProvider? provider)
+#pragma warning disable EPS06
         => this.AsSpan2D().ToDisplayString(format, provider);
+#pragma warning restore EPS06
 
     //
     // Methods


### PR DESCRIPTION
The most important change is the way numeric types are formatted. For rational numbers, the format strings `N` and `D` can be used to select either numerators or denominators, respectively. For complex numbers, the format strings `RE` and `IM` can be used to select either real or imaginary parts, respectively.

Methods that convert real numbers to rational numbers have been improved. Use
```csharp
var rational = Rational<int>.FromDouble(3.14);
```
to get an exact representation of the rational number, `(157, 50)`. Use
```csharp
_ = Rational<int>.TryCreateFromDouble(0.667, 0.01, 4, out var rational);
```
to get the closest rational representation of the input value, `0.667`, to within a certain threshold, `0.01`, and maximum denominator size, `4`; this returns the value `(2 / 3)`.

This request also includes an update to the documentation site as well as numerous minor updates involving code style.