### PR TITLE
Add checkpointing for gradient tapes

### DIFF
--- a/docs/docs/autodiff/forward-mode-autodiff.md
+++ b/docs/docs/autodiff/forward-mode-autodiff.md
@@ -4,7 +4,7 @@ description: Use first and second-order, forward-mode automatic differentiation 
 keywords: [forward-mode, autodiff, dual numbers, hyperdual, math, C#, csharp, .NET]
 ---
 
-# Forward-mode Automatic Differentiation
+# Forward-Mode Automatic Differentiation
 
 Support for first and second-order, forward-mode autodiff are provided by dual and hyperdual numbers.
 

--- a/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
+++ b/src/Mathematics.NET/AutoDiff/AutoDiffExtensions.cs
@@ -33,10 +33,8 @@ namespace Mathematics.NET.AutoDiff;
 public static class AutoDiffExtensions
 {
     //
-    // Vector calculus
+    // Vector Calculus
     //
-
-    // TODO: Improve performance; perhaps see if caching is possible for some of these methods
 
     /// <summary>Compute the curl of a vector field using reverse-mode automatic differentiation: $ (\nabla\times\textbf{F})(\textbf{x}) $.</summary>
     /// <typeparam name="T">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -195,24 +195,24 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, x.Value + y.Value);
     }
 
-    public Variable<T> Add(T c, Variable<T> x)
+    public Variable<T> Add(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c + x.Value);
+            _nodes.Add(new(T.One, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x + y.Value);
         }
-        return new(_nodes.Count, c + x.Value);
+        return new(_nodes.Count, x + y.Value);
     }
 
-    public Variable<T> Add(Variable<T> x, T c)
+    public Variable<T> Add(Variable<T> x, T y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value + c);
+            return new(_nodes.Count - 1, x.Value + y);
         }
-        return new(_nodes.Count, x.Value + c);
+        return new(_nodes.Count, x.Value + y);
     }
 
     public Variable<T> Divide(Variable<T> x, Variable<T> y)
@@ -226,20 +226,20 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, x.Value * u);
     }
 
-    public Variable<T> Divide(T c, Variable<T> x)
+    public Variable<T> Divide(T x, Variable<T> y)
     {
-        var u = T.One / x.Value;
+        var u = T.One / y.Value;
         if (_isTracking)
         {
-            _nodes.Add(new(-c * u * u, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c * u);
+            _nodes.Add(new(-x * u * u, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x * u);
         }
-        return new(_nodes.Count, c * u);
+        return new(_nodes.Count, x * u);
     }
 
-    public Variable<T> Divide(Variable<T> x, T c)
+    public Variable<T> Divide(Variable<T> x, T y)
     {
-        var u = T.One / c;
+        var u = T.One / y;
         if (_isTracking)
         {
             _nodes.Add(new(u, x._index, _nodes.Count));
@@ -258,24 +258,24 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, x.Value % y.Value);
     }
 
-    public Variable<Real> Modulo(Real c, in Variable<Real> x)
+    public Variable<Real> Modulo(Real x, in Variable<Real> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c % x.Value);
+            _nodes.Add(new(x * Real.Floor(x / y.Value), y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x % y.Value);
         }
-        return new(_nodes.Count, c % x.Value);
+        return new(_nodes.Count, x % y.Value);
     }
 
-    public Variable<Real> Modulo(in Variable<Real> x, Real c)
+    public Variable<Real> Modulo(in Variable<Real> x, Real y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value % c);
+            return new(_nodes.Count - 1, x.Value % y);
         }
-        return new(_nodes.Count, x.Value % c);
+        return new(_nodes.Count, x.Value % y);
     }
 
     public Variable<T> Multiply(Variable<T> x, Variable<T> y)
@@ -288,24 +288,24 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, x.Value * y.Value);
     }
 
-    public Variable<T> Multiply(T c, Variable<T> x)
+    public Variable<T> Multiply(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c * x.Value);
+            _nodes.Add(new(x, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x * y.Value);
         }
-        return new(_nodes.Count, c * x.Value);
+        return new(_nodes.Count, x * y.Value);
     }
 
-    public Variable<T> Multiply(Variable<T> x, T c)
+    public Variable<T> Multiply(Variable<T> x, T y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value * c);
+            _nodes.Add(new(y, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value * y);
         }
-        return new(_nodes.Count, x.Value * c);
+        return new(_nodes.Count, x.Value * y);
     }
 
     public Variable<T> Subtract(Variable<T> x, Variable<T> y)
@@ -318,24 +318,24 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, x.Value - y.Value);
     }
 
-    public Variable<T> Subtract(T c, Variable<T> x)
+    public Variable<T> Subtract(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(-T.One, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c - x.Value);
+            _nodes.Add(new(-T.One, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x - y.Value);
         }
-        return new(_nodes.Count, c - x.Value);
+        return new(_nodes.Count, x - y.Value);
     }
 
-    public Variable<T> Subtract(Variable<T> x, T c)
+    public Variable<T> Subtract(Variable<T> x, T y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value - c);
+            return new(_nodes.Count - 1, x.Value - y);
         }
-        return new(_nodes.Count, x.Value - c);
+        return new(_nodes.Count, x.Value - y);
     }
 
     //

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -352,7 +352,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, -x.Value);
     }
 
-    // Exponential functions
+    // Exponential functions.
 
     public Variable<T> Exp(Variable<T> x)
     {
@@ -387,7 +387,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, exp10);
     }
 
-    // Hyperbolic functions
+    // Hyperbolic functions.
 
     public Variable<T> Acosh(Variable<T> x)
     {
@@ -450,7 +450,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, T.Tanh(x.Value));
     }
 
-    // Logarithmic functions
+    // Logarithmic functions.
 
     public Variable<T> Ln(Variable<T> x)
     {
@@ -493,7 +493,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, T.Log10(x.Value));
     }
 
-    // Power functions
+    // Power functions.
 
     public Variable<T> Pow(Variable<T> x, Variable<T> y)
     {
@@ -528,7 +528,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, pow);
     }
 
-    // Root functions
+    // Root functions.
 
     public Variable<T> Cbrt(Variable<T> x)
     {
@@ -563,7 +563,7 @@ public record class GradientTape<T> : ITape<T>
         return new(_nodes.Count, sqrt);
     }
 
-    // Trigonometric functions
+    // Trigonometric functions.
 
     public Variable<T> Acos(Variable<T> x)
     {

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -67,6 +67,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Mathematics.NET.DifferentialGeometry;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.Exceptions;
 using Mathematics.NET.LinearAlgebra;
 using Microsoft.Extensions.Logging;
 
@@ -159,7 +160,7 @@ public record class GradientTape<T> : ITape<T>
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed)
     {
         if (_variableCount == 0)
-            throw new Exception("The gradient tape contains no root nodes.");
+            throw new AutoDiffException("The gradient tape contains no root nodes.");
 
         ReadOnlySpan<GradientNode<T>> nodes = CollectionsMarshal.AsSpan(_nodes);
         ref var start = ref MemoryMarshal.GetReference(nodes);

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -415,7 +415,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, T.Zero, T.One, T.Zero, x._index, y._index));
+            _nodes.Add(new(T.One, T.Zero, T.Zero, T.One, T.Zero, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value + y.Value);
         }
         return new(_nodes.Count, x.Value + y.Value);
@@ -425,7 +425,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, y._index, _nodes.Count));
+            _nodes.Add(new(T.One, T.Zero, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, x + y.Value);
         }
         return new(_nodes.Count, x + y.Value);
