### PR TITLE
Add methods for the DifGeo class

### DIFF
--- a/src/Mathematics.NET.SourceGenerators.Public/Mathematics.NET.SourceGenerators.Public.csproj
+++ b/src/Mathematics.NET.SourceGenerators.Public/Mathematics.NET.SourceGenerators.Public.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mathematics.NET.SourceGenerators/Mathematics.NET.SourceGenerators.csproj
+++ b/src/Mathematics.NET.SourceGenerators/Mathematics.NET.SourceGenerators.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="none">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mathematics.NET/AutoDiff/Dual.cs
+++ b/src/Mathematics.NET/AutoDiff/Dual.cs
@@ -252,8 +252,26 @@ public readonly struct Dual<T>(T d0, T d1) : IDual<Dual<T>, T>
         => new(f(x._d0, y._d0), dfy(x._d0, y._d0) * x._d1 + dfx(x._d0, y._d1) * y._d1);
 
     //
+    // Implicit Operators
+    //
+
+    public static implicit operator Dual<T>(T value) => new(value);
+
+    //
     // DifGeo
     //
+
+    public static AutoDiffTensor2<Dual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1)
+        where U : IIndex
+        => new(x0, x1);
+
+    public static AutoDiffTensor3<Dual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1, T x2)
+        where U : IIndex
+        => new(x0, x1, x2);
+
+    public static AutoDiffTensor4<Dual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1, T x2, T x3)
+        where U : IIndex
+        => new(x0, x1, x2, x3);
 
     public static AutoDiffTensor2<Dual<T>, T, U> CreateAutoDiffTensor<U>(in Dual<T> x0, in Dual<T> x1)
         where U : IIndex

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -37,9 +37,9 @@
 //                  ┌───────────╳ Cos ────────────┐
 //     Root Node 1: ╳────┐                        │
 //                       ╳ Sum ────┐              ╳ Divide ──── Result
-//     Root Node 2: ╳────┘         |              │
+//     Root Node 2: ╳────┘         │              │
 //                                 ╳ Multiply ────┘
-//                                 |
+//                                 │
 //     Root Node 3: ╳────╳ Sin ────┘
 //
 // Nodes, ╳, are numbered starting at the root in the order they were added using the CreateVariable()
@@ -57,6 +57,9 @@
 // operations:
 //
 //     ╳────╳ '*', '+', '%', etc. and constant ──── Result
+
+// TODO: Add a way of finding and tracking different branches in the tree. This will be useful for checkpointing
+// and improving the efficiency of calculations by not having to perform operations multiple times.
 
 #pragma warning disable IDE0032
 

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -144,7 +144,7 @@ public record class GradientTape<T> : ITape<T>
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                logger.LogInformation("Log nodes operation cancelled");
+                logger.LogInformation("Log nodes operation cancelled.");
                 cancellationToken.ThrowIfCancellationRequested();
             }
         }

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -112,7 +112,7 @@ public record class HessianTape<T> : ITape<T>
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                logger.LogInformation("Log nodes operation cancelled");
+                logger.LogInformation("Log nodes operation cancelled.");
                 cancellationToken.ThrowIfCancellationRequested();
             }
         }

--- a/src/Mathematics.NET/AutoDiff/HyperDual.cs
+++ b/src/Mathematics.NET/AutoDiff/HyperDual.cs
@@ -279,33 +279,55 @@ public readonly struct HyperDual<T>(Dual<T> d0, Dual<T> d1) : IDual<HyperDual<T>
         => new(f(x._d0, y._d0), dfy(x._d0, y._d0) * x._d1 + dfx(x._d0, y._d1) * y._d1);
 
     //
+    // Implicit Operators
+    //
+
+    public static implicit operator HyperDual<T>(T value) => new(value);
+
+    /// <summary>Convert a dual number into a hyper-dual number.</summary>
+    /// <param name="value">A dual number.</param>
+    public static implicit operator HyperDual<T>(Dual<T> value) => new(value);
+
+    //
     // DifGeo
     //
 
-    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(in Dual{TN}, in Dual{TN})" />
-    public static AutoDiffTensor2<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1)
+    public static AutoDiffTensor2<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1)
         where U : IIndex
         => new(x0, x1);
 
-    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(in Dual{TN}, in Dual{TN}, in Dual{TN})" />
-    public static AutoDiffTensor3<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1, in HyperDual<T> x2)
+    public static AutoDiffTensor3<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1, T x2)
         where U : IIndex
         => new(x0, x1, x2);
 
-    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(in Dual{TN}, in Dual{TN}, in Dual{TN}, in Dual{TN})"/>
-    public static AutoDiffTensor4<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1, in HyperDual<T> x2, in HyperDual<T> x3)
+    public static AutoDiffTensor4<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(T x0, T x1, T x2, T x3)
         where U : IIndex
         => new(x0, x1, x2, x3);
 
     public static AutoDiffTensor2<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in Dual<T> x0, in Dual<T> x1)
         where U : IIndex
-        => new(new(x0), new(x1));
+        => new(x0, x1);
 
     public static AutoDiffTensor3<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in Dual<T> x0, in Dual<T> x1, in Dual<T> x2)
         where U : IIndex
-        => new(new(x0), new(x1), new(x2));
+        => new(x0, x1, x2);
 
     public static AutoDiffTensor4<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in Dual<T> x0, in Dual<T> x1, in Dual<T> x2, in Dual<T> x3)
         where U : IIndex
-        => new(new(x0), new(x1), new(x2), new(x3));
+        => new(x0, x1, x2, x3);
+
+    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(TN, TN)" />
+    public static AutoDiffTensor2<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1)
+        where U : IIndex
+        => new(x0, x1);
+
+    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(TN, TN, TN)" />
+    public static AutoDiffTensor3<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1, in HyperDual<T> x2)
+        where U : IIndex
+        => new(x0, x1, x2);
+
+    /// <inheritdoc cref="IDual{TDN, TN}.CreateAutoDiffTensor{TI}(TN, TN, TN, TN)"/>
+    public static AutoDiffTensor4<HyperDual<T>, T, U> CreateAutoDiffTensor<U>(in HyperDual<T> x0, in HyperDual<T> x1, in HyperDual<T> x2, in HyperDual<T> x3)
+        where U : IIndex
+        => new(x0, x1, x2, x3);
 }

--- a/src/Mathematics.NET/AutoDiff/HyperDual.cs
+++ b/src/Mathematics.NET/AutoDiff/HyperDual.cs
@@ -57,6 +57,10 @@ public readonly struct HyperDual<T>(Dual<T> d0, Dual<T> d1) : IDual<HyperDual<T>
     /// <summary>Represents the third tangent part, the cross term, of a hyper-dual number.</summary>
     public T D3 => _d1.D1;
 
+    internal Dual<T> Primal => _d0;
+
+    internal Dual<T> Tangent => _d1;
+
     //
     // Operators
     //
@@ -124,6 +128,8 @@ public readonly struct HyperDual<T>(Dual<T> d0, Dual<T> d1) : IDual<HyperDual<T>
     public static HyperDual<T> CreateVariable(T value) => new(new(value, T.Zero));
 
     public static HyperDual<T> CreateVariable(T value, T seed) => new(new(value, seed));
+
+    internal static HyperDual<T> CreateVariable(Dual<T> value, T seed) => new(value, seed);
 
     /// <summary>Create an instance of the type with a specified value and two seed values.</summary>
     /// <remarks>Use this to compute mixed second derivatives.</remarks>

--- a/src/Mathematics.NET/AutoDiff/IDual.cs
+++ b/src/Mathematics.NET/AutoDiff/IDual.cs
@@ -78,6 +78,15 @@ public interface IDual<TDN, TN>
     TDN WithSeed(TN seed);
 
     //
+    // Implicit Operators
+    //
+
+    /// <summary>Convert a number into a dual number.</summary>
+    /// <remarks>The tangent parts of the dual number will be zero.</remarks>
+    /// <param name="value">A number.</param>
+    static abstract implicit operator TDN(TN value);
+
+    //
     // DifGeo
     //
 
@@ -86,7 +95,7 @@ public interface IDual<TDN, TN>
     /// <param name="x0">The zeroth value.</param>
     /// <param name="x1">The first value.</param>
     /// <returns>A rank-one tensor of two initial and seed values.</returns>
-    static abstract AutoDiffTensor2<TDN, TN, TI> CreateAutoDiffTensor<TI>(in Dual<TN> x0, in Dual<TN> x1)
+    static abstract AutoDiffTensor2<TDN, TN, TI> CreateAutoDiffTensor<TI>(TN x0, TN x1)
         where TI : IIndex;
 
     /// <summary>Create an autodiff, rank-one tensor from initial and seed values.</summary>
@@ -95,7 +104,7 @@ public interface IDual<TDN, TN>
     /// <param name="x1">The first value.</param>
     /// <param name="x2">The second value.</param>
     /// <returns>A rank-one tensor of two initial and seed values.</returns>
-    static abstract AutoDiffTensor3<TDN, TN, TI> CreateAutoDiffTensor<TI>(in Dual<TN> x0, in Dual<TN> x1, in Dual<TN> x2)
+    static abstract AutoDiffTensor3<TDN, TN, TI> CreateAutoDiffTensor<TI>(TN x0, TN x1, TN x2)
         where TI : IIndex;
 
     /// <summary>Create an autodiff, rank-one tensor from initial and seed values.</summary>
@@ -105,6 +114,18 @@ public interface IDual<TDN, TN>
     /// <param name="x2">The second value.</param>
     /// <param name="x3">The third value.</param>
     /// <returns>A rank-one tensor of two initial and seed values.</returns>
+    static abstract AutoDiffTensor4<TDN, TN, TI> CreateAutoDiffTensor<TI>(TN x0, TN x1, TN x2, TN x3)
+        where TI : IIndex;
+
+    /// <inheritdoc cref="CreateAutoDiffTensor{TI}(TN, TN)"/>
+    static abstract AutoDiffTensor2<TDN, TN, TI> CreateAutoDiffTensor<TI>(in Dual<TN> x0, in Dual<TN> x1)
+        where TI : IIndex;
+
+    /// <inheritdoc cref="CreateAutoDiffTensor{TI}(TN, TN, TN)"/>
+    static abstract AutoDiffTensor3<TDN, TN, TI> CreateAutoDiffTensor<TI>(in Dual<TN> x0, in Dual<TN> x1, in Dual<TN> x2)
+        where TI : IIndex;
+
+    /// <inheritdoc cref="CreateAutoDiffTensor{TI}(TN, TN, TN, TN)"/>
     static abstract AutoDiffTensor4<TDN, TN, TI> CreateAutoDiffTensor<TI>(in Dual<TN> x0, in Dual<TN> x1, in Dual<TN> x2, in Dual<TN> x3)
         where TI : IIndex;
 }

