### PR TITLE
Update gradient and Hessian tapes

### DIFF
--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -58,10 +58,7 @@
 //
 //     ╳────╳ '*', '+', '%', etc. and constant ──── Result
 
-// TODO: Add a way of finding and tracking different branches in the tree. This will be useful for checkpointing
-// and improving the efficiency of calculations by not having to perform operations multiple times.
-
-#pragma warning disable IDE0032
+#pragma warning disable IDE0032, IDE0058
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -138,7 +135,9 @@ public record class GradientTape<T> : ITape<T>
             // TODO: Figure out the ideal initial capacity.
             PriorityQueue<int, int> indices = new(_nodes.Count, s_comparer);
             HashSet<int> visited = new(_nodes.Count);
+
             indices.Enqueue(x.Index, x.Index);
+            visited.Add(x.Index);
 
             Span<T> gradientSpan = new T[x.Index + 1];
             gradientSpan[x.Index] = T.One;
@@ -146,14 +145,8 @@ public record class GradientTape<T> : ITape<T>
             while (indices.Count > 0)
             {
                 var i = indices.Dequeue();
+
                 var node = Unsafe.Add(ref start, i);
-
-                // Do not change the order of checks within the if statements without careful consideration.
-                if (node.PX >= _variableCount && visited.Add(node.PX))
-                    indices.Enqueue(node.PX, node.PX);
-                if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
-                    indices.Enqueue(node.PY, node.PY);
-
                 var gradientElement = gradientSpan[i];
 
                 if (_checkpoints.TryGetValue(i, out var checkpoint))
@@ -168,7 +161,14 @@ public record class GradientTape<T> : ITape<T>
                 }
 
                 gradientSpan[node.PX] += gradientElement * node.DX;
-                gradientSpan[node.PY] += gradientElement * node.DY;
+                if (node.PY != i)
+                    gradientSpan[node.PY] += gradientElement * node.DY;
+
+                // Do not change the order of checks within the if statements without careful consideration.
+                if (node.PX >= _variableCount && visited.Add(node.PX))
+                    indices.Enqueue(node.PX, node.PX);
+                if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
+                    indices.Enqueue(node.PY, node.PY);
             }
 
             _checkpoints.Add(x.Index, new()
@@ -247,7 +247,9 @@ public record class GradientTape<T> : ITape<T>
 
         PriorityQueue<int, int> indices = new(_nodes.Count, s_comparer);
         HashSet<int> visited = new(_nodes.Count);
+
         indices.Enqueue(index, index);
+        visited.Add(index);
 
         Span<T> gradientSpan = new T[index + 1];
         gradientSpan[index] = seed;
@@ -255,13 +257,8 @@ public record class GradientTape<T> : ITape<T>
         while (indices.Count > 0)
         {
             var i = indices.Dequeue();
+
             var node = Unsafe.Add(ref start, i);
-
-            if (node.PX >= _variableCount && visited.Add(node.PX))
-                indices.Enqueue(node.PX, node.PX);
-            if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
-                indices.Enqueue(node.PY, node.PY);
-
             var gradientElement = gradientSpan[i];
 
             if (_checkpoints.TryGetValue(i, out var checkpoint))
@@ -276,7 +273,13 @@ public record class GradientTape<T> : ITape<T>
             }
 
             gradientSpan[node.PX] += gradientElement * node.DX;
-            gradientSpan[node.PY] += gradientElement * node.DY;
+            if (node.PY != i)
+                gradientSpan[node.PY] += gradientElement * node.DY;
+
+            if (node.PX >= _variableCount && visited.Add(node.PX))
+                indices.Enqueue(node.PX, node.PX);
+            if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
+                indices.Enqueue(node.PY, node.PY);
         }
 
         gradient = gradientSpan[.._variableCount];

--- a/src/Mathematics.NET/AutoDiff/GradientTape.cs
+++ b/src/Mathematics.NET/AutoDiff/GradientTape.cs
@@ -148,9 +148,10 @@ public record class GradientTape<T> : ITape<T>
                 var i = indices.Dequeue();
                 var node = Unsafe.Add(ref start, i);
 
-                if (visited.Add(node.PX) && node.PX >= _variableCount)
+                // Do not change the order of checks within the if statements without careful consideration.
+                if (node.PX >= _variableCount && visited.Add(node.PX))
                     indices.Enqueue(node.PX, node.PX);
-                if (node.PY != i && visited.Add(node.PY) && node.PY >= _variableCount)
+                if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
                     indices.Enqueue(node.PY, node.PY);
 
                 var gradientElement = gradientSpan[i];