@@ -435,7 +435,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(T.One, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value + y);
         }
         return new(_nodes.Count, x.Value + y);
@@ -447,7 +447,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var dfxy = -u * u;
-            _nodes.Add(new(u, T.Zero, dfxy, x.Value * dfxy, -2.0 * u * x.Value * dfxy, x._index, y._index));
+            _nodes.Add(new(u, T.Zero, dfxy, x.Value * dfxy, -2.0 * u * x.Value * dfxy, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value * u);
         }
         return new(_nodes.Count, x.Value * u);
@@ -459,7 +459,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var dfxy = -u * u;
-            _nodes.Add(new(x * dfxy, -2.0 * u * x * dfxy, y._index, _nodes.Count));
+            _nodes.Add(new(x * dfxy, -2.0 * u * x * dfxy, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, x * u);
         }
         return new(_nodes.Count, x * u);
@@ -470,7 +470,7 @@ public record class HessianTape<T> : ITape<T>
         var u = T.One / y;
         if (_isTracking)
         {
-            _nodes.Add(new(u, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(u, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value * u);
         }
         return new(_nodes.Count, x.Value * u);
@@ -480,7 +480,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, T.Zero, x.Value * Real.Floor(x.Value / y.Value), T.Zero, x._index, y._index));
+            _nodes.Add(new(T.One, T.Zero, T.Zero, x.Value * Real.Floor(x.Value / y.Value), T.Zero, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value % y.Value);
         }
         return new(_nodes.Count, x.Value % y.Value);
@@ -490,7 +490,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(x * Real.Floor(x / y.Value), T.Zero, y._index, _nodes.Count));
+            _nodes.Add(new(x * Real.Floor(x / y.Value), T.Zero, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, x % y.Value);
         }
         return new(_nodes.Count, x % y.Value);
@@ -500,7 +500,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(T.One, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value % y);
         }
         return new(_nodes.Count, x.Value % y);
@@ -510,7 +510,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(y.Value, T.Zero, T.One, x.Value, T.Zero, x._index, y._index));
+            _nodes.Add(new(y.Value, T.Zero, T.One, x.Value, T.Zero, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value * y.Value);
         }
         return new(_nodes.Count, x.Value * y.Value);
@@ -520,7 +520,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(x, T.Zero, y._index, _nodes.Count));
+            _nodes.Add(new(x, T.Zero, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, x * y.Value);
         }
         return new(_nodes.Count, x * y.Value);
@@ -530,7 +530,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(y, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(y, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value * y);
         }
         return new(_nodes.Count, x.Value * y);
@@ -540,7 +540,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, T.Zero, -T.One, T.Zero, x._index, y._index));
+            _nodes.Add(new(T.One, T.Zero, T.Zero, -T.One, T.Zero, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value - y.Value);
         }
         return new(_nodes.Count, x.Value - y.Value);
@@ -550,7 +550,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(-T.One, T.Zero, y._index, _nodes.Count));
+            _nodes.Add(new(-T.One, T.Zero, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, x - y.Value);
         }
         return new(_nodes.Count, x - y.Value);
@@ -560,7 +560,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(T.One, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value - y);
         }
         return new(_nodes.Count, x.Value - y);
@@ -574,7 +574,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(-T.One, T.Zero, x._index, _nodes.Count));
+            _nodes.Add(new(-T.One, T.Zero, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, -x.Value);
         }
         return new(_nodes.Count, -x.Value);