--- a/src/Mathematics.NET/Core/Buffers/FMTensor2Buffer2.cs
+++ b/src/Mathematics.NET/Core/Buffers/FMTensor2Buffer2.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="FMTensor2Buffer2.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0051
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+
+namespace Mathematics.NET.Core.Buffers;
+
+/// <summary>Represents a buffer of 2 AutoDiffTensor2 delegates.</summary>
+/// <typeparam name="TDN">A type that implements <see cref="IDual{TDN, TN}"/>.</typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
+[InlineArray(2)]
+internal struct FMTensor2Buffer2<TDN, TN, TPI>
+    where TDN : IDual<TDN, TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TPI : IIndex
+{
+    private Func<AutoDiffTensor2<TDN, TN, TPI>, TDN> _element0;
+}

--- a/src/Mathematics.NET/Core/Buffers/FMTensor3Buffer3.cs
+++ b/src/Mathematics.NET/Core/Buffers/FMTensor3Buffer3.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="FMTensor3Buffer3.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0051
+
+using System.Runtime.CompilerServices;
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
+
+namespace Mathematics.NET.Core.Buffers;
+
+/// <summary>Represents a buffer of 3 AutoDiffTensor3 delegates.</summary>
+/// <typeparam name="TDN">A type that implements <see cref="IDual{TDN, TN}"/>.</typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
+[InlineArray(3)]
+internal struct FMTensor3Buffer3<TDN, TN, TPI>
+    where TDN : IDual<TDN, TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TPI : IIndex
+{
+    private Func<AutoDiffTensor3<TDN, TN, TPI>, TDN> _element0;
+}

--- a/src/Mathematics.NET/Core/CoreExtensions.cs
+++ b/src/Mathematics.NET/Core/CoreExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Extensions.cs" company="Mathematics.NET">
+﻿// <copyright file="CoreExtensions.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -30,11 +30,11 @@ using System.Runtime.CompilerServices;
 
 namespace Mathematics.NET.Core;
 
-/// <summary>Extension methods for Mathematics.NET.</summary>
-public static class Extensions
+/// <summary>Core extension methods for Mathematics.NET.</summary>
+public static class CoreExtensions
 {
     //
-    // Casts and reinterprets
+    // Casts and Reinterprets
     //
 
     /// <summary>Reinterprets a <see cref="Real"/> as a new <see cref="double"/>.</summary>

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -73,12 +73,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 2; k++)
+            for (int j = 0; j < 2; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor2<TDN, TN, Index<Upper, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor2<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -100,12 +98,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 3; k++)
+            for (int j = 0; j < 3; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor3<TDN, TN, Index<Upper, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor3<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -127,12 +123,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 4; k++)
+            for (int j = 0; j < 4; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor4<TDN, TN, Index<Upper, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor4<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -154,12 +148,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 2; k++)
+            for (int j = 0; j < 2; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor2<TDN, TN, Index<Lower, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor2<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -181,12 +173,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 3; k++)
+            for (int j = 0; j < 3; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor3<TDN, TN, Index<Lower, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor3<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -208,12 +198,10 @@ public static partial class DifGeo
         {
             var seed = point;
             seed[i] = TDN.CreateVariable(seed[i].D0, 1);
-            for (int k = 0; k < 4; k++)
+            for (int j = 0; j < 4; j++)
             {
-                if (tensor[k] is Func<AutoDiffTensor4<TDN, TN, Index<Lower, TPIN>>, TDN> function)
-                {
-                    dTensor[i, k] = function(seed).D1;
-                }
+                if (tensor[j] is Func<AutoDiffTensor4<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                    dTensor[i, j] = function(seed).D1;
             }
         }
     }
@@ -249,10 +237,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 2; k++)
+                for (int j = 0; j < 2; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -278,10 +265,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 3; k++)
+                for (int j = 0; j < 3; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -307,10 +293,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 4; k++)
+                for (int j = 0; j < 4; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -336,10 +321,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 2; k++)
+                for (int j = 0; j < 2; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -365,10 +349,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 3; k++)
+                for (int j = 0; j < 3; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -394,10 +377,9 @@ public static partial class DifGeo
             {
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out var gradient);
-
-                for (int k = 0; k < 4; k++)
+                for (int j = 0; j < 4; j++)
                 {
-                    dTensor[k, i] = gradient[k];
+                    dTensor[j, i] = gradient[j];
                 }
             }
         }
