### PR TITLE
Make minor fixes

### DIFF
--- a/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
+++ b/src/Mathematics.NET/LinearAlgebra/LinAlg.cs
@@ -88,7 +88,7 @@ public static class LinAlg
         where T : IComplex<T>
     {
         if (left.Width != right.Height)
-            throw new ArgumentException("Cannot multiply matrices of incompatible dimensions");
+            throw new ArgumentException("Cannot multiply matrices of incompatible dimensions.");
 
         Span2D<T> result = new T[left.Height, right.Width];
         for (int i = 0; i < left.Height; i++)

--- a/tests/Mathematics.NET.Tests/Core/ComplexTests.cs
+++ b/tests/Mathematics.NET.Tests/Core/ComplexTests.cs
@@ -246,7 +246,6 @@ public sealed class ComplexTests
     [DataRow(1.23, 45.678, 1, 0)]
     [DataRow(0, 1.2345, 6, 4)]
     [DataRow(1.2345, 0, 6, 1)]
-    [DataRow(1.2345, 0, 6, 1)]
     [DataRow(1.2345, 0, 7, 7)]
     [DataRow(1.2345, 0, 8, 8)]
     public void TryFormat_ComplexWithInadequateDestinationLength_ReturnsCorrectNumberOfCharsWritten(double inReal, double inImaginary, int length, int expected)


### PR DESCRIPTION
Remove a duplicate DataRow from a test, and add punctuation to an exception message.