@@ -587,7 +587,7 @@ public record class HessianTape<T> : ITape<T>
         var exp = T.Exp(x.Value);
         if (_isTracking)
         {
-            _nodes.Add(new(exp, exp, x._index, _nodes.Count));
+            _nodes.Add(new(exp, exp, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp);
         }
         return new(_nodes.Count, exp);
@@ -599,7 +599,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = Real.Ln2 * exp2;
-            _nodes.Add(new(df, Real.Ln2 * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, Real.Ln2 * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp2);
         }
         return new(_nodes.Count, exp2);
@@ -611,7 +611,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = Real.Ln10 * exp10;
-            _nodes.Add(new(df, Real.Ln10 * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, Real.Ln10 * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp10);
         }
         return new(_nodes.Count, exp10);
@@ -625,7 +625,7 @@ public record class HessianTape<T> : ITape<T>
         {
             var u = x.Value - T.One;
             var v = x.Value + T.One;
-            _nodes.Add(new(T.One / (T.Sqrt(u) * T.Sqrt(v)), -x.Value * T.Pow(u, -1.5) * T.Pow(v, -1.5), x._index, _nodes.Count));
+            _nodes.Add(new(T.One / (T.Sqrt(u) * T.Sqrt(v)), -x.Value * T.Pow(u, -1.5) * T.Pow(v, -1.5), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Acosh(x.Value));
         }
         return new(_nodes.Count, T.Acosh(x.Value));
@@ -636,7 +636,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var u = T.One + x.Value * x.Value;
-            _nodes.Add(new(T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+            _nodes.Add(new(T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Asinh(x.Value));
         }
         return new(_nodes.Count, T.Asinh(x.Value));
@@ -647,7 +647,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = T.One / (T.One - x.Value * x.Value);
-            _nodes.Add(new(df, 2.0 * df * x.Value * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, 2.0 * df * x.Value * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Atanh(x.Value));
         }
         return new(_nodes.Count, T.Atanh(x.Value));
@@ -658,7 +658,7 @@ public record class HessianTape<T> : ITape<T>
         var cosh = T.Cosh(x.Value);
         if (_isTracking)
         {
-            _nodes.Add(new(T.Sinh(x.Value), cosh, x._index, _nodes.Count));
+            _nodes.Add(new(T.Sinh(x.Value), cosh, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, cosh);
         }
         return new(_nodes.Count, cosh);
@@ -669,7 +669,7 @@ public record class HessianTape<T> : ITape<T>
         var sinh = T.Sinh(x.Value);
         if (_isTracking)
         {
-            _nodes.Add(new(T.Cosh(x.Value), sinh, x._index, _nodes.Count));
+            _nodes.Add(new(T.Cosh(x.Value), sinh, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, sinh);
         }
         return new(_nodes.Count, sinh);
@@ -682,7 +682,7 @@ public record class HessianTape<T> : ITape<T>
         {
             var u = T.One / T.Cosh(x.Value);
             var df = u * u;
-            _nodes.Add(new(df, -2.0 * df * tanh, x._index, _nodes.Count));
+            _nodes.Add(new(df, -2.0 * df * tanh, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, tanh);
         }
         return new(_nodes.Count, tanh);
@@ -695,7 +695,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = T.One / x.Value;
-            _nodes.Add(new(df, -df * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, -df * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Ln(x.Value));
         }
         return new(_nodes.Count, T.Ln(x.Value));
@@ -709,7 +709,7 @@ public record class HessianTape<T> : ITape<T>
             var lnb = T.Ln(b.Value);
             var dfx = T.One / (lnb * x.Value);
             var dfb = -lnx / (lnb * lnb * b.Value);
-            _nodes.Add(new(dfx, -dfx / x.Value, -dfx / (lnb * b.Value), dfb, -dfb * (2.0 / lnb + T.One) / b.Value, x._index, b._index));
+            _nodes.Add(new(dfx, -dfx / x.Value, -dfx / (lnb * b.Value), dfb, -dfb * (2.0 / lnb + T.One) / b.Value, x.Index, b.Index));
             return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
         }
         return new(_nodes.Count, T.Log(x.Value, b.Value));
@@ -721,7 +721,7 @@ public record class HessianTape<T> : ITape<T>
         {
             var u = T.One / x.Value;
             var df = u / Real.Ln2;
-            _nodes.Add(new(df, -u * u / Real.Ln2, x._index, _nodes.Count));
+            _nodes.Add(new(df, -u * u / Real.Ln2, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Log2(x.Value));
         }
         return new(_nodes.Count, T.Log2(x.Value));
@@ -733,7 +733,7 @@ public record class HessianTape<T> : ITape<T>
         {
             var u = T.One / x.Value;
             var df = u / Real.Ln10;
-            _nodes.Add(new(df, -u * u / Real.Ln10, x._index, _nodes.Count));
+            _nodes.Add(new(df, -u * u / Real.Ln10, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Log10(x.Value));
         }
         return new(_nodes.Count, T.Log10(x.Value));
@@ -741,45 +741,45 @@ public record class HessianTape<T> : ITape<T>
 
     // Power functions.
 
-    public Variable<T> Pow(Variable<T> x, Variable<T> y)
+    public Variable<T> Pow(Variable<T> x, Variable<T> n)
     {
-        var pow = T.Pow(x.Value, y.Value);
+        var pow = T.Pow(x.Value, n.Value);
         if (_isTracking)
         {
             var lnx = T.Ln(x.Value);
-            var pownmo = T.Pow(x.Value, y.Value - T.One);
+            var pownmo = T.Pow(x.Value, n.Value - T.One);
             var dfn = lnx * pow;
             _nodes.Add(new(
-                y.Value * pownmo,
-                (y.Value - T.One) * y.Value * T.Pow(x.Value, y.Value - 2.0),
-                (T.One + lnx * y.Value) * pownmo,
+                n.Value * pownmo,
+                (n.Value - T.One) * n.Value * T.Pow(x.Value, n.Value - 2.0),
+                (T.One + lnx * n.Value) * pownmo,
                 dfn,
                 lnx * dfn,
-                x._index,
-                y._index));
+                x.Index,
+                n.Index));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count, pow);
     }
 
-    public Variable<T> Pow(Variable<T> x, T y)
+    public Variable<T> Pow(Variable<T> x, T n)
     {
-        var pow = T.Pow(x.Value, y);
+        var pow = T.Pow(x.Value, n);
         if (_isTracking)
         {
-            _nodes.Add(new(y * T.Pow(x.Value, y - T.One), (y - T.One) * y * T.Pow(x.Value, y - 2.0), x._index, _nodes.Count));
+            _nodes.Add(new(n * T.Pow(x.Value, n - T.One), (n - T.One) * n * T.Pow(x.Value, n - 2.0), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count, pow);
     }
 
-    public Variable<T> Pow(T x, Variable<T> y)
+    public Variable<T> Pow(T x, Variable<T> n)
     {
-        var pow = T.Pow(x, y.Value);
+        var pow = T.Pow(x, n.Value);
         if (_isTracking)
         {
             var lnx = T.Ln(x);
-            _nodes.Add(new(lnx * pow, lnx * lnx * pow, y._index, _nodes.Count));
+            _nodes.Add(new(lnx * pow, lnx * lnx * pow, n.Index, _nodes.Count));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count - 1, pow);
@@ -793,7 +793,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = T.One / (3.0 * cbrt * cbrt);
-            _nodes.Add(new(df, -2.0 * df / (3.0 * x.Value), x._index, _nodes.Count));
+            _nodes.Add(new(df, -2.0 * df / (3.0 * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, cbrt);
         }
         return new(_nodes.Count, cbrt);
@@ -816,8 +816,8 @@ public record class HessianTape<T> : ITape<T>
                 -root * (lnx * u + T.One) * v * uu,
                 dfn,
                 -(2.0 * u + lnx * uu) * dfn,
-                x._index,
-                n._index));
+                x.Index,
+                n.Index));
             return new(_nodes.Count - 1, root);
         }
         return new(_nodes.Count, root);
@@ -829,7 +829,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = 0.5 / sqrt;
-            _nodes.Add(new(df, -0.5 / x.Value * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, -0.5 / x.Value * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, sqrt);
         }
         return new(_nodes.Count, sqrt);
@@ -842,7 +842,7 @@ public record class HessianTape<T> : ITape<T>
         var cos = T.Cos(x.Value);
         if (_isTracking)
         {
-            _nodes.Add(new(-T.Sin(x.Value), -cos, x._index, _nodes.Count));
+            _nodes.Add(new(-T.Sin(x.Value), -cos, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, cos);
         }
         return new(_nodes.Count, cos);
@@ -853,7 +853,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var u = T.One - x.Value * x.Value;
-            _nodes.Add(new(-T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+            _nodes.Add(new(-T.One / T.Sqrt(u), -x.Value * T.Pow(u, -1.5), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Acos(x.Value));
         }
         return new(_nodes.Count, T.Acos(x.Value));
@@ -864,7 +864,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var u = T.One - x.Value * x.Value;
-            _nodes.Add(new(T.One / T.Sqrt(u), x.Value * T.Pow(u, -1.5), x._index, _nodes.Count));
+            _nodes.Add(new(T.One / T.Sqrt(u), x.Value * T.Pow(u, -1.5), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Asin(x.Value));
         }
         return new(_nodes.Count, T.Asin(x.Value));
@@ -875,7 +875,7 @@ public record class HessianTape<T> : ITape<T>
         if (_isTracking)
         {
             var df = T.One / (T.One + x.Value * x.Value);
-            _nodes.Add(new(df, -2.0 * df * x.Value * df, x._index, _nodes.Count));
+            _nodes.Add(new(df, -2.0 * df * x.Value * df, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Atan(x.Value));
         }
         return new(_nodes.Count, T.Atan(x.Value));
@@ -896,8 +896,8 @@ public record class HessianTape<T> : ITape<T>
                 (u - v) * b,
                 -y.Value * a,
                 -dfyy,
-                y._index,
-                x._index));
+                y.Index,
+                x.Index));
             return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
         }
         return new(_nodes.Count, Real.Atan2(y.Value, x.Value));
@@ -908,7 +908,7 @@ public record class HessianTape<T> : ITape<T>
         var sin = T.Sin(x.Value);
         if (_isTracking)
         {
-            _nodes.Add(new(T.Cos(x.Value), -sin, x._index, _nodes.Count));
+            _nodes.Add(new(T.Cos(x.Value), -sin, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, sin);
         }
         return new(_nodes.Count, sin);
@@ -921,7 +921,7 @@ public record class HessianTape<T> : ITape<T>
         {
             var sec = T.One / T.Cos(x.Value);
             var df = sec * sec;
-            _nodes.Add(new(df, 2.0 * df * tan, x._index, _nodes.Count));
+            _nodes.Add(new(df, 2.0 * df * tan, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, tan);
         }
         return new(_nodes.Count, tan);
@@ -941,7 +941,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(dfx(x.Value), dfxx(x.Value), x._index, _nodes.Count));
+            _nodes.Add(new(dfx(x.Value), dfxx(x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, f(x.Value));
         }
         return new(_nodes.Count, f(x.Value));
@@ -969,7 +969,7 @@ public record class HessianTape<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.Add(new(dfx(x.Value, y.Value), dfxx(x.Value, y.Value), dfxy(x.Value, y.Value), dfy(x.Value, y.Value), dfyy(x.Value, y.Value), x._index, y._index));
+            _nodes.Add(new(dfx(x.Value, y.Value), dfxx(x.Value, y.Value), dfxy(x.Value, y.Value), dfy(x.Value, y.Value), dfyy(x.Value, y.Value), x.Index, y.Index));
             return new(_nodes.Count - 1, f(x.Value, y.Value));
         }
         return new(_nodes.Count, f(x.Value, y.Value));

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -456,7 +456,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, -x.Value);
     }
 
-    // Exponential functions
+    // Exponential functions.
 
     public Variable<T> Exp(Variable<T> x)
     {
@@ -493,7 +493,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, exp10);
     }
 
-    // Hyperbolic functions
+    // Hyperbolic functions.
 
     public Variable<T> Acosh(Variable<T> x)
     {
@@ -564,7 +564,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, tanh);
     }
 
-    // Logarithmic functions
+    // Logarithmic functions.
 
     public Variable<T> Ln(Variable<T> x)
     {
@@ -615,7 +615,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, T.Log10(x.Value));
     }
 