@@ -588,7 +570,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 2; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -622,7 +603,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 3; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -656,7 +636,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 4; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -690,7 +669,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 2; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -724,7 +702,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 3; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -758,7 +735,6 @@ public static partial class DifGeo
                 {
                     _ = function(tape, point);
                     tape.ReverseAccumulate(out var gradient);
-
                     for (int k = 0; k < 4; k++)
                     {
                         dTensor[k, i, j] = gradient[k];
@@ -804,11 +780,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 2; k++)
+                for (int j = 0; j < 2; j++)
                 {
-                    for (int l = 0; l < 2; l++)
+                    for (int k = 0; k < 2; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -838,11 +814,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 3; k++)
+                for (int j = 0; j < 3; j++)
                 {
-                    for (int l = 0; l < 3; l++)
+                    for (int k = 0; k < 3; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -871,11 +847,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 4; k++)
+                for (int j = 0; j < 4; j++)
                 {
-                    for (int l = 0; l < 4; l++)
+                    for (int k = 0; k < 4; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -904,11 +880,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 2; k++)
+                for (int j = 0; j < 2; j++)
                 {
-                    for (int l = 0; l < 2; l++)
+                    for (int k = 0; k < 2; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -937,11 +913,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 3; k++)
+                for (int j = 0; j < 3; j++)
                 {
-                    for (int l = 0; l < 3; l++)
+                    for (int k = 0; k < 3; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -970,11 +946,11 @@ public static partial class DifGeo
                 _ = function(tape, point);
                 tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
 
-                for (int k = 0; k < 4; k++)
+                for (int j = 0; j < 4; j++)
                 {
-                    for (int l = 0; l < 4; l++)
+                    for (int k = 0; k < 4; k++)
                     {
-                        d2Tensor[k, l, i] = hessian[k, l];
+                        d2Tensor[j, k, i] = hessian[j, k];
                     }
                 }
             }
@@ -1655,15 +1631,15 @@ public static partial class DifGeo
         var cChristoffels = Contract(christoffel, christoffel.WithIndices<Index<Upper, Index1>, TI2N, TI4N>());
 
         riemann = new();
-        for (int r = 0; r < 2; r++)
+        for (int i = 0; i < 2; i++)
         {
-            for (int s = 0; s < 2; s++)
+            for (int j = 0; j < 2; j++)
             {
-                for (int m = 0; m < 2; m++)
+                for (int k = 0; k < 2; k++)
                 {
-                    for (int n = 0; n < 2; n++)
+                    for (int l = 0; l < 2; l++)
                     {
-                        riemann[r, s, m, n] = dChristoffel[m, r, s, n] - dChristoffel[n, r, s, m] + cChristoffels[r, m, s, n] - cChristoffels[r, n, s, m];
+                        riemann[i, j, k, l] = dChristoffel[k, i, j, l] - dChristoffel[l, i, j, k] + cChristoffels[i, k, j, l] - cChristoffels[i, l, j, k];
                     }
                 }
             }
@@ -1688,15 +1664,15 @@ public static partial class DifGeo
         var cChristoffels = Contract(christoffel, christoffel.WithIndices<Index<Upper, Index1>, TI2N, TI4N>());
 
         riemann = new();
-        for (int r = 0; r < 3; r++)
+        for (int i = 0; i < 3; i++)
         {
-            for (int s = 0; s < 3; s++)
+            for (int j = 0; j < 3; j++)
             {
-                for (int m = 0; m < 3; m++)
+                for (int k = 0; k < 3; k++)
                 {
-                    for (int n = 0; n < 3; n++)
+                    for (int l = 0; l < 3; l++)
                     {
-                        riemann[r, s, m, n] = dChristoffel[m, r, s, n] - dChristoffel[n, r, s, m] + cChristoffels[r, m, s, n] - cChristoffels[r, n, s, m];
+                        riemann[i, j, k, l] = dChristoffel[k, i, j, l] - dChristoffel[l, i, j, k] + cChristoffels[i, k, j, l] - cChristoffels[i, l, j, k];
                     }
                 }
             }
@@ -1721,15 +1697,15 @@ public static partial class DifGeo
         var cChristoffels = Contract(christoffel, christoffel.WithIndices<Index<Upper, Index1>, TI2N, TI4N>());
 
         riemann = new();
-        for (int r = 0; r < 4; r++)
+        for (int i = 0; i < 4; i++)
         {
-            for (int s = 0; s < 4; s++)
+            for (int j = 0; j < 4; j++)
             {
-                for (int m = 0; m < 4; m++)
+                for (int k = 0; k < 4; k++)
                 {
-                    for (int n = 0; n < 4; n++)
+                    for (int l = 0; l < 4; l++)
                     {
-                        riemann[r, s, m, n] = dChristoffel[m, r, s, n] - dChristoffel[n, r, s, m] + cChristoffels[r, m, s, n] - cChristoffels[r, n, s, m];
+                        riemann[i, j, k, l] = dChristoffel[k, i, j, l] - dChristoffel[l, i, j, k] + cChristoffels[i, k, j, l] - cChristoffels[i, l, j, k];
                     }
                 }
             }

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -755,6 +755,203 @@ public static partial class DifGeo
     /// <typeparam name="TI1N">The name of the first index of the tensor.</typeparam>
     /// <typeparam name="TI2N">The name of the second index of the tensor.</typeparam>
     /// <typeparam name="TI3N">The name of the third index of the tensor.</typeparam>
+    /// <param name="tensor">A rank-one tensor field.</param>
+    /// <param name="point">A point on the manifold.</param>
+    /// <param name="d2Tensor">A rank-three tensor.</param>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField2<HyperDual<TN>, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor2<HyperDual<TN>, TN, Index<Upper, TPIN>> point,
+        out Tensor<Array2x2x2<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 2; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 2; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor2<HyperDual<TN>, TN, Index<Upper, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(FMTensorField2{HyperDual{TN}, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{HyperDual{TN}, TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField3<HyperDual<TN>, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor3<HyperDual<TN>, TN, Index<Upper, TPIN>> point,
+        out Tensor<Array3x3x3<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 3; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 3; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor3<HyperDual<TN>, TN, Index<Upper, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(FMTensorField2{HyperDual{TN}, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{HyperDual{TN}, TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField4<HyperDual<TN>, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor4<HyperDual<TN>, TN, Index<Upper, TPIN>> point,
+        out Tensor<Array4x4x4<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 4; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 4; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor4<HyperDual<TN>, TN, Index<Upper, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(FMTensorField2{HyperDual{TN}, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{HyperDual{TN}, TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField2<HyperDual<TN>, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor2<HyperDual<TN>, TN, Index<Lower, TPIN>> point,
+        out Tensor<Array2x2x2<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 2; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 2; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor2<HyperDual<TN>, TN, Index<Lower, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(FMTensorField2{HyperDual{TN}, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{HyperDual{TN}, TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField3<HyperDual<TN>, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor3<HyperDual<TN>, TN, Index<Lower, TPIN>> point,
+        out Tensor<Array3x3x3<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 3; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 3; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor3<HyperDual<TN>, TN, Index<Lower, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(FMTensorField2{HyperDual{TN}, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{HyperDual{TN}, TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        FMTensorField4<HyperDual<TN>, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor4<HyperDual<TN>, TN, Index<Lower, TPIN>> point,
+        out Tensor<Array4x4x4<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            var dSeed = point;
+            dSeed[i] = HyperDual<TN>.CreateVariable(dSeed[i].D0, 1);
+            for (int j = 0; j < 4; j++)
+            {
+                var d2Seed = dSeed;
+                d2Seed[j] = HyperDual<TN>.CreateVariable(dSeed[j].Primal, 1);
+                for (int k = 0; k < 4; k++)
+                {
+                    if (tensor[k] is Func<AutoDiffTensor4<HyperDual<TN>, TN, Index<Lower, TPIN>>, HyperDual<TN>> function)
+                        d2Tensor[i, j, k] = function(d2Seed).D3;
+                }
+            }
+        }
+    }
+
+    /// <summary>Compute the second derivative of rank-one tensor.</summary>
+    /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
+    /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+    /// <typeparam name="TPIN">The name of the point index.</typeparam>
+    /// <typeparam name="TI2P">The index position of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI3P">The index position of the third index of the tensor.</typeparam>
+    /// <typeparam name="TI1N">The name of the first index of the tensor.</typeparam>
+    /// <typeparam name="TI2N">The name of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI3N">The name of the third index of the tensor.</typeparam>
     /// <param name="tape">A Hessian tape.</param>
     /// <param name="tensor">A rank-two tensor field.</param>
     /// <param name="point">A point on the manifold.</param>

--- a/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/DifGeo.cs
@@ -39,10 +39,369 @@ namespace Mathematics.NET.DifferentialGeometry;
 public static partial class DifGeo
 {
     //
-    // General calculus
+    // General Calculus
     //
 
-    // TODO: Optimize the following methods
+    // TODO: Optimize the following methods.
+
+    // First derivatives.
+
+    /// <summary>Compute the derivative of rank-one tensor.</summary>
+    /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
+    /// <typeparam name="TDN">A type that implements <see cref="IDual{TDN, TN}"/>.</typeparam>
+    /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+    /// <typeparam name="TPIN">The name of the point index.</typeparam>
+    /// <typeparam name="TI2P">The index position of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI1N">The name of the first index of the tensor.</typeparam>
+    /// <typeparam name="TI2N">The name of the second index of the tensor.</typeparam>
+    /// <param name="tensor">A rank-one tensor field.</param>
+    /// <param name="point">A point on the manifold.</param>
+    /// <param name="dTensor">A rank-two tensor.</param>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField2<TDN, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor2<TDN, TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix2x2<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 2; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor2<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TDN, TN, TPIN, TI2P, TI1N, TI2N}(FMTensorField2{TDN, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TDN, TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField3<TDN, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor3<TDN, TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix3x3<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 3; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor3<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TDN, TN, TPIN, TI2P, TI1N, TI2N}(FMTensorField2{TDN, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TDN, TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField4<TDN, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor4<TDN, TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix4x4<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 4; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor4<TDN, TN, Index<Upper, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TDN, TN, TPIN, TI2P, TI1N, TI2N}(FMTensorField2{TDN, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TDN, TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField2<TDN, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor2<TDN, TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix2x2<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 2; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor2<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TDN, TN, TPIN, TI2P, TI1N, TI2N}(FMTensorField2{TDN, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TDN, TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField3<TDN, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor3<TDN, TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix3x3<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 3; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor3<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TDN, TN, TPIN, TI2P, TI1N, TI2N}(FMTensorField2{TDN, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TDN, TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TDN, TN, TPIN, TI2P, TI1N, TI2N>(
+        FMTensorField4<TDN, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor4<TDN, TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix4x4<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TDN : IDual<TDN, TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            var seed = point;
+            seed[i] = TDN.CreateVariable(seed[i].D0, 1);
+            for (int k = 0; k < 4; k++)
+            {
+                if (tensor[k] is Func<AutoDiffTensor4<TDN, TN, Index<Lower, TPIN>>, TDN> function)
+                {
+                    dTensor[i, k] = function(seed).D1;
+                }
+            }
+        }
+    }
+
+    /// <summary>Compute the derivative of rank-one tensor.</summary>
+    /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
+    /// <typeparam name="TT">A type that implements <see cref="ITape{T}"/>.</typeparam>
+    /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+    /// <typeparam name="TPIN">The name of the point index.</typeparam>
+    /// <typeparam name="TI2P">The index position of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI1N">The name of the first index of the tensor.</typeparam>
+    /// <typeparam name="TI2N">The name of the second index of the tensor.</typeparam>
+    /// <param name="tape">A gradient or Hessian tape.</param>
+    /// <param name="tensor">A rank-one tensor field.</param>
+    /// <param name="point">A point on the manifold.</param>
+    /// <param name="dTensor">A rank-two tensor.</param>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField2<TT, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor2<TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix2x2<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor2<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 2; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI2P, TI1N, TI2N}(TT, RMTensorField2{TT, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField3<TT, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor3<TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix3x3<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor3<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 3; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI2P, TI1N, TI2N}(TT, RMTensorField2{TT, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField4<TT, TN, TI2P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
+        out Tensor<Matrix4x4<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor4<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 4; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI2P, TI1N, TI2N}(TT, RMTensorField2{TT, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField2<TT, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor2<TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix2x2<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor2<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 2; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI2P, TI1N, TI2N}(TT, RMTensorField2{TT, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField3<TT, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor3<TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix3x3<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor3<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 3; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="Derivative{TT, TN, TPIN, TI2P, TI1N, TI2N}(TT, RMTensorField2{TT, TN, TI2P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Matrix2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}})"/>
+    public static void Derivative<TT, TN, TPIN, TI2P, TI1N, TI2N>(
+        TT tape,
+        RMTensorField4<TT, TN, TI2P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor4<TN, Index<Lower, TPIN>> point,
+        out Tensor<Matrix4x4<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>> dTensor)
+        where TT : ITape<TN>
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+    {
+        dTensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            if (tensor[i] is Func<TT, AutoDiffTensor4<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out var gradient);
+
+                for (int k = 0; k < 4; k++)
+                {
+                    dTensor[k, i] = gradient[k];
+                }
+            }
+        }
+    }
 
     /// <summary>Compute the derivative of the inverse of a metric tensor.</summary>
     /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
@@ -409,6 +768,219 @@ public static partial class DifGeo
         }
     }
 
+    // Second derivatives.
+
+    /// <summary>Compute the second derivative of rank-one tensor.</summary>
+    /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
+    /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+    /// <typeparam name="TPIN">The name of the point index.</typeparam>
+    /// <typeparam name="TI2P">The index position of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI3P">The index position of the third index of the tensor.</typeparam>
+    /// <typeparam name="TI1N">The name of the first index of the tensor.</typeparam>
+    /// <typeparam name="TI2N">The name of the second index of the tensor.</typeparam>
+    /// <typeparam name="TI3N">The name of the third index of the tensor.</typeparam>
+    /// <param name="tape">A Hessian tape.</param>
+    /// <param name="tensor">A rank-two tensor field.</param>
+    /// <param name="point">A point on the manifold.</param>
+    /// <param name="d2Tensor">A rank-two tensor.</param>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField2<HessianTape<TN>, TN, TI3P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor2<TN, Index<Upper, TPIN>> point,
+        out Tensor<Array2x2x2<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor2<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 2; k++)
+                {
+                    for (int l = 0; l < 2; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(HessianTape{TN}, RMTensorField2{HessianTape{TN}, TN, TI3P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField3<HessianTape<TN>, TN, TI3P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor3<TN, Index<Upper, TPIN>> point,
+        out Tensor<Array3x3x3<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor3<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 3; k++)
+                {
+                    for (int l = 0; l < 3; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(HessianTape{TN}, RMTensorField2{HessianTape{TN}, TN, TI3P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField4<HessianTape<TN>, TN, TI3P, Index<Upper, TPIN>> tensor,
+        AutoDiffTensor4<TN, Index<Upper, TPIN>> point,
+        out Tensor<Array4x4x4<TN>, TN, Index<Lower, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor4<TN, Index<Upper, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 4; k++)
+                {
+                    for (int l = 0; l < 4; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(HessianTape{TN}, RMTensorField2{HessianTape{TN}, TN, TI3P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField2<HessianTape<TN>, TN, TI3P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor2<TN, Index<Lower, TPIN>> point,
+        out Tensor<Array2x2x2<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor2<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 2; k++)
+                {
+                    for (int l = 0; l < 2; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(HessianTape{TN}, RMTensorField2{HessianTape{TN}, TN, TI3P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField3<HessianTape<TN>, TN, TI3P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor3<TN, Index<Lower, TPIN>> point,
+        out Tensor<Array3x3x3<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor3<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 3; k++)
+                {
+                    for (int l = 0; l < 3; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc cref="SecondDerivative{TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N}(HessianTape{TN}, RMTensorField2{HessianTape{TN}, TN, TI3P, Index{Upper, TPIN}}, AutoDiffTensor2{TN, Index{Upper, TPIN}}, out Tensor{Array2x2x2{TN}, TN, Index{Lower, TI1N}, Index{TI2P, TI2N}, Index{TI3P, TI3N}})"/>
+    public static void SecondDerivative<TN, TPIN, TI2P, TI3P, TI1N, TI2N, TI3N>(
+        HessianTape<TN> tape,
+        RMTensorField4<HessianTape<TN>, TN, TI3P, Index<Lower, TPIN>> tensor,
+        AutoDiffTensor4<TN, Index<Lower, TPIN>> point,
+        out Tensor<Array4x4x4<TN>, TN, Index<Upper, TI1N>, Index<TI2P, TI2N>, Index<TI3P, TI3N>> d2Tensor)
+        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+        where TPIN : IIndexName
+        where TI2P : IIndexPosition
+        where TI3P : IIndexPosition
+        where TI1N : IIndexName
+        where TI2N : IIndexName
+        where TI3N : IIndexName
+    {
+        d2Tensor = new();
+        for (int i = 0; i < 4; i++)
+        {
+            if (tensor[i] is Func<HessianTape<TN>, AutoDiffTensor4<TN, Index<Lower, TPIN>>, Variable<TN>> function)
+            {
+                _ = function(tape, point);
+                tape.ReverseAccumulate(out ReadOnlySpan2D<TN> hessian);
+
+                for (int k = 0; k < 4; k++)
+                {
+                    for (int l = 0; l < 4; l++)
+                    {
+                        d2Tensor[k, l, i] = hessian[k, l];
+                    }
+                }
+            }
+        }
+    }
+
     /// <summary>Compute the second derivative or a rank-two tensor.</summary>
     /// <remarks>Though the result of this operation returns a tensor object, it may not be a tensor in the mathematical sense.</remarks>
     /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
@@ -645,7 +1217,7 @@ public static partial class DifGeo
     }
 
     //
-    // Christoffel symbols
+    // Christoffel symbols.
     //
 
     /// <summary>Compute a Christoffel symbol of the first kind given a metric tensor.</summary>
@@ -1052,7 +1624,7 @@ public static partial class DifGeo
     }
 
     //
-    // Riemann tensor
+    // Riemann tensors.
     //
 
     /// <summary>Compute a Riemann tensor given a metric tensor.</summary>
@@ -1168,7 +1740,7 @@ public static partial class DifGeo
     // Tensor contractions
     //
 
-    // Rank-one and Rank-one
+    // Rank-one and rank-one.
 
     [GenerateTensorContractions]
     public static TN Contract<TLR1T, TRR1T, TV, TN, TCI>(in IRankOneTensor<TLR1T, TV, TN, Index<Lower, TCI>> left, in IRankOneTensor<TRR1T, TV, TN, Index<Upper, TCI>> right)
@@ -1186,7 +1758,7 @@ public static partial class DifGeo
         return result;
     }
 
-    // Rank-one and Rank-two
+    // Rank-one and rank-two.
 
     [GenerateTensorContractions]
     public static Tensor<Vector2<TN>, TN, TI> Contract<TR1T, TR2T, TN, TCI, TI>(
@@ -1314,7 +1886,7 @@ public static partial class DifGeo
         return new(vector);
     }
 
-    // Rank-one and Rank-three
+    // Rank-one and rank-three.
 
     [GenerateTensorContractions]
     public static Tensor<Matrix2x2<TN>, TN, TI1, TI2> Contract<TR1T, TR3T, TN, TCI, TI1, TI2>(
@@ -1466,7 +2038,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    // Rank-one and Rank-four
+    // Rank-one and rank-four.
 
     [GenerateTensorContractions]
     public static Tensor<Array2x2x2<TN>, TN, TI1, TI2, TI3> Contract<TR1T, TR4T, TN, TCI, TI1, TI2, TI3>(
@@ -1642,7 +2214,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    // Rank-two and Rank-two
+    // Rank-two and rank-two.
 
     [GenerateTensorContractions]
     public static Tensor<Matrix2x2<TN>, TN, TI1, TI2> Contract<TLR2T, TRR3T, TN, TCI, TI1, TI2>(
@@ -1719,7 +2291,7 @@ public static partial class DifGeo
         return new(matrix);
     }
 
-    // Rank-two and Rank-three
+    // Rank-two and rank-three.
 
     [GenerateTensorContractions]
     public static Tensor<Array2x2x2<TN>, TN, TI1, TI2, TI3> Contract<TR2T, TR3T, TN, TCI, TI1, TI2, TI3>(
@@ -1895,7 +2467,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    // Rank-two and Rank-four
+    // Rank-two and rank-four.
 
     [GenerateTensorContractions]
     public static Tensor<Array2x2x2x2<TN>, TN, TI1, TI2, TI3, TI4> Contract<TR2T, TR4T, TN, TCI, TI1, TI2, TI3, TI4>(
@@ -2095,7 +2667,7 @@ public static partial class DifGeo
         return new(array);
     }
 
-    // Rank-three and Rank-three
+    // Rank-three and rank-three.
 
     [GenerateTensorContractions]
     public static Tensor<Array2x2x2x2<TN>, TN, TI1, TI2, TI3, TI4> Contract<TLR3T, TRR3T, TN, TCI, TI1, TI2, TI3, TI4>(
@@ -2197,7 +2769,7 @@ public static partial class DifGeo
     }
 
     //
-    // Tensor self-contractions
+    // Tensor Self-Contractions
     //
 
     [GenerateTensorSelfContractions]
@@ -2336,7 +2908,7 @@ public static partial class DifGeo
     }
 
     //
-    // Tensor products
+    // Tensor Products
     //
 
     /// <summary>Compute the tensor product of two rank-one tensors.</summary>

--- a/src/Mathematics.NET/DifferentialGeometry/FMTensorField2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/FMTensorField2.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricTensorField3x3.cs" company="Mathematics.NET">
+﻿// <copyright file="FMTensorField2.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -25,50 +25,47 @@
 // SOFTWARE.
 // </copyright>
 
+using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Core.Buffers;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
 using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a 3x3 metric tensor field.</summary>
-/// <typeparam name="TT">A type that implements <see cref="ITape{T}"/>.</typeparam>
+/// <summary>Represents a rank-one tensor field with two elements.</summary>
+/// <typeparam name="TDN">A type that implements <see cref="IDual{TDN, TN}"/>.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TIP">The position of the index of the tensor.</typeparam>
 /// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
-public class MetricTensorField3x3<TT, TN, TPI> : RMTensorField3x3<TT, TN, Lower, Lower, TPI>
-    where TT : ITape<TN>
+public class FMTensorField2<TDN, TN, TIP, TPI> : TensorField<TN, TPI>
+    where TDN : IDual<TDN, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TIP : IIndexPosition
     where TPI : IIndex
 {
-    public MetricTensorField3x3() { }
+    private protected FMTensor2Buffer2<TDN, TN, TPI> _buffer;
 
-    /// <inheritdoc cref="MetricTensorField2x2{TT, TN, TPI}.Compute{TI1N, TI2N}(TT, AutoDiffTensor2{TN, TPI})"/>
-    public new MetricTensor<Matrix3x3<TN>, TN, Lower, TI1N, TI2N> Compute<TI1N, TI2N>(TT tape, AutoDiffTensor3<TN, TPI> point)
-        where TI1N : IIndexName
-        where TI2N : IIndexName
+    public FMTensorField2() { }
+
+    public Func<AutoDiffTensor2<TDN, TN, TPI>, TDN> this[int index]
     {
-        tape.IsTracking = false;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _buffer[index];
 
-        Matrix3x3<TN> result = new();
-        for (int i = 0; i < 3; i++)
-        {
-            for (int j = 0; j < 3; j++)
-            {
-                if (_buffer[i][j] is Func<TT, AutoDiffTensor3<TN, TPI>, Variable<TN>> function)
-                    result[i, j] = function(tape, point).Value;
-            }
-        }
-
-        tape.IsTracking = true;
-        return new MetricTensor<Matrix3x3<TN>, TN, Lower, TI1N, TI2N>(result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _buffer[index] = value;
     }
 
-    /// <inheritdoc cref="MetricTensorField2x2{TT, TN, TPI}.ComputeInverse{TI1N, TI2N}(TT, AutoDiffTensor2{TN, TPI})"/>
-    public MetricTensor<Matrix3x3<TN>, TN, Upper, TI1N, TI2N> ComputeInverse<TI1N, TI2N>(TT tape, AutoDiffTensor3<TN, TPI> point)
-        where TI1N : IIndexName
-        where TI2N : IIndexName
+    public Tensor<Vector2<TN>, TN, Index<TIP, TIN>> Compute<TIN>(AutoDiffTensor2<TDN, TN, TPI> point)
+        where TIN : IIndexName
     {
-        var value = Compute<TI1N, TI2N>(tape, point);
-        return value.Inverse();
+        Vector2<TN> result = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (_buffer[i] is Func<AutoDiffTensor2<TDN, TN, TPI>, TDN> function)
+                result[i] = function(point).D0;
+        }
+        return new Tensor<Vector2<TN>, TN, Index<TIP, TIN>>(result);
     }
 }

--- a/src/Mathematics.NET/DifferentialGeometry/FMTensorField3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/FMTensorField3.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricTensorField3x3.cs" company="Mathematics.NET">
+﻿// <copyright file="FMTensorField3.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -25,50 +25,47 @@
 // SOFTWARE.
 // </copyright>
 
+using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
+using Mathematics.NET.Core.Buffers;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
 using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
-/// <summary>Represents a 3x3 metric tensor field.</summary>
-/// <typeparam name="TT">A type that implements <see cref="ITape{T}"/>.</typeparam>
+/// <summary>Represents a rank-one tensor field with three elements.</summary>
+/// <typeparam name="TDN">A type that implements <see cref="IDual{TDN, TN}"/>.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
+/// <typeparam name="TIP">The position of the index of the tensor.</typeparam>
 /// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
-public class MetricTensorField3x3<TT, TN, TPI> : RMTensorField3x3<TT, TN, Lower, Lower, TPI>
-    where TT : ITape<TN>
+public class FMTensorField3<TDN, TN, TIP, TPI> : TensorField<TN, TPI>
+    where TDN : IDual<TDN, TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
+    where TIP : IIndexPosition
     where TPI : IIndex
 {
-    public MetricTensorField3x3() { }
+    private protected FMTensor3Buffer3<TDN, TN, TPI> _buffer;
 
-    /// <inheritdoc cref="MetricTensorField2x2{TT, TN, TPI}.Compute{TI1N, TI2N}(TT, AutoDiffTensor2{TN, TPI})"/>
-    public new MetricTensor<Matrix3x3<TN>, TN, Lower, TI1N, TI2N> Compute<TI1N, TI2N>(TT tape, AutoDiffTensor3<TN, TPI> point)
-        where TI1N : IIndexName
-        where TI2N : IIndexName
+    public FMTensorField3() { }
+
+    public Func<AutoDiffTensor3<TDN, TN, TPI>, TDN> this[int index]
     {
-        tape.IsTracking = false;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _buffer[index];
 
-        Matrix3x3<TN> result = new();
-        for (int i = 0; i < 3; i++)
-        {
-            for (int j = 0; j < 3; j++)
-            {
-                if (_buffer[i][j] is Func<TT, AutoDiffTensor3<TN, TPI>, Variable<TN>> function)
-                    result[i, j] = function(tape, point).Value;
-            }
-        }
-
-        tape.IsTracking = true;
-        return new MetricTensor<Matrix3x3<TN>, TN, Lower, TI1N, TI2N>(result);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _buffer[index] = value;
     }
 
-    /// <inheritdoc cref="MetricTensorField2x2{TT, TN, TPI}.ComputeInverse{TI1N, TI2N}(TT, AutoDiffTensor2{TN, TPI})"/>
-    public MetricTensor<Matrix3x3<TN>, TN, Upper, TI1N, TI2N> ComputeInverse<TI1N, TI2N>(TT tape, AutoDiffTensor3<TN, TPI> point)
-        where TI1N : IIndexName
-        where TI2N : IIndexName
+    public Tensor<Vector3<TN>, TN, Index<TIP, TIN>> Compute<TIN>(AutoDiffTensor3<TDN, TN, TPI> point)
+        where TIN : IIndexName
     {
-        var value = Compute<TI1N, TI2N>(tape, point);
-        return value.Inverse();
+        Vector3<TN> result = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (_buffer[i] is Func<AutoDiffTensor3<TDN, TN, TPI>, TDN> function)
+                result[i] = function(point).D0;
+        }
+        return new Tensor<Vector3<TN>, TN, Index<TIP, TIN>>(result);
     }
 }

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensorField2x2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensorField2x2.cs
@@ -35,7 +35,7 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="TT">A type that implements <see cref="ITape{T}"/>.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
 /// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
-public abstract class MetricTensorField2x2<TT, TN, TPI> : RMTensorField2x2<TT, TN, Lower, Lower, TPI>
+public class MetricTensorField2x2<TT, TN, TPI> : RMTensorField2x2<TT, TN, Lower, Lower, TPI>
     where TT : ITape<TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
     where TPI : IIndex

--- a/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/MetricTensorField4x4.cs
@@ -35,7 +35,7 @@ namespace Mathematics.NET.DifferentialGeometry;
 /// <typeparam name="TT">A type that implements <see cref="ITape{T}"/>.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
 /// <typeparam name="TPI">The index of the point on the manifold.</typeparam>
-public abstract class MetricTensorField4x4<TT, TN, TPI> : RMTensorField4x4<TT, TN, Lower, Lower, TPI>
+public class MetricTensorField4x4<TT, TN, TPI> : RMTensorField4x4<TT, TN, Lower, Lower, TPI>
     where TT : ITape<TN>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
     where TPI : IIndex

--- a/src/Mathematics.NET/DifferentialGeometry/RMTensorField2.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/RMTensorField2.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.Core.Buffers;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
@@ -54,5 +55,22 @@ public class RMTensorField2<TT, TN, TIP, TPI> : TensorField<TN, TPI>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _buffer[index] = value;
+    }
+
+    /// <summary>Compute the value of the tensor at a specified point.</summary>
+    /// <typeparam name="TIN">An index name.</typeparam>
+    /// <param name="tape">A gradient or Hessian tape.</param>
+    /// <param name="point">A point.</param>
+    /// <returns>The value of the tensor at the specified point.</returns>
+    public Tensor<Vector2<TN>, TN, Index<TIP, TIN>> Compute<TIN>(TT tape, AutoDiffTensor2<TN, TPI> point)
+        where TIN : IIndexName
+    {
+        Vector2<TN> result = new();
+        for (int i = 0; i < 2; i++)
+        {
+            if (_buffer[i] is Func<TT, AutoDiffTensor2<TN, TPI>, Variable<TN>> function)
+                result[i] = function(tape, point).Value;
+        }
+        return new Tensor<Vector2<TN>, TN, Index<TIP, TIN>>(result);
     }
 }

--- a/src/Mathematics.NET/DifferentialGeometry/RMTensorField3.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/RMTensorField3.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.Core.Buffers;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
@@ -54,5 +55,18 @@ public class RMTensorField3<TT, TN, TIP, TPI> : TensorField<TN, TPI>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _buffer[index] = value;
+    }
+
+    /// <inheritdoc cref="RMTensorField2{TT, TN, TIP, TPI}.Compute{TIN}(TT, AutoDiffTensor2{TN, TPI})"/>
+    public Tensor<Vector3<TN>, TN, Index<TIP, TIN>> Compute<TIN>(TT tape, AutoDiffTensor3<TN, TPI> point)
+        where TIN : IIndexName
+    {
+        Vector3<TN> result = new();
+        for (int i = 0; i < 3; i++)
+        {
+            if (_buffer[i] is Func<TT, AutoDiffTensor3<TN, TPI>, Variable<TN>> function)
+                result[i] = function(tape, point).Value;
+        }
+        return new Tensor<Vector3<TN>, TN, Index<TIP, TIN>>(result);
     }
 }

--- a/src/Mathematics.NET/DifferentialGeometry/RMTensorField4.cs
+++ b/src/Mathematics.NET/DifferentialGeometry/RMTensorField4.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 using Mathematics.NET.AutoDiff;
 using Mathematics.NET.Core.Buffers;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.DifferentialGeometry;
 
@@ -54,5 +55,18 @@ public class RMTensorField4<TT, TN, TIP, TPI> : TensorField<TN, TPI>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _buffer[index] = value;
+    }
+
+    /// <inheritdoc cref="RMTensorField2{TT, TN, TIP, TPI}.Compute{TIN}(TT, AutoDiffTensor2{TN, TPI})"/>
+    public Tensor<Vector4<TN>, TN, Index<TIP, TIN>> Compute<TIN>(TT tape, AutoDiffTensor4<TN, TPI> point)
+        where TIN : IIndexName
+    {
+        Vector4<TN> result = new();
+        for (int i = 0; i < 4; i++)
+        {
+            if (_buffer[i] is Func<TT, AutoDiffTensor4<TN, TPI>, Variable<TN>> function)
+                result[i] = function(tape, point).Value;
+        }
+        return new Tensor<Vector4<TN>, TN, Index<TIP, TIN>>(result);
     }
 }

--- a/src/Mathematics.NET/Exceptions/ComputeServiceException.cs
+++ b/src/Mathematics.NET/Exceptions/ComputeServiceException.cs
@@ -1,0 +1,96 @@
+﻿// <copyright file="ComputeException.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+using Silk.NET.OpenCL;
+
+namespace Mathematics.NET.Exceptions;
+
+/// <summary>Represents compute-related errors.</summary>
+public sealed class ComputeServiceException : Exception
+{
+    public ComputeServiceException() { }
+
+    public ComputeServiceException(string message)
+        : base(message) { }
+
+    public ComputeServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+
+    public ComputeServiceException(string message, string? device = default, string? kernel = default)
+        : base(message)
+    {
+        Device = device;
+        Kernel = kernel;
+    }
+
+    /// <summary>The device where the exception occured.</summary>
+    public string? Device { get; }
+
+    /// <summary>The kernel where the exception occured.</summary>
+    public string? Kernel { get; }
+
+    //
+    // Throw Helpers
+    //
+
+    /// <summary>Throw a <see cref="ComputeServiceException"/> if a compute method did not return a success error code.</summary>
+    /// <param name="errorCode">The error code returned from a compute method.</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="device">The device where the error occured.</param>
+    /// <param name="kernel">The kernel where the error occured.</param>
+    /// <exception cref="ComputeServiceException">Thrown when the compute service encounters an error.</exception>
+    public static void ThrowIfNotSuccess(int errorCode, string message, string? device = default, string? kernel = default)
+    {
+        if (errorCode != (int)ErrorCodes.Success)
+            throw new ComputeServiceException(message, device, kernel);
+    }
+
+    /// <summary>Throw a <see cref="ComputeServiceException"/> if the argument of a kernel could not be set.</summary>
+    /// <param name="errorCode">The error code returned from the argument-setting method.</param>
+    /// <param name="device">The device where the error occured.</param>
+    /// <param name="kernel">The kernel where the error occured.</param>
+    /// <exception cref="ComputeServiceException">Thrown when the compute service encounters an error.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfCouldNotSetKernelArguments(int errorCode, string device, string kernel)
+    {
+        if (errorCode != (int)ErrorCodes.Success)
+            throw new ComputeServiceException("Unable to set arguments for the kernel.", device, kernel);
+    }
+
+    /// <summary>Throw a <see cref="ComputeServiceException"/> if an n-dimensional range kernel could not be enqueued.</summary>
+    /// <param name="errorCode">The error code returned from the kernel-enqueing method.</param>
+    /// <param name="device">The device where the error occured.</param>
+    /// <param name="kernel">The kernel where the error occured.</param>
+    /// <exception cref="ComputeServiceException">Thrown when the compute service encounters an error.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfCouldNotEnqueueNDRangeKernel(int errorCode, string device, string kernel)
+    {
+        if (errorCode != (int)ErrorCodes.Success)
+            throw new ComputeServiceException("Unable to enqueue the n-dimensional range kernel.", device, kernel);
+    }
+}

--- a/src/Mathematics.NET/Exceptions/MathematicsException.cs
+++ b/src/Mathematics.NET/Exceptions/MathematicsException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Platform.cs" company="Mathematics.NET">
+﻿// <copyright file="MathematicsException.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -25,36 +25,16 @@
 // SOFTWARE.
 // </copyright>
 
-#pragma warning disable IDE0058
+namespace Mathematics.NET.Exceptions;
 
-using System.Text;
-using Silk.NET.OpenCL;
-
-namespace Mathematics.NET.GPU.OpenCL;
-
-/// <summary>Represents an OpenCL platform.</summary>
-public sealed class Platform : IOpenCLObject
+/// <summary>Represents a mathematics exception.</summary>
+public sealed class MathematicsException : Exception
 {
-    private readonly CL _cl;
+    public MathematicsException() { }
 
-    // Platform information.
-    public readonly string Vendor;
+    public MathematicsException(string message)
+        : base(message) { }
 
-    public unsafe Platform(CL cl, nint handle)
-    {
-        _cl = cl;
-        Handle = handle;
-
-        // Platform vendor.
-        _cl.GetPlatformInfo(Handle, PlatformInfo.Vendor, 0, null, out var vendorSize);
-        Span<byte> vendorSpan = new byte[vendorSize];
-        _cl.GetPlatformInfo(Handle, PlatformInfo.Vendor, vendorSize, vendorSpan, []);
-        Vendor = Encoding.UTF8.GetString(vendorSpan).TrimEnd('\0');
-    }
-
-    public void Dispose() => Handle = 0;
-
-    public nint Handle { get; private set; }
-
-    public bool IsValidInstance => Handle != 0;
+    public MathematicsException(string message, Exception innerException)
+        : base(message, innerException) { }
 }

--- a/src/Mathematics.NET/Extensions.cs
+++ b/src/Mathematics.NET/Extensions.cs
@@ -27,7 +27,7 @@
 
 using System.Text;
 
-namespace Mathematics.NET.Utilities;
+namespace Mathematics.NET;
 
 /// <summary>A class containing extension methods for external .NET objects.</summary>
 public static class Extensions

--- a/src/Mathematics.NET/GPU/OpenCL/CommandQueue.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/CommandQueue.cs
@@ -34,7 +34,6 @@ namespace Mathematics.NET.GPU.OpenCL;
 /// <summary>Represents an OpenCL command queue.</summary>
 public sealed class CommandQueue : IOpenCLObject
 {
-    // Api.
     private readonly CL _cl;
 
     public unsafe CommandQueue(CL cl, Context context, Device device, CommandQueueProperties commandQueueProperties)

--- a/src/Mathematics.NET/GPU/OpenCL/Device.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/Device.cs
@@ -35,7 +35,6 @@ namespace Mathematics.NET.GPU.OpenCL;
 /// <summary>Represents an OpenCL device.</summary>
 public sealed class Device : IOpenCLObject
 {
-    // Api.
     private readonly CL _cl;
 
     // Device information, listed mostly alphabetically.

--- a/src/Mathematics.NET/GPU/OpenCL/Kernel.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/Kernel.cs
@@ -27,33 +27,27 @@
 
 #pragma warning disable IDE0058
 
+using Mathematics.NET.Exceptions;
 using Microsoft.Extensions.Logging;
 using Silk.NET.OpenCL;
 
 namespace Mathematics.NET.GPU.OpenCL;
 
 /// <summary>Represents an OpenCL kernel.</summary>
-public sealed class Kernel : IOpenCLObject
+public sealed partial class Kernel : IOpenCLObject
 {
     private CL _cl;
-    private ILogger<OpenCLService> _logger;
 
     public readonly string Name;
 
-    public unsafe Kernel(ILogger<OpenCLService> logger, CL cl, Program program, string name)
+    public unsafe Kernel(CL cl, Program program, string name)
     {
         _cl = cl;
-        _logger = logger;
 
         Name = name;
-
         Handle = _cl.CreateKernel(program.Handle, name, out var error);
-#if DEBUG
-        if (error != (int)ErrorCodes.Success)
-        {
-            _logger.LogDebug("Unable to create kernel.");
-        }
-#endif
+
+        ComputeServiceException.ThrowIfNotSuccess(error, "Unable to create the kernel", kernel: name);
     }
 
     public void Dispose()

--- a/src/Mathematics.NET/GPU/OpenCL/KernelWorkGroupInformation.cs
+++ b/src/Mathematics.NET/GPU/OpenCL/KernelWorkGroupInformation.cs
@@ -33,9 +33,9 @@ using Silk.NET.OpenCL;
 namespace Mathematics.NET.GPU.OpenCL;
 
 /// <summary>Represents a kernel work group info object.</summary>
-public sealed class KernelWorkGroupInformation
+public sealed partial class KernelWorkGroupInformation
 {
-    // Api.
+    private ILogger<OpenCLService> _logger;
     private CL _cl;
 
     // Kernel work group information.
@@ -48,6 +48,7 @@ public sealed class KernelWorkGroupInformation
 
     public unsafe KernelWorkGroupInformation(ILogger<OpenCLService> logger, CL cl, Device device, Kernel kernel)
     {
+        _logger = logger;
         _cl = cl;
 
         // Kernel compile work group size.
@@ -61,7 +62,7 @@ public sealed class KernelWorkGroupInformation
         if (error != (int)ErrorCodes.Success)
         {
             if (error == (int)ErrorCodes.InvalidValue)
-                logger.LogDebug("This device does not support the parameter CL_KERNEL_GLOBAL_WORK_SIZE for clGetKernelWorkGroupInfo.");
+                ParameterNotSupported();
             KernelGlobalWorkSize = Array.Empty<nuint>();
         }
         else
@@ -89,4 +90,7 @@ public sealed class KernelWorkGroupInformation
         _cl.GetKernelWorkGroupInfo(kernel.Handle, device.Handle, KernelWorkGroupInfo.WorkGroupSize, (nuint)sizeof(nuint), &kernelWorkGroupSize, null);
         KernelWorkGroupSize = kernelWorkGroupSize;
     }
+
+    [LoggerMessage(LogLevel.Warning, "This device does not support the parameter CL_KERNEL_GLOBAL_WORK_SIZE for clGetKernelWorkGroupInfo.")]
+    private partial void ParameterNotSupported();
 }

--- a/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlgExtensions.cs
@@ -31,7 +31,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Text;
 using Mathematics.NET.AutoDiff;
-using Mathematics.NET.Utilities;
 
 namespace Mathematics.NET.LinearAlgebra;
 

--- a/src/Mathematics.NET/Mathematics.NET.csproj
+++ b/src/Mathematics.NET/Mathematics.NET.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.2.0" />
+    <PackageReference Include="Verify.MSTest" Version="28.6.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.6.1" />
+    <PackageReference Include="Verify.MSTest" Version="28.7.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.2.0" />
+    <PackageReference Include="Verify.MSTest" Version="28.6.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.6.1" />
+    <PackageReference Include="Verify.MSTest" Version="28.7.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests/Assert.cs
+++ b/tests/Mathematics.NET.Tests/Assert.cs
@@ -26,14 +26,15 @@
 // </copyright>
 
 using CommunityToolkit.HighPerformance;
+using Mathematics.NET.DifferentialGeometry.Abstractions;
 using Mathematics.NET.LinearAlgebra.Abstractions;
 
 namespace Mathematics.NET.Tests;
 
 /// <summary>Assert helpers for Mathemtics.NET.</summary>
-/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/>.</typeparam>
+/// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
 public sealed class Assert<TN>
-    where TN : IComplex<TN>
+    where TN : IComplex<TN>, IDifferentiableFunctions<TN>
 {
     /// <summary>Assert that two values are approximately equal.</summary>
     /// <param name="expected">The expected value.</param>
@@ -42,9 +43,7 @@ public sealed class Assert<TN>
     public static void AreApproximatelyEqual(TN expected, TN actual, Real epsilon)
     {
         if (TN.IsNaN(expected) && TN.IsNaN(actual) || TN.IsInfinity(expected) && TN.IsInfinity(actual))
-        {
             return;
-        }
 
         if (!Precision.AreApproximatelyEqual(expected, actual, epsilon))
         {
@@ -57,7 +56,7 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in vector are approximately equal.</summary>
+    /// <summary>Assert that the elements of two vectors are approximately equal.</summary>
     /// <typeparam name="TV">A vector.</typeparam>
     /// <param name="expected">The expected vector.</param>
     /// <param name="actual">The actual vector.</param>
@@ -79,23 +78,48 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in two read-only spans are approximately equal.</summary>
+    /// <summary>Assert that the elements of two rank-one tensors are approximately equal.</summary>
+    /// <typeparam name="TR1T">A rank-one tensor.</typeparam>
+    /// <typeparam name="TV">The backing vector of the tensor.</typeparam>
+    /// <typeparam name="TI">An index.</typeparam>
+    /// <param name="expected">The expected tensor.</param>
+    /// <param name="actual">The actual tensor.</param>
+    /// <param name="epsilon">The margin of error.</param>
+    public static void AreApproximatelyEqual<TR1T, TV, TI>(
+        IRankOneTensor<TR1T, TV, TN, TI> expected,
+        IRankOneTensor<TR1T, TV, TN, TI> actual,
+        Real epsilon)
+        where TR1T : IRankOneTensor<TR1T, TV, TN, TI>
+        where TV : IVector<TV, TN>
+        where TI : IIndex
+    {
+        for (int i = 0; i < TR1T.E1Components; i++)
+        {
+            if (!Precision.AreApproximatelyEqual(expected[i], actual[i], epsilon))
+            {
+                Assert.Fail($$"""
+                    Actual value at index {{i}} does not fall within the specified margin of error, {{epsilon}}
+
+                    Expected: {{expected[i]}}
+                    Actual: {{actual[i]}}
+                    """);
+            }
+        }
+    }
+
+    /// <summary>Assert that the elements of two read-only spans are approximately equal.</summary>
     /// <param name="expected">A read-only span of expected values.</param>
     /// <param name="actual">A read-only span of actual values.</param>
     /// <param name="epsilon">A margin of error.</param>
     public static void AreApproximatelyEqual(ReadOnlySpan<TN> expected, ReadOnlySpan<TN> actual, Real epsilon)
     {
         if (expected.Length != actual.Length)
-        {
             Assert.Fail($"Length of the actual array, {actual.Length}, does not match the length of the expected array, {expected.Length}");
-        }
 
         for (int i = 0; i < expected.Length; i++)
         {
             if (TN.IsNaN(expected[i]) && TN.IsNaN(actual[i]) || TN.IsInfinity(expected[i]) && TN.IsInfinity(actual[i]))
-            {
                 continue;
-            }
 
             if (!Precision.AreApproximatelyEqual(expected[i], actual[i], epsilon))
             {
@@ -109,7 +133,7 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in a matrix are approximately equal.</summary>
+    /// <summary>Assert that the elements of two matrices are approximately equal.</summary>
     /// <typeparam name="TM">A matrix.</typeparam>
     /// <param name="expected">The expected matrix.</param>
     /// <param name="actual">The actual matrix.</param>
@@ -134,25 +158,55 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in two 2D, read-only spans are approximately equal.</summary>
+    /// <summary>Assert that the elements of two rank-two tensors are approximately equal.</summary>
+    /// <typeparam name="TR2T">A rank-two tensor.</typeparam>
+    /// <typeparam name="TSM">The backing matrix of the tensor.</typeparam>
+    /// <typeparam name="TI1">The first index.</typeparam>
+    /// <typeparam name="TI2">The second index.</typeparam>
+    /// <param name="expected">The expected rank-two tensor.</param>
+    /// <param name="actual">The actual rank-two tensor.</param>
+    /// <param name="epsilon">The margin of error.</param>
+    public static void AreApproximatelyEqual<TR2T, TSM, TI1, TI2>(
+        IRankTwoTensor<TR2T, TSM, TN, TI1, TI2> expected,
+        IRankTwoTensor<TR2T, TSM, TN, TI1, TI2> actual,
+        Real epsilon)
+        where TR2T : IRankTwoTensor<TR2T, TSM, TN, TI1, TI2>
+        where TSM : ISquareMatrix<TSM, TN>
+        where TI1 : IIndex
+        where TI2 : IIndex
+    {
+        for (int i = 0; i < TSM.E1Components; i++)
+        {
+            for (int j = 0; j < TSM.E2Components; j++)
+            {
+                if (!Precision.AreApproximatelyEqual(expected[i, j], actual[i, j], epsilon))
+                {
+                    Assert.Fail($$"""
+                        Actual value at row {{i}} and column {{j}} does not fall within the specified margin of error, {{epsilon}}:
+
+                        Expected: {{expected[i, j]}}
+                        Actual: {{actual[i, j]}}
+                        """);
+                }
+            }
+        }
+    }
+
+    /// <summary>Assert that the elements of two 2D, read-only spans are approximately equal.</summary>
     /// <param name="expected">A 2D, read-only span of expected values.</param>
     /// <param name="actual">A 2D, read-only span of actual values.</param>
     /// <param name="epsilon">A margin of error.</param>
     public static void AreApproximatelyEqual(ReadOnlySpan2D<TN> expected, ReadOnlySpan2D<TN> actual, Real epsilon)
     {
         if (expected.Height != actual.Height || expected.Width != actual.Width)
-        {
             Assert.Fail($"Dimensions of the actual matrix, [{actual.Height}, {actual.Width}], does not match the dimensions of the expected matrix, [{expected.Height}, {expected.Width}]");
-        }
 
         for (int i = 0; i < expected.Height; i++)
         {
             for (int j = 0; j < expected.Width; j++)
             {
                 if (TN.IsNaN(expected[i, j]) && TN.IsNaN(actual[i, j]) || TN.IsInfinity(expected[i, j]) && TN.IsInfinity(actual[i, j]))
-                {
                     continue;
-                }
 
                 if (!Precision.AreApproximatelyEqual(expected[i, j], actual[i, j], epsilon))
                 {
@@ -167,16 +221,14 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in two 3D arrays are approximately equal.</summary>
+    /// <summary>Assert that the elements of two 3D arrays are approximately equal.</summary>
     /// <param name="expected">A 3D array of expected values.</param>
     /// <param name="actual">A 3D array of actual values.</param>
     /// <param name="epsilon">A margin of error.</param>
     public static void AreApproximatelyEqual(TN[,,] expected, TN[,,] actual, Real epsilon)
     {
         if (expected.GetLength(0) != actual.GetLength(0) || expected.GetLength(1) != actual.GetLength(1) || expected.GetLength(2) != actual.GetLength(2))
-        {
             Assert.Fail($"Dimensions of the actual array, [{actual.GetLength(0)}, {actual.GetLength(1)}, {actual.GetLength(2)}], does not match the dimensions of the expected matrix, [{expected.GetLength(0)}, {expected.GetLength(1)}, {expected.GetLength(2)}]");
-        }
 
         for (int i = 0; i < expected.GetLength(0); i++)
         {
@@ -185,9 +237,7 @@ public sealed class Assert<TN>
                 for (int k = 0; k < expected.GetLength(2); k++)
                 {
                     if (TN.IsNaN(expected[i, j, k]) && TN.IsNaN(actual[i, j, k]) || TN.IsInfinity(expected[i, j, k]) && TN.IsInfinity(actual[i, j, k]))
-                    {
                         continue;
-                    }
 
                     if (!Precision.AreApproximatelyEqual(expected[i, j, k], actual[i, j, k], epsilon))
                     {
@@ -203,7 +253,7 @@ public sealed class Assert<TN>
         }
     }
 
-    /// <summary>Assert that the elements in two 4D arrays are approximately equal.</summary>
+    /// <summary>Assert that the elements of two 4D arrays are approximately equal.</summary>
     /// <param name="expected">A 4D array of expected values.</param>
     /// <param name="actual">A 4D array of actual values.</param>
     /// <param name="epsilon">A margin of error.</param>
@@ -226,9 +276,7 @@ public sealed class Assert<TN>
                     for (int l = 0; l < expected.GetLength(3); l++)
                     {
                         if (TN.IsNaN(expected[i, j, k, l]) && TN.IsNaN(actual[i, j, k, l]) || TN.IsInfinity(expected[i, j, k, l]) && TN.IsInfinity(actual[i, j, k, l]))
-                        {
                             continue;
-                        }
 
                         if (!Precision.AreApproximatelyEqual(expected[i, j, k, l], actual[i, j, k, l], epsilon))
                         {

--- a/tests/Mathematics.NET.Tests/AutoDiff/DualOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/DualOfRealTests.cs
@@ -369,6 +369,19 @@ public sealed class DualOfRealTests
     }
 
     [TestMethod]
+    [DataRow(1.23)]
+    public void ImplicitOperator_Number_ReturnsDualNumber(double value)
+    {
+        Real input = value;
+
+        Dual<Real> expected = new(input, 0);
+
+        Dual<Real> actual = input;
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
     [DataRow(1.23, 0.813008130081301)]
     public void Ln_DualNumber_ReturnsDerivative(double input, double expected)
     {

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoForwardModeTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoForwardModeTests.cs
@@ -60,8 +60,22 @@ public sealed class DifGeoForwardModeTests
 
         var expected = (Real[,])values[0];
 
-        DifGeo.Derivative(R1Tensor, point, out Tensor<Matrix4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>> derivative);
-        var actual = derivative.ToArray();
+        DifGeo.Derivative(R1Tensor, point, out Tensor<Matrix4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>> dTensor);
+        var actual = dTensor.ToArray();
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetR1TensorSecondDerivativeData), DynamicDataSourceType.Method)]
+    public void SecondDerivative_RankOneTensor_ReturnsRankTwoTensor(object[] input, object[] values)
+    {
+        var point = HyperDual<Real>.CreateAutoDiffTensor<Index<Upper, PIN>>(1.23, 2.34, 3.45, 4.56);
+
+        var expected = (Real[,,])values[0];
+
+        DifGeo.SecondDerivative(R1Tensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>, Index<Upper, Gamma>> d2Tensor);
+        var actual = d2Tensor.ToArray();
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -83,6 +97,44 @@ public sealed class DifGeoForwardModeTests
                     { -0.9096285273579445, 0.47343399708193507, 0,                  0                  },
                     { 0,                   0.47343399708193507, 3010.9171128823823, 0                  },
                     { 0,                   0,                   3010.9171128823823, 0.2077929087308457 }
+                }
+            }
+        };
+    }
+
+    public static IEnumerable<object[]> GetR1TensorSecondDerivativeData()
+    {
+        yield return new[]
+        {
+            [1.23, 2.34, 3.45, 4.56],
+            new object[]
+            {
+                new Real[,,]
+                {
+                    {
+                        { 0.4154226067712459, 0, 0, -0.017944119924943498 },
+                        { 0.4154226067712459, 0, 0, 0                     },
+                        { 0,                  0, 0, 0                     },
+                        { 0,                  0, 0, -0.017944119924943498 }
+                    },
+                    {
+                        { 0.4154226067712459, 0,                  0, 0 },
+                        { 0.4154226067712459, -0.880829296973609, 0, 0 },
+                        { 0,                  -0.880829296973609, 0, 0 },
+                        { 0,                  0,                  0, 0 }
+                    },
+                    {
+                        { 0, 0,                  0,                  0 },
+                        { 0, -0.880829296973609, 0,                  0 },
+                        { 0, -0.880829296973609, 3010.9171128823823, 0 },
+                        { 0, 0,                  3010.9171128823823, 0 }
+                    },
+                    {
+                        { 0, 0, 0,                  -0.017944119924943498 },
+                        { 0, 0, 0,                  0                     },
+                        { 0, 0, 3010.9171128823823, 0                     },
+                        { 0, 0, 3010.9171128823823, -0.017944119924943498 }
+                    },
                 }
             }
         };

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoForwardModeTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoForwardModeTests.cs
@@ -1,0 +1,90 @@
+﻿// <copyright file="DifGeoForwardModeTests.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0060
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.LinearAlgebra;
+
+namespace Mathematics.NET.Tests.DifferentialGeometry;
+
+[TestClass]
+[TestCategory("DifGeo")]
+public sealed class DifGeoForwardModeTests
+{
+    public static FMTensorField4<HyperDual<Real>, Real, Upper, Index<Upper, PIN>> R1Tensor { get; set; } = new();
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+        R1Tensor[0] = x => HyperDual<Real>.Sin(x.X0 + x.X1);
+        R1Tensor[1] = x => HyperDual<Real>.Cos(x.X1 + x.X2);
+        R1Tensor[2] = x => HyperDual<Real>.Exp(x.X2 + x.X3);
+        R1Tensor[3] = x => HyperDual<Real>.Sqrt(x.X3 + x.X0);
+    }
+
+    //
+    // Tests
+    //
+
+    [TestMethod]
+    [DynamicData(nameof(GetR1TenserDerivativeData), DynamicDataSourceType.Method)]
+    public void Derivative_RankOneTensor_ReturnsRankTwoTensor(object[] input, object[] values)
+    {
+        var point = HyperDual<Real>.CreateAutoDiffTensor<Index<Upper, PIN>>(1.23, 2.34, 3.45, 4.56);
+
+        var expected = (Real[,])values[0];
+
+        DifGeo.Derivative(R1Tensor, point, out Tensor<Matrix4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>> derivative);
+        var actual = derivative.ToArray();
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+
+    //
+    // Helpers
+    //
+
+    public static IEnumerable<object[]> GetR1TenserDerivativeData()
+    {
+        yield return new[]
+        {
+            [1.23, 2.34, 3.45, 4.56],
+            new object[]
+            {
+                new Real[,]
+                {
+                    { -0.9096285273579445, 0,                   0,                  0.2077929087308457 },
+                    { -0.9096285273579445, 0.47343399708193507, 0,                  0                  },
+                    { 0,                   0.47343399708193507, 3010.9171128823823, 0                  },
+                    { 0,                   0,                   3010.9171128823823, 0.2077929087308457 }
+                }
+            }
+        };
+    }
+}

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoReverseModeTests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoReverseModeTests.cs
@@ -89,8 +89,8 @@ public sealed class DifGeoReverseModeTests
 
         var expected = (Real[,])values[0];
 
-        DifGeo.Derivative(Tape, R1Tensor, point, out Tensor<Matrix4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>> derivative);
-        var actual = derivative.ToArray();
+        DifGeo.Derivative(Tape, R1Tensor, point, out Tensor<Matrix4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>> dTensor);
+        var actual = dTensor.ToArray();
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -103,8 +103,8 @@ public sealed class DifGeoReverseModeTests
 
         var expected = (Real[,,])values[0];
 
-        DifGeo.Derivative(Tape, MetricTensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Lower, Beta>, Index<Lower, Gamma>> derivative);
-        var actual = derivative.ToArray();
+        DifGeo.Derivative(Tape, MetricTensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Lower, Beta>, Index<Lower, Gamma>> dTensor);
+        var actual = dTensor.ToArray();
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -117,10 +117,26 @@ public sealed class DifGeoReverseModeTests
 
         var expected = (Real[,,])values[0];
 
-        DifGeo.Derivative(Tape, MetricTensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>, Index<Upper, Gamma>> derivative);
-        var actual = derivative.ToArray();
+        DifGeo.Derivative(Tape, MetricTensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>, Index<Upper, Gamma>> dTensor);
+        var actual = dTensor.ToArray();
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-13);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(GetR1TensorSecondDerivativeData), DynamicDataSourceType.Method)]
+    public void SecondDerivative_RankOneTensor_ReturnsRankThreeTensor(object[] input, object[] values)
+    {
+        var point = Tape.CreateAutoDiffTensor<Index<Upper, PIN>>((double)input[0], (double)input[1], (double)input[2], (double)input[3]);
+
+        var expected = (Real[,,])values[0];
+
+        DifGeo.SecondDerivative(Tape, R1Tensor, point, out Tensor<Array4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Upper, Beta>, Index<Upper, Gamma>> d2Tensor);
+        var actual = d2Tensor.ToArray();
+
+        Console.WriteLine(d2Tensor);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
 
     [TestMethod]
@@ -131,8 +147,8 @@ public sealed class DifGeoReverseModeTests
 
         var expected = (Real[,,,])values[0];
 
-        DifGeo.SecondDerivative(Tape, MetricTensor, point, out Tensor<Array4x4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Lower, Beta>, Index<Lower, Gamma>, Index<Lower, Delta>> secondDerivative);
-        var actual = secondDerivative.ToArray();
+        DifGeo.SecondDerivative(Tape, MetricTensor, point, out Tensor<Array4x4x4x4<Real>, Real, Index<Lower, Alpha>, Index<Lower, Beta>, Index<Lower, Gamma>, Index<Lower, Delta>> d2Tensor);
+        var actual = d2Tensor.ToArray();
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
@@ -229,6 +245,44 @@ public sealed class DifGeoReverseModeTests
                         { -99.9083713139095,  2.583393035830481,    -108.4372846947553, 0.0894257725193976     },
                         { 0.0876578722667318, -0.00238146677635786, 0.0960322791258335, -0.0000743715905405725 },
                         { -21.22135210759896, 0.5469516019661675,   -23.0619674179585,  0.01887653616804277    }
+                    },
+                }
+            }
+        };
+    }
+
+    public static IEnumerable<object[]> GetR1TensorSecondDerivativeData()
+    {
+        yield return new[]
+        {
+            [1.23, 2.34, 3.45, 4.56],
+            new object[]
+            {
+                new Real[,,]
+                {
+                    {
+                        { 0.4154226067712459, 0, 0, -0.017944119924943498 },
+                        { 0.4154226067712459, 0, 0, 0                     },
+                        { 0,                  0, 0, 0                     },
+                        { 0,                  0, 0, -0.017944119924943498 }
+                    },
+                    {
+                        { 0.4154226067712459, 0,                  0, 0 },
+                        { 0.4154226067712459, -0.880829296973609, 0, 0 },
+                        { 0,                  -0.880829296973609, 0, 0 },
+                        { 0,                  0,                  0, 0 }
+                    },
+                    {
+                        { 0, 0,                  0,                  0 },
+                        { 0, -0.880829296973609, 0,                  0 },
+                        { 0, -0.880829296973609, 3010.9171128823823, 0 },
+                        { 0, 0,                  3010.9171128823823, 0 }
+                    },
+                    {
+                        { 0, 0, 0,                  -0.017944119924943498 },
+                        { 0, 0, 0,                  0                     },
+                        { 0, 0, 3010.9171128823823, 0                     },
+                        { 0, 0, 3010.9171128823823, -0.017944119924943498 }
                     },
                 }
             }

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/DifGeoTestHelpers.cs
@@ -25,92 +25,27 @@
 // SOFTWARE.
 // </copyright>
 
-using Mathematics.NET.AutoDiff;
 using Mathematics.NET.DifferentialGeometry;
-using Mathematics.NET.DifferentialGeometry.Abstractions;
 
 namespace Mathematics.NET.Tests.DifferentialGeometry;
 
-public static class DifGeoTestHelpers
-{
-    public sealed class Test2x2MetricTensorFieldNo1<TT, TN, TPI> : MetricTensorField2x2<TT, TN, TPI>
-        where TT : ITape<TN>
-        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
-        where TPI : IIndex
-    {
-        public Test2x2MetricTensorFieldNo1()
-        {
-            Initialize();
-        }
-
-        private void Initialize()
-        {
-            base[0, 0] = (tape, x) =>
-            {
-                return tape.Multiply(x.X0, x.X0);
-            };
-
-            base[0, 1] = (tape, x) =>
-            {
-                return tape.Multiply(x.X0, x.X1);
-            };
-
-            base[1, 0] = (tape, x) =>
-            {
-                return tape.Negate(tape.Multiply(x.X0, x.X1));
-            };
-
-            base[1, 1] = (tape, x) =>
-            {
-                return tape.Multiply(x.X1, x.X1);
-            };
-        }
-    }
-
-    public sealed class Test4x4MetricTensorFieldNo1<TT, TN, TPI> : MetricTensorField4x4<TT, TN, TPI>
-        where TT : ITape<TN>
-        where TN : IComplex<TN>, IDifferentiableFunctions<TN>
-        where TPI : IIndex
-    {
-        public Test4x4MetricTensorFieldNo1()
-        {
-            Initialize();
-        }
-
-        private void Initialize()
-        {
-            base[0, 0] = (tape, x) => tape.Sin(x.X0);
-            base[0, 1] = (tape, x) => tape.Multiply(2, tape.Cos(x.X1));
-            base[0, 2] = (tape, x) => tape.Multiply(3, tape.Exp(x.X2));
-            base[0, 3] = (tape, x) => tape.Multiply(4, tape.Ln(x.X3));
-
-            base[1, 0] = (tape, x) => tape.Multiply(5, tape.Sqrt(x.X1));
-            base[1, 1] = (tape, x) => tape.Multiply(6, tape.Tan(x.X2));
-            base[1, 2] = (tape, x) => tape.Multiply(7, tape.Sinh(x.X3));
-            base[1, 3] = (tape, x) => tape.Multiply(8, tape.Cosh(x.X0));
-
-            base[2, 0] = (tape, x) => tape.Multiply(9, tape.Tanh(x.X2));
-            base[2, 1] = (tape, x) => tape.Divide(10, x.X3);
-            base[2, 2] = (tape, x) => tape.Multiply(11, tape.Pow(x.X0, 2));
-            base[2, 3] = (tape, x) => tape.Multiply(12, tape.Multiply(tape.Sin(x.X1), tape.Cos(x.X1)));
-
-            base[3, 0] = (tape, x) => tape.Multiply(13, tape.Multiply(tape.Exp(x.X3), tape.Sin(x.X0)));
-            base[3, 1] = (tape, x) => tape.Multiply(14, tape.Divide(x.X3, x.X1));
-            base[3, 2] = (tape, x) => tape.Multiply(15, tape.Sin(tape.Subtract(x.X3, tape.Multiply(2, x.X2))));
-            base[3, 3] = (tape, x) => tape.Multiply(16, tape.Multiply(x.X0, tape.Multiply(x.X1, tape.Multiply(x.X2, x.X3))));
-        }
-    }
-}
+public static class DifGeoTestHelpers;
 
 //
 // Symbols
 //
 
+public readonly struct PIN : IIndexName
+{
+    /// <inheritdoc cref="IIndexName.DisplayString"/>
+    public const string DisplayString = "TestIndex";
+    static string IIndexName.DisplayString => DisplayString;
+}
+
 public readonly struct Alpha : IIndexName
 {
     /// <inheritdoc cref="IIndexName.DisplayString"/>
     public const string DisplayString = "Alpha";
-
     static string IIndexName.DisplayString => DisplayString;
 }
 
@@ -118,7 +53,6 @@ public readonly struct Beta : IIndexName
 {
     /// <inheritdoc cref="IIndexName.DisplayString"/>
     public const string DisplayString = "Beta";
-
     static string IIndexName.DisplayString => DisplayString;
 }
 
@@ -126,7 +60,6 @@ public readonly struct Gamma : IIndexName
 {
     /// <inheritdoc cref="IIndexName.DisplayString"/>
     public const string DisplayString = "Gamma";
-
     static string IIndexName.DisplayString => DisplayString;
 }
 
@@ -134,7 +67,6 @@ public readonly struct Delta : IIndexName
 {
     /// <inheritdoc cref="IIndexName.DisplayString"/>
     public const string DisplayString = "Delta";
-
     static string IIndexName.DisplayString => DisplayString;
 }
 
@@ -142,6 +74,5 @@ public readonly struct Epsilon : IIndexName
 {
     /// <inheritdoc cref="IIndexName.DisplayString"/>
     public const string DisplayString = "Epsilon";
-
     static string IIndexName.DisplayString => DisplayString;
 }

--- a/tests/Mathematics.NET.Tests/DifferentialGeometry/RMTensorField4Tests.cs
+++ b/tests/Mathematics.NET.Tests/DifferentialGeometry/RMTensorField4Tests.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="RMTensorField4Tests.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+#pragma warning disable IDE0060
+
+using Mathematics.NET.AutoDiff;
+using Mathematics.NET.DifferentialGeometry;
+using Mathematics.NET.LinearAlgebra;
+
+namespace Mathematics.NET.Tests.DifferentialGeometry;
+
+[TestClass]
+[TestCategory("DifGeo")]
+public sealed class RMTensorField4Tests
+{
+    public static RMTensorField4<HessianTape<Real>, Real, Upper, Index<Upper, Alpha>> Tensor { get; set; } = new();
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext context)
+    {
+        Tensor[0] = (tape, x) => tape.Sin(tape.Add(x.X0, x.X1));
+        Tensor[1] = (tape, x) => tape.Cos(tape.Add(x.X1, x.X2));
+        Tensor[2] = (tape, x) => tape.Exp(tape.Add(x.X2, x.X3));
+        Tensor[3] = (tape, x) => tape.Sqrt(tape.Add(x.X3, x.X0));
+    }
+
+    public RMTensorField4Tests()
+    {
+        Tape = new();
+    }
+
+    public HessianTape<Real> Tape { get; set; }
+
+    //
+    // Tests
+    //
+
+    [TestMethod]
+    [DataRow(1.23, 2.34, 3.45, 4.56, -0.4154226067712459, 0.880829296973609, 3010.9171128823823, 2.406241883103193)]
+    public void Compute_Variable_ReturnsValue(double x0, double x1, double x2, double x3, double expectedX0, double expectedX1, double expectedX2, double expectedX3)
+    {
+        var x = Tape.CreateAutoDiffTensor<Index<Upper, Alpha>>(x0, x1, x2, x3);
+
+        Tensor<Vector4<Real>, Real, Index<Upper, Alpha>> expected = new(new Vector4<Real>(expectedX0, expectedX1, expectedX2, expectedX3));
+
+        var actual = Tensor.Compute<Alpha>(Tape, x);
+
+        Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
+    }
+}

--- a/tests/Mathematics.NET.Tests/LinearAlgebra/LinAlgTests.cs
+++ b/tests/Mathematics.NET.Tests/LinearAlgebra/LinAlgTests.cs
@@ -74,7 +74,7 @@ public sealed class LinAlgTests
         => QRGramSchmidt_Helper_MatrixOfGeneric_ReturnsQRDecompositionOfMatrix(matrix);
 
     public static void QRGramSchmidt_Helper_MatrixOfGeneric_ReturnsQRDecompositionOfMatrix<T>(T[,] matrix)
-        where T : IComplex<T>
+        where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         var expected = matrix.AsSpan2D();
         LinAlg.QRGramSchmidt(expected, out var Q, out var R);

--- a/tests/Mathematics.NET.Tests/LinearAlgebra/Matrix4x4Tests.cs
+++ b/tests/Mathematics.NET.Tests/LinearAlgebra/Matrix4x4Tests.cs
@@ -64,7 +64,7 @@ public sealed class Matrix4x4Tests
         => Inverse_Helper_MatrixOfGeneric_ReturnsInverseOfMatrix(input, expected);
 
     public static void Inverse_Helper_MatrixOfGeneric_ReturnsInverseOfMatrix<T>(T[,] inputArray, T[,] expectedArray)
-        where T : IComplex<T>
+        where T : IComplex<T>, IDifferentiableFunctions<T>
     {
         Matrix4x4<T> expected = new(
             expectedArray[0, 0], expectedArray[0, 1], expectedArray[0, 2], expectedArray[0, 3],

--- a/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
+++ b/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Add methods for computing first and second derivatives on rank-one, forward-mode tensors. Update existed classes to support this feature, and update tests as well.