### PR TITLE
Update generate-documentation-site.yml

### DIFF
--- a/.github/workflows/generate-documentation-site.yml
+++ b/.github/workflows/generate-documentation-site.yml
@@ -28,9 +28,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.x
-          9.x
+        dotnet-version: 9.x
 
     - name: Build Mathematics.NET Project
       run: |


### PR DESCRIPTION
For the documentation site, use .NET 9 only.