-    // Power functions
+    // Power functions.
 
     public Variable<T> Pow(Variable<T> x, Variable<T> y)
     {
@@ -661,7 +661,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count - 1, pow);
     }
 
-    // Root functions
+    // Root functions.
 
     public Variable<T> Cbrt(Variable<T> x)
     {
@@ -711,7 +711,7 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, sqrt);
     }
 
-    // Trigonometric functions
+    // Trigonometric functions.
 
     public Variable<T> Cos(Variable<T> x)
     {

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -297,24 +297,24 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, x.Value + y.Value);
     }
 
-    public Variable<T> Add(T c, Variable<T> x)
+    public Variable<T> Add(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c + x.Value);
+            _nodes.Add(new(T.One, T.Zero, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x + y.Value);
         }
-        return new(_nodes.Count, c + x.Value);
+        return new(_nodes.Count, x + y.Value);
     }
 
-    public Variable<T> Add(Variable<T> x, T c)
+    public Variable<T> Add(Variable<T> x, T y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value + c);
+            return new(_nodes.Count - 1, x.Value + y);
         }
-        return new(_nodes.Count, x.Value + c);
+        return new(_nodes.Count, x.Value + y);
     }
 
     public Variable<T> Divide(Variable<T> x, Variable<T> y)
@@ -329,21 +329,21 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, x.Value * u);
     }
 
-    public Variable<T> Divide(T c, Variable<T> x)
+    public Variable<T> Divide(T x, Variable<T> y)
     {
-        var u = T.One / x.Value;
+        var u = T.One / y.Value;
         if (_isTracking)
         {
             var dfxy = -u * u;
-            _nodes.Add(new(c * dfxy, -2.0 * u * c * dfxy, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c * u);
+            _nodes.Add(new(x * dfxy, -2.0 * u * x * dfxy, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x * u);
         }
-        return new(_nodes.Count, c * u);
+        return new(_nodes.Count, x * u);
     }
 
-    public Variable<T> Divide(Variable<T> x, T c)
+    public Variable<T> Divide(Variable<T> x, T y)
     {
-        var u = T.One / c;
+        var u = T.One / y;
         if (_isTracking)
         {
             _nodes.Add(new(u, T.Zero, x._index, _nodes.Count));
@@ -362,24 +362,24 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, x.Value % y.Value);
     }
 
-    public Variable<Real> Modulo(Real c, in Variable<Real> x)
+    public Variable<Real> Modulo(Real x, in Variable<Real> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c * Real.Floor(c / x.Value), T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c % x.Value);
+            _nodes.Add(new(x * Real.Floor(x / y.Value), T.Zero, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x % y.Value);
         }
-        return new(_nodes.Count, c % x.Value);
+        return new(_nodes.Count, x % y.Value);
     }
 
-    public Variable<Real> Modulo(in Variable<Real> x, Real c)
+    public Variable<Real> Modulo(in Variable<Real> x, Real y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value % c);
+            return new(_nodes.Count - 1, x.Value % y);
         }
-        return new(_nodes.Count, x.Value % c);
+        return new(_nodes.Count, x.Value % y);
     }
 
     public Variable<T> Multiply(Variable<T> x, Variable<T> y)
@@ -392,24 +392,24 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, x.Value * y.Value);
     }
 
-    public Variable<T> Multiply(T c, Variable<T> x)
+    public Variable<T> Multiply(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c * x.Value);
+            _nodes.Add(new(x, T.Zero, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x * y.Value);
         }
-        return new(_nodes.Count, c * x.Value);
+        return new(_nodes.Count, x * y.Value);
     }
 
-    public Variable<T> Multiply(Variable<T> x, T c)
+    public Variable<T> Multiply(Variable<T> x, T y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(c, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value * c);
+            _nodes.Add(new(y, T.Zero, x._index, _nodes.Count));
+            return new(_nodes.Count - 1, x.Value * y);
         }
-        return new(_nodes.Count, x.Value * c);
+        return new(_nodes.Count, x.Value * y);
     }
 
     public Variable<T> Subtract(Variable<T> x, Variable<T> y)
@@ -422,24 +422,24 @@ public record class HessianTape<T> : ITape<T>
         return new(_nodes.Count, x.Value - y.Value);
     }
 
