### PR TITLE
Disable the EPS06 warning for sections of code.

### DIFF
--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -199,7 +199,9 @@ public static class LinAlgExtensions
     {
         Span<T> span = new T[readOnlySpan.Length];
         readOnlySpan.CopyTo(span);
+#pragma warning disable EPS06
         return span.ToDisplayString(format, provider);
+#pragma warning restore EPS06
     }
 
     /// <summary>Get the string representation of this <see cref="Span{T}"/> object.</summary>
@@ -246,7 +248,9 @@ public static class LinAlgExtensions
     {
         Span2D<T> span = new T[readOnlySpan2D.Height, readOnlySpan2D.Width];
         readOnlySpan2D.CopyTo(span);
+#pragma warning disable EPS06
         return span.ToDisplayString(format, provider);
+#pragma warning restore EPS06
     }
 
     /// <summary>Get the string representation of this <see cref="Span2D{T}"/> object.</summary>

--- a/src/Mathematics.NET/LinearAlgebra/Matrix2x2.cs
+++ b/src/Mathematics.NET/LinearAlgebra/Matrix2x2.cs
@@ -176,7 +176,9 @@ public struct Matrix2x2<T> : ISquareMatrix<Matrix2x2<T>, T>
     //
 
     public string ToString(string? format, IFormatProvider? provider)
+#pragma warning disable EPS06
         => this.AsSpan2D().ToDisplayString(format, provider);
+#pragma warning restore EPS06
 
     //
     // Methods


### PR DESCRIPTION
Disable the `EPS06` warning for sections of code; these are diagnostic messages from [ErrorProne.NET](https://github.com/SergeyTeplyakov/ErrorProne.NET) and can be ignored in some cases.