@@ -256,9 +257,9 @@ public record class GradientTape<T> : ITape<T>
             var i = indices.Dequeue();
             var node = Unsafe.Add(ref start, i);
 
-            if (visited.Add(node.PX) && node.PX >= _variableCount)
+            if (node.PX >= _variableCount && visited.Add(node.PX))
                 indices.Enqueue(node.PX, node.PX);
-            if (node.PY != i && visited.Add(node.PY) && node.PY >= _variableCount)
+            if (node.PY != i && node.PY >= _variableCount && visited.Add(node.PY))
                 indices.Enqueue(node.PY, node.PY);
 
             var gradientElement = gradientSpan[i];

--- a/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators.Public/Mathematics.NET.Tests.SourceGenerators.Public.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.9.0" />
+    <PackageReference Include="Verify.MSTest" Version="28.10.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
+++ b/tests/Mathematics.NET.Tests.SourceGenerators/Mathematics.NET.Tests.SourceGenerators.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify.MSTest" Version="28.9.0" />
+    <PackageReference Include="Verify.MSTest" Version="28.10.1" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
   </ItemGroup>
 

--- a/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
+++ b/tests/Mathematics.NET.Tests/AutoDiff/HessianTapeOfRealTests.cs
@@ -27,6 +27,7 @@
 
 using CommunityToolkit.HighPerformance;
 using Mathematics.NET.AutoDiff;
+using Mathematics.NET.LinearAlgebra;
 
 namespace Mathematics.NET.Tests.AutoDiff;
 
@@ -1234,6 +1235,40 @@ public sealed class HessianTapeOfRealTests
 
         Assert<Real>.AreApproximatelyEqual(expected, actual, 1e-15);
     }
+
+    // NOTE: Uncomment this when testing checkpointing implementations for Hessian tapes.
+
+    //[TestMethod]
+    //public void ReverseAccumulate_WithCheckpointing_ReturnsHessians()
+    //{
+    //    var vector = _tape.CreateAutoDiffVector(1.23, 2.34, 3.45, 4.56);
+
+    //    var u = _tape.CreateCheckpoint(_tape.Cos(_tape.Multiply(_tape.Sin(_tape.Multiply(vector.X1, vector.X2)), vector.X4)));
+    //    var v = _tape.CreateCheckpoint(_tape.Divide(_tape.Exp(_tape.Multiply(vector.X3, vector.X2)), u));
+    //    var x = _tape.Exp(_tape.Divide(u, _tape.Sqrt(_tape.Multiply(_tape.Multiply(vector.X3, vector.X4), vector.X2))));
+    //    var y = _tape.Add(u, _tape.Multiply(_tape.Ln(_tape.Divide(vector.X3, vector.X4)), _tape.Multiply(v, vector.X1)));
+
+    //    Real[,] expectedX = new Real[4, 4]
+    //    {
+    //        { -3.269111440669215,  -1.382588686878912,  -0.2576955176979706,  0.2816358989885482   },
+    //        { -1.382588686878911,  -1.29349964200687,   -0.1332984723661985,  0.1592727857914262   },
+    //        { -0.2576955176979706, -0.1332984723661985, 0.004218770637959509, 0.007619177680006728 },
+    //        { 0.2816358989885482,  0.1592727857914262,  0.007619177680006728, 0.00950636476047293  }
+    //    };
+    //    Real[,] expectedY = new Real[4, 4]
+    //    {
+    //        { -3974963.896171443, -1838701.006587713, 94531.7459783768,   176781.9853341257  },
+    //        { -1838701.006587713, -894765.86272895,   35189.07508929406,  80204.1648122194   },
+    //        { 94531.7459783768,   35189.07508929406,  -2686.604369731605, -7876.060456864863 },
+    //        { 176781.9853341257,  80204.1648122194,   -7876.060456864863, -5122.315081861823 }
+    //    };
+
+    //    _tape.ReverseAccumulate(out ReadOnlySpan2D<Real> actualX, x.Index);
+    //    _tape.ReverseAccumulate(out ReadOnlySpan2D<Real> actualY, y.Index);
+
+    //    Assert<Real>.AreApproximatelyEqual(expectedX, actualX, 1e-14);
+    //    Assert<Real>.AreApproximatelyEqual(expectedY, actualY, 1e-14);
+    //}
 
     [TestMethod]
     [DataRow(1.23, 2.34, 0.3795771135606888, -0.04130373687338086)]

--- a/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
+++ b/tests/Mathematics.NET.Tests/Mathematics.NET.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Make some minor performance updates to Hessian tapes. Fix gradient tape checkpoints including unnecessary indices—ones not needed for reverse accumulation.