-    public Variable<T> Subtract(T c, Variable<T> x)
+    public Variable<T> Subtract(T x, Variable<T> y)
     {
         if (_isTracking)
         {
-            _nodes.Add(new(-T.One, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, c - x.Value);
+            _nodes.Add(new(-T.One, T.Zero, y._index, _nodes.Count));
+            return new(_nodes.Count - 1, x - y.Value);
         }
-        return new(_nodes.Count, c - x.Value);
+        return new(_nodes.Count, x - y.Value);
     }
 
-    public Variable<T> Subtract(Variable<T> x, T c)
+    public Variable<T> Subtract(Variable<T> x, T y)
     {
         if (_isTracking)
         {
             _nodes.Add(new(T.One, T.Zero, x._index, _nodes.Count));
-            return new(_nodes.Count - 1, x.Value - c);
+            return new(_nodes.Count - 1, x.Value - y);
         }
-        return new(_nodes.Count, x.Value - c);
+        return new(_nodes.Count, x.Value - y);
     }
 
     //

--- a/src/Mathematics.NET/AutoDiff/HessianTape.cs
+++ b/src/Mathematics.NET/AutoDiff/HessianTape.cs
@@ -31,6 +31,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Mathematics.NET.DifferentialGeometry;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.Exceptions;
 using Mathematics.NET.LinearAlgebra;
 using Microsoft.Extensions.Logging;
 
@@ -123,21 +124,21 @@ public record class HessianTape<T> : ITape<T>
 
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting Hessian.</summary>
     /// <param name="hessian">The Hessian.</param>
-    /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The Hessian tape does not have any tracked variables.</exception>
     public void ReverseAccumulate(out ReadOnlySpan2D<T> hessian)
         => ReverseAccumulate(out hessian, T.One);
 
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting gradient and Hessian.</summary>
     /// <param name="gradient">The gradient.</param>
     /// <param name="hessian">The Hessian.</param>
-    /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The Hessian tape does not have any tracked variables.</exception>
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian)
         => ReverseAccumulate(out gradient, out hessian, T.One);
 
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed)
     {
         if (_variableCount == 0)
-            throw new Exception("The Hessian tape contains no root nodes.");
+            throw new AutoDiffException("The Hessian tape contains no root nodes.");
 
         ReadOnlySpan<HessianNode<T>> nodes = CollectionsMarshal.AsSpan(_nodes);
         ref var start = ref MemoryMarshal.GetReference(nodes);
@@ -161,11 +162,11 @@ public record class HessianTape<T> : ITape<T>
     /// <summary>Perform reverse accumulation on the Hessian tape and output the resulting Hessian.</summary>
     /// <param name="hessian">The Hessian.</param>
     /// <param name="seed">A seed value.</param>
-    /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The Hessian tape does not have any tracked variables.</exception>
     public void ReverseAccumulate(out ReadOnlySpan2D<T> hessian, T seed)
     {
         if (_variableCount == 0)
-            throw new Exception("The Hessian tape contains no root nodes.");
+            throw new AutoDiffException("The Hessian tape contains no root nodes.");
 
         ReadOnlySpan<HessianNode<T>> nodes = CollectionsMarshal.AsSpan(_nodes);
         ref var start = ref MemoryMarshal.GetReference(nodes);
@@ -199,11 +200,11 @@ public record class HessianTape<T> : ITape<T>
     /// <param name="gradient">The gradient.</param>
     /// <param name="hessian">The Hessian.</param>
     /// <param name="seed">A seed value.</param>
-    /// <exception cref="Exception">The Hessian tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The Hessian tape does not have any tracked variables.</exception>
     public void ReverseAccumulate(out ReadOnlySpan<T> gradient, out ReadOnlySpan2D<T> hessian, T seed)
     {
         if (_variableCount == 0)
-            throw new Exception("The Hessian tape contains no root nodes.");
+            throw new AutoDiffException("The Hessian tape contains no root nodes.");
 
         ReadOnlySpan<HessianNode<T>> nodes = CollectionsMarshal.AsSpan(_nodes);
         ref var start = ref MemoryMarshal.GetReference(nodes);

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -58,16 +58,31 @@ public interface ITape<T>
     /// <param name="limit">The total number of nodes to log.</param>
     void LogNodes(ILogger<ITape<T>> logger, CancellationToken cancellationToken, int limit = 100);
 
-    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the result.</summary>
     /// <param name="gradient">The gradient.</param>
     /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
     void ReverseAccumulate(out ReadOnlySpan<T> gradient);
 
-    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the result.</summary>
     /// <param name="gradient">The gradient.</param>
     /// <param name="seed">A seed value.</param>
     /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
     void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed);
+
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape starting at a specific node and output the result.</summary>
+    /// <param name="gradient">The gradient.</param>
+    /// <param name="index">The index of the starting node.</param>
+    /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
+    /// <exception cref="IndexOutOfRangeException">The index does not refer to a valid starting node.</exception>
+    public void ReverseAccumulate(out ReadOnlySpan<T> gradient, int index);
+
+    /// <summary>Perform reverse accumulation on the gradient or Hessian tape starting at a specific node and output the result.</summary>
+    /// <param name="gradient">The gradient.</param>
+    /// <param name="seed">A seed value.</param>
+    /// <param name="index">The index of the starting node.</param>
+    /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
+    /// <exception cref="IndexOutOfRangeException">The index does not refer to a valid starting node.</exception>
+    void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed, int index);
 
     //
     // Basic Operations

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -235,13 +235,13 @@ public interface ITape<T>
     // Power functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
-    Variable<T> Pow(Variable<T> x, Variable<T> y);
+    Variable<T> Pow(Variable<T> x, Variable<T> n);
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
-    Variable<T> Pow(Variable<T> x, T y);
+    Variable<T> Pow(Variable<T> x, T n);
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
-    Variable<T> Pow(T x, Variable<T> y);
+    Variable<T> Pow(T x, Variable<T> n);
 
     // Root functions.
 

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -80,16 +80,16 @@ public interface ITape<T>
     Variable<T> Add(Variable<T> x, Variable<T> y);
 
     /// <summary>Add a constant value and a variable.</summary>
-    /// <param name="c">A constant value.</param>
-    /// <param name="x">A variable.</param>
+    /// <param name="x">A constant value.</param>
+    /// <param name="y">A variable.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Add(T c, Variable<T> x);
+    Variable<T> Add(T x, Variable<T> y);
 
     /// <summary>Add a variable and a constant value.</summary>
     /// <param name="x">A variable.</param>
-    /// <param name="c">A constant value.</param>
+    /// <param name="y">A constant value.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Add(Variable<T> x, T c);
+    Variable<T> Add(Variable<T> x, T y);
 
     /// <summary>Divide two variables.</summary>
     /// <param name="x">A dividend.</param>
@@ -98,16 +98,16 @@ public interface ITape<T>
     Variable<T> Divide(Variable<T> x, Variable<T> y);
 
     /// <summary>Divide a constant value by a variable.</summary>
-    /// <param name="c">A constant dividend.</param>
-    /// <param name="x">A variable divisor.</param>
+    /// <param name="x">A constant dividend.</param>
+    /// <param name="y">A variable divisor.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Divide(T c, Variable<T> x);
+    Variable<T> Divide(T x, Variable<T> y);
 
     /// <summary>Divide a variable by a constant value.</summary>
     /// <param name="x">A variable dividend.</param>
-    /// <param name="c">A constant divisor.</param>
+    /// <param name="y">A constant divisor.</param>
     /// <returns>A variabl.</returns>
-    Variable<T> Divide(Variable<T> x, T c);
+    Variable<T> Divide(Variable<T> x, T y);
 
     /// <summary>Compute the modulo of a variable given a divisor.</summary>
     /// <param name="x">A dividend.</param>
@@ -116,16 +116,16 @@ public interface ITape<T>
     Variable<Real> Modulo(in Variable<Real> x, in Variable<Real> y);
 
     /// <summary>Compute the modulo of a real value given a divisor.</summary>
-    /// <param name="c">A real dividend.</param>
-    /// <param name="x">A variable divisor.</param>
-    /// <returns><paramref name="c"/> mod <paramref name="x"/>.</returns>
-    Variable<Real> Modulo(Real c, in Variable<Real> x);
+    /// <param name="x">A real dividend.</param>
+    /// <param name="y">A variable divisor.</param>
+    /// <returns><paramref name="x"/> mod <paramref name="y"/>.</returns>
+    Variable<Real> Modulo(Real x, in Variable<Real> y);
 
     /// <summary>Compute the modulo of a variable given a divisor.</summary>
     /// <param name="x">A variable dividend.</param>
-    /// <param name="c">A real divisor.</param>
-    /// <returns><paramref name="x"/> mod <paramref name="c"/>.</returns>
-    Variable<Real> Modulo(in Variable<Real> x, Real c);
+    /// <param name="y">A real divisor.</param>
+    /// <returns><paramref name="x"/> mod <paramref name="y"/>.</returns>
+    Variable<Real> Modulo(in Variable<Real> x, Real y);
 
     /// <summary>Multiply two variables.</summary>
     /// <param name="x">The first variable.</param>
@@ -134,16 +134,16 @@ public interface ITape<T>
     Variable<T> Multiply(Variable<T> x, Variable<T> y);
 
     /// <summary>Multiply a constant value by a variable.</summary>
-    /// <param name="c">A constant value.</param>
-    /// <param name="x">A variable.</param>
+    /// <param name="x">A constant value.</param>
+    /// <param name="y">A variable.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Multiply(T c, Variable<T> x);
+    Variable<T> Multiply(T x, Variable<T> y);
 
     /// <summary>Multiply a variable by a constant value.</summary>
     /// <param name="x">A variable.</param>
-    /// <param name="c">A constant value.</param>
+    /// <param name="y">A constant value.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Multiply(Variable<T> x, T c);
+    Variable<T> Multiply(Variable<T> x, T y);
 
     /// <summary>Subract two variables.</summary>
     /// <param name="x">The first variable.</param>
@@ -152,16 +152,16 @@ public interface ITape<T>
     Variable<T> Subtract(Variable<T> x, Variable<T> y);
 
     /// <summary>Subtract a variable from a constant value.</summary>
-    /// <param name="c">A constant value.</param>
-    /// <param name="x">A variable.</param>
+    /// <param name="x">A constant value.</param>
+    /// <param name="y">A variable.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Subtract(T c, Variable<T> x);
+    Variable<T> Subtract(T x, Variable<T> y);
 
     /// <summary>Subtract a constant value from a variable.</summary>
     /// <param name="x">A variable.</param>
-    /// <param name="c">A constant value.</param>
+    /// <param name="y">A constant value.</param>
     /// <returns>A variable.</returns>
-    Variable<T> Subtract(Variable<T> x, T c);
+    Variable<T> Subtract(Variable<T> x, T y);
 
     //
     // Other operations

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -70,7 +70,7 @@ public interface ITape<T>
     void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed);
 
     //
-    // Basic operations
+    // Basic Operations
     //
 
     /// <summary>Add two variables.</summary>
@@ -164,7 +164,7 @@ public interface ITape<T>
     Variable<T> Subtract(Variable<T> x, T y);
 
     //
-    // Other operations
+    // Other Operations
     //
 
     /// <summary>Negate a variable.</summary>
@@ -172,7 +172,7 @@ public interface ITape<T>
     /// <returns>Minus one times the variable.</returns>
     Variable<T> Negate(Variable<T> x);
 
-    // Exponential functions
+    // Exponential functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp(T)"/>
     Variable<T> Exp(Variable<T> x);
@@ -183,7 +183,7 @@ public interface ITape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Exp10(T)"/>
     Variable<T> Exp10(Variable<T> x);
 
-    // Hyperbolic functions
+    // Hyperbolic functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Acosh(T)"/>
     Variable<T> Acosh(Variable<T> x);
@@ -203,7 +203,7 @@ public interface ITape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Tanh(T)"/>
     Variable<T> Tanh(Variable<T> x);
 
-    // Logarithmic functions
+    // Logarithmic functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Ln(T)"/>
     Variable<T> Ln(Variable<T> x);
@@ -217,7 +217,7 @@ public interface ITape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Log10(T)"/>
     Variable<T> Log10(Variable<T> x);
 
-    // Power functions
+    // Power functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
     Variable<T> Pow(Variable<T> x, Variable<T> y);
@@ -228,7 +228,7 @@ public interface ITape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Pow(T, T)"/>
     Variable<T> Pow(T x, Variable<T> y);
 
-    // Root functions
+    // Root functions.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Cbrt(T)"/>
     Variable<T> Cbrt(Variable<T> x);
@@ -239,7 +239,7 @@ public interface ITape<T>
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Sqrt(T)"/>
     Variable<T> Sqrt(Variable<T> x);
 
-    // Trigonometric function
+    // Trigonometric function.
 
     /// <inheritdoc cref="IDifferentiableFunctions{T}.Acos(T)"/>
     Variable<T> Acos(Variable<T> x);

--- a/src/Mathematics.NET/AutoDiff/ITape.cs
+++ b/src/Mathematics.NET/AutoDiff/ITape.cs
@@ -27,6 +27,7 @@
 
 using Mathematics.NET.DifferentialGeometry;
 using Mathematics.NET.DifferentialGeometry.Abstractions;
+using Mathematics.NET.Exceptions;
 using Mathematics.NET.LinearAlgebra;
 using Microsoft.Extensions.Logging;
 
@@ -59,13 +60,13 @@ public interface ITape<T>
 
     /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
     /// <param name="gradient">The gradient.</param>
-    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
     void ReverseAccumulate(out ReadOnlySpan<T> gradient);
 
     /// <summary>Perform reverse accumulation on the gradient or Hessian tape and output the resulting gradient.</summary>
     /// <param name="gradient">The gradient.</param>
     /// <param name="seed">A seed value.</param>
-    /// <exception cref="Exception">The gradient tape does not have any tracked variables.</exception>
+    /// <exception cref="AutoDiffException">The gradient tape does not have any tracked variables.</exception>
     void ReverseAccumulate(out ReadOnlySpan<T> gradient, T seed);
 
     //

--- a/src/Mathematics.NET/AutoDiff/NodeIndexComparer.cs
+++ b/src/Mathematics.NET/AutoDiff/NodeIndexComparer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Variable.cs" company="Mathematics.NET">
+﻿// <copyright file="NodeIndexComparer.cs" company="Mathematics.NET">
 // Mathematics.NET
 // https://github.com/HamletTanyavong/Mathematics.NET
 //
@@ -25,27 +25,10 @@
 // SOFTWARE.
 // </copyright>
 
-using System.Runtime.InteropServices;
-
 namespace Mathematics.NET.AutoDiff;
 
-/// <summary>Represents a variable used in reverse-mode automatic differentiation.</summary>
-/// <typeparam name="T">A type that implements <see cref="IComplex{T}"/>.</typeparam>
-[StructLayout(LayoutKind.Sequential)]
-public readonly unsafe record struct Variable<T>
-    where T : IComplex<T>
+internal sealed class NodeIndexComparer : IComparer<int>
 {
-    /// <summary>The index of the variable.</summary>
-    public readonly int Index;
-
-    /// <summary>The value of the variable.</summary>
-    public readonly T Value;
-
-    internal Variable(int index, T value)
-    {
-        Index = index;
-        Value = value;
-    }
-
-    public override string? ToString() => Value.ToString();
+    // There should be no duplicate indices to compare, so we can ignore the case where both are equal.
+    public int Compare(int x, int y) => x > y ? -1 : 1;
 }

--- a/src/Mathematics.NET/Core/IDifferentiableFunctions.cs
+++ b/src/Mathematics.NET/Core/IDifferentiableFunctions.cs
@@ -114,11 +114,11 @@ public interface IDifferentiableFunctions<T>
     // Power functions
     //
 
-    /// <summary>Compute <paramref name="x"/> raised to the power of <paramref name="y"/>: $ x^y $ </summary>
+    /// <summary>Compute <paramref name="x"/> raised to the power of <paramref name="n"/>: $ x^y $ </summary>
     /// <param name="x">A value.</param>
-    /// <param name="y">A power.</param>
-    /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
-    static abstract T Pow(T x, T y);
+    /// <param name="n">A power.</param>
+    /// <returns><paramref name="x"/> raised to the power of <paramref name="n"/>.</returns>
+    static abstract T Pow(T x, T n);
 
     //
     // Root functions

--- a/src/Mathematics.NET/Exceptions/AutoDiffException.cs
+++ b/src/Mathematics.NET/Exceptions/AutoDiffException.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="AutoDiffException.cs" company="Mathematics.NET">
+// Mathematics.NET
+// https://github.com/HamletTanyavong/Mathematics.NET
+//
+// MIT License
+//
+// Copyright (c) 2023-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Mathematics.NET.Exceptions;
+
+/// <summary>Represents an autodiff exception.</summary>
+public sealed class AutoDiffException : Exception
+{
+    public AutoDiffException() { }
+
+    public AutoDiffException(string message)
+        : base(message) { }
+
+    public AutoDiffException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Mathematics.NET/Solvers/RungeKutta4`3.cs
+++ b/src/Mathematics.NET/Solvers/RungeKutta4`3.cs
@@ -33,12 +33,12 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.Solvers;
 
 /// <summary>Represents a fourth-order Runge-Kutta solver.</summary>
-/// <typeparam name="TSC">A type that implements <see cref="IStateItem{TSC, TA, TN}"/>.</typeparam>
+/// <typeparam name="TSI">A type that implements <see cref="IStateItem{TSC, TA, TN}"/>.</typeparam>
 /// <typeparam name="TA">An array-like object that supports addition and multiplication on its elements.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
 /// <param name="function">A function to use for the integration step.</param>
-public sealed class RungeKutta4<TSC, TA, TN>(Func<TN, TSC, TSC> function)
-    where TSC : IStateItem<TSC, TA, TN>
+public sealed class RungeKutta4<TSI, TA, TN>(Func<TN, TSI, TSI> function)
+    where TSI : IStateItem<TSI, TA, TN>
     where TA
     : I1DArrayRepresentable<TA, TN>,
       IAdditionOperation<TA, TA>,
@@ -47,14 +47,14 @@ public sealed class RungeKutta4<TSC, TA, TN>(Func<TN, TSC, TSC> function)
       IUnaryMinusOperation<TA, TA>
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
 {
-    private readonly struct RK4IntegrateAction(Func<TN, TSC, TSC> function, TN time, TN dt) : IRefAction<TSC>
+    private readonly struct RK4IntegrateAction(Func<TN, TSI, TSI> function, TN time, TN dt) : IRefAction<TSI>
     {
-        private readonly Func<TN, TSC, TSC> _function = function;
+        private readonly Func<TN, TSI, TSI> _function = function;
         private readonly TN _time = time;
         private readonly TN _dt = dt;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Invoke(ref TSC value)
+        public void Invoke(ref TSI value)
         {
             var k1 = _function(_time, value);
             var k2 = _function(_time + 0.5 * _dt, value + 0.5 * k1 * _dt);
@@ -64,10 +64,10 @@ public sealed class RungeKutta4<TSC, TA, TN>(Func<TN, TSC, TSC> function)
         }
     }
 
-    private readonly Func<TN, TSC, TSC> _function = function;
+    private readonly Func<TN, TSI, TSI> _function = function;
 
     /// <inheritdoc cref="RungeKutta4{T}.Integrate(State{T}, T)"/>
-    public void Integrate(State<TSC, TA, TN> state, TN dt)
+    public void Integrate(State<TSI, TA, TN> state, TN dt)
     {
         var system = state.System.Span;
         var time = state.Time;
@@ -84,7 +84,7 @@ public sealed class RungeKutta4<TSC, TA, TN>(Func<TN, TSC, TSC> function)
     }
 
     /// <inheritdoc cref="RungeKutta4{T}.IntegrateParallel(State{T}, T)"/>
-    public void IntegrateParallel(State<TSC, TA, TN> state, TN dt)
+    public void IntegrateParallel(State<TSI, TA, TN> state, TN dt)
     {
         ParallelHelper.ForEach(state.System, new RK4IntegrateAction(_function, state.Time, dt));
         state.Time += dt;

--- a/src/Mathematics.NET/Solvers/State`3.cs
+++ b/src/Mathematics.NET/Solvers/State`3.cs
@@ -31,13 +31,13 @@ using Mathematics.NET.LinearAlgebra.Abstractions;
 namespace Mathematics.NET.Solvers;
 
 /// <summary>Represents the state of a system.</summary>
-/// <typeparam name="TSC">A type that implements <see cref="IStateItem{TSC, TA, TN}"/>.</typeparam>
+/// <typeparam name="TSI">A type that implements <see cref="IStateItem{TSC, TA, TN}"/>.</typeparam>
 /// <typeparam name="TA">An array-like object that supports addition and multiplication on its elements.</typeparam>
 /// <typeparam name="TN">A type that implements <see cref="IComplex{T}"/> and <see cref="IDifferentiableFunctions{T}"/>.</typeparam>
 /// <param name="system">The system.</param>
 /// <param name="time">The time.</param>
-public sealed class State<TSC, TA, TN>(Memory<TSC> system, TN time)
-    where TSC : IStateItem<TSC, TA, TN>
+public sealed class State<TSI, TA, TN>(Memory<TSI> system, TN time)
+    where TSI : IStateItem<TSI, TA, TN>
     where TA
     : I1DArrayRepresentable<TA, TN>,
       IAdditionOperation<TA, TA>,
@@ -47,7 +47,7 @@ public sealed class State<TSC, TA, TN>(Memory<TSC> system, TN time)
     where TN : IComplex<TN>, IDifferentiableFunctions<TN>
 {
     /// <inheritdoc cref="State{T}.System"/>
-    public Memory<TSC> System = system;
+    public Memory<TSI> System = system;
 
     /// <inheritdoc cref="State{T}.Time"/>
     public TN Time = time;

--- a/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
+++ b/tests/Mathematics.NET.Benchmarks.Implementations/AutoDiff/GradientTapeWithLinkedList.cs
@@ -137,7 +137,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, T.One, x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(T.One, T.One, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value + y.Value);
         }
         return new(_nodes.Count, x.Value + y.Value);
@@ -147,7 +147,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, c + x.Value);
         }
         return new(_nodes.Count, c + x.Value);
@@ -157,7 +157,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value + c);
         }
         return new(_nodes.Count, x.Value + c);
@@ -168,7 +168,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var u = T.One / y.Value;
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / y.Value, -x.Value * u * u, x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(T.One / y.Value, -x.Value * u * u, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value * u);
         }
         return new(_nodes.Count, x.Value * u);
@@ -179,7 +179,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var u = T.One / x.Value;
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(-c * u * u, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(-c * u * u, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, c * u);
         }
         return new(_nodes.Count, c * u);
@@ -190,7 +190,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var u = T.One / c;
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(u, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(u, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value * u);
         }
         return new(_nodes.Count, x.Value * u);
@@ -200,7 +200,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, x.Value * Real.Floor(x.Value / y.Value), x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(T.One, x.Value * Real.Floor(x.Value / y.Value), x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value % y.Value);
         }
         return new(_nodes.Count, x.Value % y.Value);
@@ -210,7 +210,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(c * Real.Floor(c / x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(c * Real.Floor(c / x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, c % x.Value);
         }
         return new(_nodes.Count, c % x.Value);
@@ -220,7 +220,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value % c);
         }
         return new(_nodes.Count, x.Value % c);
@@ -230,7 +230,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(y.Value, x.Value, x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(y.Value, x.Value, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value * y.Value);
         }
         return new(_nodes.Count, x.Value * y.Value);
@@ -240,7 +240,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(c, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(c, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, c * x.Value);
         }
         return new(_nodes.Count, c * x.Value);
@@ -250,7 +250,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(c, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(c, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value * c);
         }
         return new(_nodes.Count, x.Value * c);
@@ -260,7 +260,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, -T.One, x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(T.One, -T.One, x.Index, y.Index));
             return new(_nodes.Count - 1, x.Value - y.Value);
         }
         return new(_nodes.Count, x.Value - y.Value);
@@ -270,7 +270,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(-T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(-T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, c - x.Value);
         }
         return new(_nodes.Count, c - x.Value);
@@ -280,7 +280,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, x.Value - c);
         }
         return new(_nodes.Count, x.Value - c);
@@ -294,7 +294,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(-T.One, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(-T.One, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, -x.Value);
         }
         return new(_nodes.Count, -x.Value);
@@ -307,7 +307,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var exp = T.Exp(x.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(exp, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(exp, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp);
         }
         return new(_nodes.Count, exp);
@@ -318,7 +318,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var exp2 = T.Exp2(x.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(Real.Ln2 * exp2, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(Real.Ln2 * exp2, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp2);
         }
         return new(_nodes.Count, exp2);
@@ -329,7 +329,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var exp10 = T.Exp10(x.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(Real.Ln10 * exp10, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(Real.Ln10 * exp10, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, exp10);
         }
         return new(_nodes.Count, exp10);
@@ -341,7 +341,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (T.Sqrt(x.Value - T.One) * T.Sqrt(x.Value + T.One)), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Acosh(x.Value));
         }
         return new(_nodes.Count, T.Acosh(x.Value));
@@ -351,7 +351,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(x.Value * x.Value + T.One), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(x.Value * x.Value + T.One), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Asinh(x.Value));
         }
         return new(_nodes.Count, T.Asinh(x.Value));
@@ -361,7 +361,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (T.One - x.Value * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (T.One - x.Value * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Atanh(x.Value));
         }
         return new(_nodes.Count, T.Atanh(x.Value));
@@ -371,7 +371,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.Sinh(x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.Sinh(x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Cosh(x.Value));
         }
         return new(_nodes.Count, T.Cosh(x.Value));
@@ -381,7 +381,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.Cosh(x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.Cosh(x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Sinh(x.Value));
         }
         return new(_nodes.Count, T.Sinh(x.Value));
@@ -392,7 +392,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         if (_isTracking)
         {
             var u = T.One / T.Cosh(x.Value);
-            _nodes.AddLast(new GradientNode<T>(u * u, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(u * u, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Tanh(x.Value));
         }
         return new(_nodes.Count, T.Tanh(x.Value));
@@ -404,7 +404,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / x.Value, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / x.Value, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Ln(x.Value));
         }
         return new(_nodes.Count, T.Ln(x.Value));
@@ -415,7 +415,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         if (_isTracking)
         {
             var lnB = T.Ln(b.Value);
-            _nodes.AddLast(new GradientNode<T>(T.One / (x.Value * lnB), -T.Ln(x.Value) / (b.Value * lnB * lnB), x._index, b._index));
+            _nodes.AddLast(new GradientNode<T>(T.One / (x.Value * lnB), -T.Ln(x.Value) / (b.Value * lnB * lnB), x.Index, b.Index));
             return new(_nodes.Count - 1, T.Log(x.Value, b.Value));
         }
         return new(_nodes.Count, T.Log(x.Value, b.Value));
@@ -425,7 +425,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln2 * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln2 * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Log2(x.Value));
         }
         return new(_nodes.Count, T.Log2(x.Value));
@@ -435,7 +435,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln10 * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (Real.Ln10 * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Log10(x.Value));
         }
         return new(_nodes.Count, T.Log10(x.Value));
@@ -448,7 +448,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var pow = T.Pow(x.Value, y.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(y.Value * T.Pow(x.Value, y.Value - T.One), T.Ln(x.Value) * pow, x._index, y._index));
+            _nodes.AddLast(new GradientNode<T>(y.Value * T.Pow(x.Value, y.Value - T.One), T.Ln(x.Value) * pow, x.Index, y.Index));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count, pow);
@@ -459,7 +459,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var pow = T.Pow(x.Value, y);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(y * T.Pow(x.Value, y - T.One), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(y * T.Pow(x.Value, y - T.One), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count, pow);
@@ -470,7 +470,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var pow = T.Pow(x, y.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.Ln(x) * pow, y._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.Ln(x) * pow, y.Index, _nodes.Count));
             return new(_nodes.Count - 1, pow);
         }
         return new(_nodes.Count, pow);
@@ -483,7 +483,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var cbrt = T.Cbrt(x.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (3.0 * cbrt * cbrt), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (3.0 * cbrt * cbrt), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, cbrt);
         }
         return new(_nodes.Count, cbrt);
@@ -494,7 +494,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var root = T.Root(x.Value, n.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(root / (n.Value * x.Value), -T.Ln(x.Value) * root / (n.Value * n.Value), x._index, n._index));
+            _nodes.AddLast(new GradientNode<T>(root / (n.Value * x.Value), -T.Ln(x.Value) * root / (n.Value * n.Value), x.Index, n.Index));
             return new(_nodes.Count - 1, root);
         }
         return new(_nodes.Count, root);
@@ -505,7 +505,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         var sqrt = T.Sqrt(x.Value);
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(0.5 / sqrt, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(0.5 / sqrt, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, sqrt);
         }
         return new(_nodes.Count, sqrt);
@@ -517,7 +517,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(-T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(-T.One / T.Sqrt(T.One - x.Value * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Acos(x.Value));
         }
         return new(_nodes.Count, T.Acos(x.Value));
@@ -527,7 +527,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(T.One - x.Value * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / T.Sqrt(T.One - x.Value * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Asin(x.Value));
         }
         return new(_nodes.Count, T.Asin(x.Value));
@@ -537,7 +537,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.One / (T.One + x.Value * x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.One / (T.One + x.Value * x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Atan(x.Value));
         }
         return new(_nodes.Count, T.Atan(x.Value));
@@ -548,7 +548,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         if (_isTracking)
         {
             var u = Real.One / (x.Value * x.Value + y.Value * y.Value);
-            _nodes.AddLast(new GradientNode<T>(x.Value * u, -y.Value * u, y._index, x._index));
+            _nodes.AddLast(new GradientNode<T>(x.Value * u, -y.Value * u, y.Index, x.Index));
             return new(_nodes.Count - 1, Real.Atan2(y.Value, x.Value));
         }
         return new(_nodes.Count, Real.Atan2(y.Value, x.Value));
@@ -558,7 +558,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(-T.Sin(x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(-T.Sin(x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Cos(x.Value));
         }
         return new(_nodes.Count, T.Cos(x.Value));
@@ -568,7 +568,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
     {
         if (_isTracking)
         {
-            _nodes.AddLast(new GradientNode<T>(T.Cos(x.Value), x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(T.Cos(x.Value), x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Sin(x.Value));
         }
         return new(_nodes.Count, T.Sin(x.Value));
@@ -579,7 +579,7 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
         if (_isTracking)
         {
             var sec = T.One / T.Cos(x.Value);
-            _nodes.AddLast(new GradientNode<T>(sec * sec, x._index, _nodes.Count));
+            _nodes.AddLast(new GradientNode<T>(sec * sec, x.Index, _nodes.Count));
             return new(_nodes.Count - 1, T.Tan(x.Value));
         }
         return new(_nodes.Count, T.Tan(x.Value));
@@ -591,13 +591,13 @@ public record class GradientTapeWithLinkedList<T> : ITape<T>
 
     public Variable<T> CustomOperation(Variable<T> x, Func<T, T> f, Func<T, T> df)
     {
-        _nodes.AddLast(new GradientNode<T>(df(x.Value), x._index, _nodes.Count));
+        _nodes.AddLast(new GradientNode<T>(df(x.Value), x.Index, _nodes.Count));
         return new(_nodes.Count - 1, f(x.Value));
     }
 
     public Variable<T> CustomOperation(Variable<T> x, Variable<T> y, Func<T, T, T> f, Func<T, T, T> dfx, Func<T, T, T> dfy)
     {
-        _nodes.AddLast(new GradientNode<T>(dfx(x.Value, y.Value), dfy(x.Value, y.Value), x._index, y._index));
+        _nodes.AddLast(new GradientNode<T>(dfx(x.Value, y.Value), dfy(x.Value, y.Value), x.Index, y.Index));
         return new(_nodes.Count - 1, f(x.Value, y.Value));
     }
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
+++ b/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This update improves the performance of gradient tapes by implementing checkpointing. To create a checkpoint, use the `CreateCheckpoint` method and store the result in a variable. This variable can be used normally for subsequent calculations. This update also includes some minor updates to gradient tapes.